### PR TITLE
フィード生成で HTML 解析を XPath から jsdom に移行

### DIFF
--- a/node/configure/schema/build.json
+++ b/node/configure/schema/build.json
@@ -367,15 +367,15 @@
 					"type": "array",
 					"items": {
 						"type": "object",
-						"required": ["html_path", "xpath", "feed_template", "feed_path"],
+						"required": ["html_path", "selector", "feed_template", "feed_path"],
 						"properties": {
 							"html_path": {
 								"type": "string",
 								"title": "HTML ファイルパス"
 							},
-							"xpath": {
+							"selector": {
 								"type": "object",
-								"title": "XPath",
+								"title": "セレクター",
 								"required": ["wrap", "date", "content"],
 								"properties": {
 									"wrap": {

--- a/node/configure/type/build.d.ts
+++ b/node/configure/type/build.d.ts
@@ -23,20 +23,20 @@ export type NoName11 = {
   src: NoName14;
 }[];
 export type HTML1 = string;
-export type NoName19 = string;
 export type NoName20 = string;
 export type NoName21 = string;
+export type NoName22 = string;
 export type Feed = string;
 export type Feed1 = string;
 export type NoName18 = {
   html_path: HTML1;
-  xpath: XPath;
+  selector: NoName19;
   feed_template: Feed;
   feed_path: Feed1;
 }[];
 export type Glob = string[];
-export type NoName23 = string;
 export type NoName24 = string;
+export type NoName25 = string;
 
 export interface NoName {
   html: {
@@ -59,7 +59,7 @@ export interface NoName {
   feed: {
     info: NoName18;
   };
-  sitemap: NoName22;
+  sitemap: NoName23;
 }
 export interface NoName1 {
   target_element: string;
@@ -147,13 +147,13 @@ export interface NoName17 {
   target_class: string;
   class_prefix: string;
 }
-export interface XPath {
-  wrap: NoName19;
-  date: NoName20;
-  content: NoName21;
+export interface NoName19 {
+  wrap: NoName20;
+  date: NoName21;
+  content: NoName22;
 }
-export interface NoName22 {
+export interface NoName23 {
   ignore: Glob;
-  template: NoName23;
-  path: NoName24;
+  template: NoName24;
+  path: NoName25;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,7 @@
 				"svgo": "^3.0.2",
 				"twitter": "^1.7.1",
 				"twitter-text": "^3.1.0",
-				"xml-formatter": "^2.6.1",
-				"xpath": "^0.0.32"
+				"xml-formatter": "^2.6.1"
 			},
 			"devDependencies": {
 				"@markuplint/ejs-parser": "^3.0.0",
@@ -14185,14 +14184,6 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
 		},
-		"node_modules/xpath": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-			"integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -24956,11 +24947,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-		},
-		"xpath": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-			"integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
 		"svgo": "^3.0.2",
 		"twitter": "^1.7.1",
 		"twitter-text": "^3.1.0",
-		"xml-formatter": "^2.6.1",
-		"xpath": "^0.0.32"
+		"xml-formatter": "^2.6.1"
 	},
 	"devDependencies": {
 		"@markuplint/ejs-parser": "^3.0.0",


### PR DESCRIPTION
- そもそも content の解析がいつの時からか正常に行われず、 `"[object HTMLElement]"` のように要素をムリヤリ String で表示する状況になっていた
- この際 XPath をやめて jsdom に移行することにした
- ついでに `<a>` 要素を取得して `entry > link` を生成している部分について、外部サイトのリンクは対象外とするように変更（`a[href^="/"]` で取得する）