### PR TITLE
`border-radius` を掛けている子孫要素に `background` がある場合に背景がはみ出るのを `overflow: hidden` で解決するように変更

### DIFF
--- a/public/assets/style/_src/object/project/_main-top.css
+++ b/public/assets/style/_src/object/project/_main-top.css
@@ -75,29 +75,27 @@ Styleguide 2.8.2
 }
 
 .p-top-nav-card__box {
-	--_border-width: 1px;
-	--_border-radius: var(--border-radius-normal);
-	--_border-radius-inner: calc(var(--_border-radius) - var(--_border-width));
-	--_bg-color: var(--color-bg-light);
-
 	display: flex; /* リンクのクリッカブルエリアを上下方向に伸ばすため */
-	box-shadow: 0 1px 2px var(--color-border-light);
-	border: var(--_border-width) solid var(--color-border-light);
-	border-radius: var(--_border-radius);
 
 	& > a {
+		--_border-width: 1px;
+		--_bg-color: var(--color-bg-light);
+		--_color: var(--color-darkgray);
+
 		flex: 1;
 		outline-width: var(--outline-width-bold);
-		outline-offset: 0;
-		border-radius: var(--_border-radius-inner);
+		outline-offset: calc(0px - var(--_border-width));
+		box-shadow: 0 1px 2px var(--color-border-light);
+		border: var(--_border-width) solid var(--color-border-light);
+		border-radius: var(--border-radius-normal);
 		background: var(--_bg-color);
-		color: var(--color-darkgray);
+		overflow: hidden;
+		color: var(--_color);
 		text-decoration-line: none;
 
 		&:hover {
 			--_bg-color: var(--color-bg-verylight);
-
-			color: inherit;
+			--_color: inherit;
 		}
 	}
 }
@@ -109,7 +107,6 @@ Styleguide 2.8.2
 
 	& img {
 		display: block;
-		border-radius: var(--_border-radius-inner) var(--_border-radius-inner) 0 0;
 		inline-size: 100%;
 		object-fit: cover;
 		object-position: var(--object-position, center);
@@ -223,12 +220,11 @@ Markup:
 Styleguide 2.8.4
 */
 .p-top-update-list {
-	--_border-width: 2px;
-
 	container-type: inline-size;
-	border: var(--_border-width) solid var(--color-border-light);
+	border: 2px solid var(--color-border-light);
 	border-radius: var(--border-radius-normal);
 	background: var(--color-white);
+	overflow: hidden;
 
 	& > li {
 		--_padding: 15px;
@@ -254,18 +250,6 @@ Styleguide 2.8.4
 	padding: var(--_padding);
 }
 
-@container (inline-size > 40em) {
-	.p-top-update-list__date {
-		@nest .p-top-update-list > li:first-child & {
-			border-start-start-radius: calc(var(--border-radius-normal) - var(--_border-width));
-		}
-
-		@nest .p-top-update-list > li:last-child & {
-			border-end-start-radius: calc(var(--border-radius-normal) - var(--_border-width));
-		}
-	}
-}
-
 @container (inline-size <= 40em) {
 	.p-top-update-list {
 		& > li {
@@ -279,10 +263,5 @@ Styleguide 2.8.4
 	.p-top-update-list__date {
 		padding-block: calc(var(--_padding) / 2);
 		font-weight: bold;
-
-		@nest .p-top-update-list > li:first-child & {
-			border-start-start-radius: calc(var(--border-radius-normal) - var(--_border-width));
-			border-start-end-radius: calc(var(--border-radius-normal) - var(--_border-width));
-		}
 	}
 }


### PR DESCRIPTION
以前は一部ブラウザで上手くいかなかったので、子孫要素にも `border-radius` を掛ける方法でやっていたが、 Firefox, Chrome, Safari の最新版で問題ないようだったので `overflow: hidden` に変更する