### PR TITLE
まどか公式サイトニュースページの静的ページ化に伴い、サイトマップURL直書きから削除

### DIFF
--- a/views/xml/sitemap.ejs
+++ b/views/xml/sitemap.ejs
@@ -17,7 +17,4 @@
 	<url>
 		<loc>https://w0s.jp/kumeta/akamatsu-generator</loc>
 	</url>
-	<url>
-		<loc>https://w0s.jp/madoka/official/news/</loc>
-	</url>
 </urlset>


### PR DESCRIPTION
#264 の対応漏れ