### PR TITLE
「メディア紹介 — 漫画雑誌」にデータ追加

### DIFF
--- a/html/kumeta/index.html
+++ b/html/kumeta/index.html
@@ -138,6 +138,12 @@
 								<li>
 									<div class="p-top-update-list__date"><span class="htmlbuild-datetime">2023年1月13日</span></div>
 									<div class="p-top-update-list__info">
+										<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に週刊少年サンデー 2018年18号のデータを追加。</p>
+									</div>
+								</li>
+								<li>
+									<div class="p-top-update-list__date"><span class="htmlbuild-datetime">2023年1月13日</span></div>
+									<div class="p-top-update-list__info">
 										<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「spoon.2Di Vol.24」「spoon.2Di Vol.26」のデータ、および「季刊エス 32号」の色紙情報を追加。</p>
 									</div>
 								</li>
@@ -157,12 +163,6 @@
 									<div class="p-top-update-list__date"><span class="htmlbuild-datetime">2022年12月17日</span></div>
 									<div class="p-top-update-list__info">
 										<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>のページを作成。</p>
-									</div>
-								</li>
-								<li>
-									<div class="p-top-update-list__date"><span class="htmlbuild-datetime">2022年12月5日</span></div>
-									<div class="p-top-update-list__info">
-										<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に2015年〜2022年のデータを追加。</p>
 									</div>
 								</li>
 							</ul>

--- a/html/kumeta/library/manga.html
+++ b/html/kumeta/library/manga.html
@@ -31,7 +31,7 @@
 
 					<div class="p-title">
 						<h1 itemprop="name">メディア紹介 — 漫画雑誌</h1>
-						<p class="p-title__update"><span itemprop="dateModified" class="htmlbuild-datetime">2023年1月4日</span>更新</p>
+						<p class="p-title__update"><span itemprop="dateModified" class="htmlbuild-datetime">2023年1月13日</span>更新</p>
 					</div>
 
 					<nav class="p-local-nav htmlbuild-localnav">
@@ -3324,6 +3324,20 @@
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2018年18号</book-name>
+							<book-release>2018-03-28</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>p.454: 目次ページの<q>もうすぐエイプリルフール。先生たちに起こった嘘みたいな出来事を教えてください。</q>に対して『天野めぐみはスキだらけ!』のねこぐち先生が<q>久米田先生に漫画のネタにして頂けたことです。信じられん…!</q>と回答</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>2月14日に発売された週刊少年サンデー 2018年12号の読切で、本棚に『天野めぐみはスキだらけ!』の単行本が並んで描かれていたことと思われる。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2018年6月号</book-name>
 							<book-release>2018-05-02</book-release>
 							<book-tag>表紙</book-tag>
@@ -3600,7 +3614,7 @@
 							<book-contents>
 								<div class="p-text">
 									<p>p.16: 「畑健二郎展〜ハヤテのごとく! とトニカクカワイイとその他展〜」お祝い色紙<q>もう十分さ　漫後はホノルルで一緒に暮らさないか?</q>（カラー）</p>
-									<p>pp.492–493: 「少年サンデーコミックスのお知らせ」で『シブヤニアファミリー』1巻が見開きで紹介、担当編集コメント掲載</p>
+									<p>pp.494–495: 「少年サンデーコミックスのお知らせ」で『シブヤニアファミリー』1巻が見開きで紹介、担当編集コメント掲載</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>


### PR DESCRIPTION
- 週刊少年サンデー 2018年18号のデータ追加
- 週刊少年サンデー 2022年44号のページ数を電子版から紙版準拠に変更