### PR TITLE
2012年9月9日の新聞記事は絶望先生と無関係だったので削除

### DIFF
--- a/html/kumeta/library/newspaper.html
+++ b/html/kumeta/library/newspaper.html
@@ -480,9 +480,6 @@
 							<li>
 								2011年4月28日の新聞に『さよなら絶望先生』記事? <small class="u-small">（<a href="https://twitter.com/yaeee212/status/63502934339616768" class="htmlbuild-host">目撃情報</a>）</small>
 							</li>
-							<li>
-								2012年9月9日の新聞に風浦可符香の話? <small class="u-small">（<a href="https://twitter.com/ni_saba/status/244813010101755904" class="htmlbuild-host">目撃情報</a>）</small>
-							</li>
 						</ul>
 					</section>
 				</main>


### PR DESCRIPTION
[さ さんのツイート](https://twitter.com/ni_saba/status/244813010101755904)より

> 今日の新聞に載ってた絶望先生カフカの話。とてもよかった。泣いてしまった。

現紙を確認したが、読売新聞1面に掲載されていたフランツ・カフカのコラムのことと思われ、『さよなら絶望先生』とは無関係だった。