### PR TITLE
まどかメディア紹介のデータを日付降順から昇順に変更

### DIFF
--- a/html/madoka/index.html
+++ b/html/madoka/index.html
@@ -49,7 +49,7 @@
 								<div class="c-grid__item">
 									<section class="p-section -hdg-b htmlbuild-heading-self-link">
 										<div class="p-section__hdg">
-											<h3>書籍</h3>
+											<h3>メディア紹介</h3>
 										</div>
 
 										<ul class="p-links">

--- a/html/madoka/library/book.html
+++ b/html/madoka/library/book.html
@@ -28,7 +28,7 @@
 					</div>
 
 					<div class="p-title">
-						<h1 itemprop="name">図書</h1>
+						<h1 itemprop="name">メディア紹介 — 図書</h1>
 						<%- include('./_include/_contents_header_date') %>
 					</div>
 

--- a/html/madoka/library/book.html
+++ b/html/madoka/library/book.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja" itemscope="" itemtype="http://schema.org/WebPage">
 	<head>
-		<title>まどか書籍ライブラリ | 図書</title>
+		<title>『魔法少女まどか☆マギカ』が図書で紹介された例</title>
 
 		<meta itemprop="dateModified" content="2019-12-27" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/html/madoka/library/book.html
+++ b/html/madoka/library/book.html
@@ -43,73 +43,647 @@
 				<main class="l-content__main">
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
-							<h2>2019年</h2>
+							<h2>2011年</h2>
 						</div>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>マギアレコード　魔法少女変身原画集　Vol.1</book-name>
-							<book-release>2019-12-27</book-release>
-							<book-amazon asin="B0834SSCMR" image-id="51okJd8J-nL" width="113" height="160"></book-amazon>
+							<book-name>@2.5</book-name>
+							<book-release>2011-03-31</book-release>
+							<book-isbn>978-4-04-894080-1</book-isbn>
+							<book-amazon asin="4048940805" image-id="51+ojV0aDoL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>原画集。<a href="https://www.aniplexplus.com/itemjTNSiCGd" class="htmlbuild-host">Aniplex+の商品ページ</a>にサンプル掲載。</p>
+									<p>pp.34-41: <em>「『魔法少女まどか☆マギカ』」</em>岩上敦宏インタビュー。脚本制作時の話など。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>本書は2011年3月31日の発売だが、インタビューは12話までの放送が終了していることを前提とした会 話であり、また10話までの本編画像も掲載されているため、震災前に取材、編集が行われたものと思われる。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>BLACK PAST</book-name>
+							<book-release>2011-06-12</book-release>
+							<book-amazon asin="B008F6Y5LG" image-id="51TSD8MDIEL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.6-21: 「すれ違いの先にある奇跡」宇野常寛×虚淵玄対談。</p>
+									<p>pp.147-158: 「受胎の記憶――ループと忘却のメカニズム」村上裕一による、『涼宮ハルヒの憂鬱』の「 エンドレスエイト」編と比較しつつ、登場キャラクターの立場についての考察など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>新房昭之×シャフト　クロニクル</book-name>
-							<book-release>2019-11-23</book-release>
-							<book-isbn>978-4-8354-5701-7</book-isbn>
-							<book-amazon asin="4835457013" image-id="510waYsj0oL" width="119" height="160"></book-amazon>
+							<book-name>成熟という檻 『魔法少女まどか☆マギカ』論</book-name>
+							<book-release>2011-08-10</book-release>
+							<book-isbn>978-4-87376-374-3</book-isbn>
+							<book-amazon asin="4873763746" image-id="51eEqZZKe4L" width="109" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.119-140: TVシリーズに関する新房昭之インタビュー。3話、5話の絵コンテ、オープニングのまどか変身シーン原画掲載。（「季刊エス」2011年春号・第34号の再掲）</p>
-									<p>pp.119-140: TVシリーズに関する新房昭之インタビュー。9話、10話の絵コンテ、10話ほむらゴルフクラブ練習シーン&amp;まどほむ抱きつきシーンの原画掲載。（「季刊エス」2012年冬号・第37号の再掲だが、原画、絵コンテは本誌で削除／追加されたものがある）</p>
-									<p>pp.181-192: [新編]に関する新房昭之インタビュー。一部シーンの原画、美術ボード掲載。（「季刊エス」2014年春号・第46号の再掲）</p>
-									<p>pp.225-230: 新房昭之、久保田光俊、岩上敦宏の対談。『まどか』での蒼樹うめと虚淵玄の人選経緯、TV放送時の回想、『マギレコ』のTVアニメ化についてなど。</p>
+									<p>山川賢一によるオフィシャル評論。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>マギアアーカイブ　マギアレコード 魔法少女まどか☆マギカ外伝　設定資料集　Vol.1</book-name>
-							<book-release>2019-09-11</book-release>
-							<book-isbn>978-4-8322-7116-6</book-isbn>
-							<book-amazon asin="4832271164" image-id="51U1g7casxL" width="113" height="160"></book-amazon>
+							<book-name>魔法少女まどか☆マギカ　公式ガイドブック　you are not alone.</book-name>
+							<book-release>2011-08-27</book-release>
+							<book-isbn>978-4-8322-4061-2</book-isbn>
+							<book-amazon asin="4832240617" image-id="51+K2ltzGxL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>キャラクターのイラスト、衣装設定、原案者によるコメント、ドッペル設定、魔女とウワサの設定。</p>
+									<p>公式ガイドブック（TVシリーズ）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>「MBSアニメヒストリアー平成ー」パンフレット</book-name>
-							<book-release>2019-03-17</book-release>
+							<book-name>魔法少女マガジン（別冊オトナアニメ）</book-name>
+							<book-release>2011-09-22</book-release>
+							<book-isbn>978-4-86248-810-7</book-isbn>
+							<book-amazon asin="4862488102" image-id="61CSyqJifML" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>2019年3月17日に幕張メッセで開催された<a href="https://www.mbs.jp/anime-historia/" class="htmlbuild-host">MBSアニメヒストリアー平成ー supported by LIVE DAM STADIUM</a>のパンフレット。</p>
-									<p>登壇者から悠木碧、斎藤千和のインタビュー（それぞれ2ページ）。</p>
-									<p>また、『まどか☆マギカ』プロデューサーとして久保田光俊のインタビュー（1ページ）。企画立ち上げ時、東日本大震災、[新編]悪魔ほむらの再アフレコなどの振り返り。続編は制作準備中とのこと。</p>
+									<p>折込ポスター:　Vol.21表紙のアルティメットまどかイラスト（中村直人）。</p>
+									<p>pp.6-25: <em>「10年代の魔法少女アニメ　魔法少女まどか☆マギカ」</em>作品概要、キャラクター紹 介、悠木碧インタビュー、ストーリー解説（1話、5話、7話、10話の絵コンテ掲載）、新房昭之インタビュー（タイトルに「魔法少女」を入れたこだわりなど）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>谷口淳一郎　アニメーション画集</book-name>
-							<book-release>2019-01-19</book-release>
-							<book-isbn>978-4-902948-25-7</book-isbn>
-							<book-amazon asin="4902948257" image-id="511cGO68yuL" width="118" height="160"></book-amazon>
+							<book-name>魔法少女まどか☆マギカ　プロダクションノート</book-name>
+							<book-release>2011-09-30</book-release>
+							<book-amazon asin="4896106261" image-id="51sH-ibbNuL" width="158" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、ほむら。</p>
-									<p>p.3: 表紙と同じイラスト。</p>
-									<p>pp.4-51: 『魔法少女まどか☆マギカ』のイラスト、原画、ラフ。</p>
-									<p>pp.52-65: 『マギアレコード 魔法少女まどか☆マギカ外伝』のイラスト、原画、ラフ。</p>
-									<p>p.239: インタビューの中で、岸田隆宏のシャープな画に影響を受けたことに触れられる。</p>
-									<p>裏表紙: キュゥべえ。</p>
-									<p>小冊子（谷口淳一郎のうすい本）: Twitterで発表したイラスト、宮本幸裕からのコメントが掲載。</p>
+									<p>TVシリーズのキャラクター設定、異空間設定、武器・小物設定、美術設定ほか。「劇団イヌカレー　イ メージノート」付属。</p>
+									<p>2014年3月には<a href="https://www.amazon.co.jp/dp/4896109163/" class="htmlbuild-host htmlbuild-amazon-associate">新装版</a>が発売されている。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>100人がしゃべり倒す! 「魔法少女まどか☆マギカ」</book-name>
+							<book-release>2011-10-14</book-release>
+							<book-isbn>978-4-7966-8525-2</book-isbn>
+							<book-amazon asin="4796685251" image-id="61v0hG6jFpL" width="115" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>様々な立場の人々による感想、考察をまとめた本。</p>
+									<p>山川賢一によるコラム「魔法少女と成熟」および「『成熟という檻』誕生秘話」も掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>夜想bis+　新房監督㊙インタビュー 番外篇</book-name>
+							<book-release>2011-11-03</book-release>
+							<book-isbn>978-4-902916-23-2</book-isbn>
+							<book-amazon asin="4902916231" image-id="51uFqAqcdXL" width="106" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.4-48: 新房昭之×飯田孝×たまごまご×吉田アミ×橋本淳子×今野裕一の対談。ほむらの家のY字路や、9話の街灯の髑髏模様、ほむらのオーディション、劇団イヌカレー起用の話が挙がる。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>月刊アニメスタイル　第4号</book-name>
+							<book-release>2011-11-11</book-release>
+							<book-isbn>978-4-902948-10-3</book-isbn>
+							<book-amazon asin="4902948109" image-id="61bC6VgVwqL" width="160" height="119"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.102-108: <em>「新房昭之のアニメスタイル」</em>小黒祐一郎×新房昭之の対談。映像的には『コゼ ットの肖像』の延長線上として『まどか☆マギカ』を考えていたこと、演出が宮本さん以外新しい人達ばかりだった（岩城忠雄が中心になって人を集めた）こと、『ef』の経験でドラマと キャラクターが乖離しても成立することに気付いたことなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ　The Beginning Story</book-name>
+							<book-release>2011-12-10</book-release>
+							<book-isbn>978-4-04-110045-5</book-isbn>
+							<book-amazon asin="4041100453" image-id="51RPvmUHnmL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>全話のシナリオ決定稿、一部シーン（3話、6話、7話、10話）のシナリオ0稿、一部シーン（1話〜4話、 6話、10話、12話）の絵コンテが掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2012年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>平成23年度[第15回]文化庁メディア芸術祭受賞作品集</book-name>
+							<book-release>2012-02-01</book-release>
+							<book-contents>
+								<div class="p-text"><p>pp.18-21: アニメーション部門大賞の贈賞理由、作品概要。作中カット13点のほか、TVシ リーズのキービジュアルと蒼樹うめによるアルティメットまどか、リボンほむらのイラスト（「ニュータイプ」2011年12月号表紙）も掲載。</p></div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.1</book-name>
+							<book-release>2012-02-29</book-release>
+							<book-amazon asin="4896106393" image-id="51PFYZHCEeL" width="110" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>原画集（TVシリーズ　オープニング）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.2</book-name>
+							<book-release>2012-03-31</book-release>
+							<book-amazon asin="4896106407" image-id="516s9KLD0OL" width="110" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>原画集（TVシリーズ第1話〜第3話）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカポータブル　ザ・コンプリートガイド</book-name>
+							<book-release>2012-04-20</book-release>
+							<book-isbn>978-4-04-886580-7</book-isbn>
+							<book-amazon asin="4048865803" image-id="61Qq0j5OJxL" width="115" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>ストーリー攻略、ダンジョン攻略、エクストラ（イベントCG、原画、プロモーションイラスト、開発者 インタビューなど）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>SKE48　放課後、二次元同好会</book-name>
+							<book-release>2012-04-20</book-release>
+							<book-amazon asin="4904209206" image-id="51-Re48iMbL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.98-101: 「サイゾー」2011年6月号掲載記事の再構成。SKE48メンバーの平松可奈子、古川愛李がコ スプレを披露（ほむら、マミ）。</p>
+									<p>pp.140-143: <em>「古川愛李×シナリオライター・虚淵玄」</em>マミが死ぬことは名前が付く前に決ま っていたこと、主人公が最終話まで変身しないこと、「ティロ・フィナーレ」の名称をアフレコ現場で変更したこと、など。</p>
+									<p>その他のページでもほむらのコスプレ衣装を着たメンバーの写真が複数掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.3</book-name>
+							<book-release>2012-04-30</book-release>
+							<book-amazon asin="4896106415" image-id="519ORaGVjKL" width="110" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>原画集（TVシリーズ第4話〜第6話）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ film memories</book-name>
+							<book-release>2012-05-26</book-release>
+							<book-isbn>978-4-8322-4151-0</book-isbn>
+							<book-amazon asin="4832241516" image-id="51QR77WCweL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>TVシリーズ全話のフィルムコミック。巻末に用語集を掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.4</book-name>
+							<book-release>2012-05-31</book-release>
+							<book-amazon asin="4896106423" image-id="51LYpJE-QpL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>原画集（TVシリーズ第7話〜第9話）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>新房語</book-name>
+							<book-release>2012-07-27</book-release>
+							<book-isbn>978-4-7580-1259-1</book-isbn>
+							<book-amazon asin="4758012598" image-id="61E8sMCR3+L" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>雑誌「キャラ☆メル」「キャラ☆メル Febri」（現在の「Febri」）での対談企画「新房語」（2007年〜2012年分）を単行本化したもの。</p>
+									<p>『まどか☆マギカ』の話題が出てくるのは第15回（あおきえい）、第16回（虚淵玄、宮本幸裕）、第18 回（鈴木博文）、および新規収録の久保田光俊との対談、劇団イヌカレー筆談会。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.5</book-name>
+							<book-release>2012-07-31</book-release>
+							<book-amazon asin="4896106431" image-id="41dl27EhJYL" width="114" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>原画集（TVシリーズ第4話〜第10話）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>コレクション（ClariS）</book-name>
+							<book-release>2012-09-14</book-release>
+							<book-isbn>978-4-7897-3542-1</book-isbn>
+							<book-amazon asin="4789735427" image-id="51GloAydDnL" width="160" height="113"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.4-5: ClariSインタビューで「コネクト」と『まどか☆マギカ』に言及。「コネクト」CD情報も掲載 。</p>
+									<p>pp.16-17: 「コネクト」紹介。ハノカゲによるClariSイラスト掲載（イラスト自体は『まどか☆マギカ 』とは無関係）。</p>
+									<p>p.43: 「プロミス」紹介。「コネクト」に対するアンサーソングであり、「鹿目まどかの視点で、TVシ リーズ最終話の世界から返答するような歌詞になっている」とのこと。</p>
+									<p>pp.58-60: 渡辺翔インタビュー。「コネクト」制作時は声の資料がほぼない状態で楽曲の方向性だけあ ったこと、当時アニメの展開は知らなかったこと、「プロミス」は鹿目まどかを意識したこと、など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.6</book-name>
+							<book-release>2012-09-30</book-release>
+							<book-amazon asin="489610644X" image-id="41l3uy+VTCL" width="114" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>原画集（TVシリーズ第11話〜第12話）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>映画館パンフレット（[前編]始まりの物語）</book-name>
+							<book-release>2012-10-06</book-release>
+							<book-amazon asin="B009MFMFAM" image-id="41sVjFXXjoL" width="160" height="115"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p><em>映画館パンフレット</em>　キャラクター紹介、スタッフインタビューなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>映画館パンフレット（[後編]永遠の物語）</book-name>
+							<book-release>2012-10-13</book-release>
+							<book-amazon asin="B009PT90PS" image-id="31ZSNb1gOTL" width="160" height="111"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p><em>映画館パンフレット</em>　スタッフインタビュー、魔女図鑑、オープニング原画集など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ピアノソロ　魔法少女まどか☆マギカ</book-name>
+							<book-release>2012-11-26</book-release>
+							<book-isbn>978-4-636-89258-1</book-isbn>
+							<book-amazon asin="4636892585" image-id="51HbzOzutrL" width="119" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>ClariS と Kalafina のインタビュー、楽譜（ルミナス、ひかりふる、コネクト、Magia、Credens justitiam、Sis puella magica!）、歌詞（ルミナス、ひかりふる、コネクト、Magia）など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2013年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE extra 始まりの物語／永遠の物語</book-name>
+							<book-release>2013-02-28</book-release>
+							<book-amazon asin="4896106768" image-id="51X1+Ul732L" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>原画集（劇場版[前編][後編]）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメスタイル 003（2013.03）</book-name>
+							<book-release>2013-03-27</book-release>
+							<book-isbn>978-4-89610-543-8</book-isbn>
+							<book-amazon asin="4896105435" image-id="51mamzDin2L" width="114" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.46-75: <em>「新房昭之3万文字インタビュー」</em>後編キービジュアル、「ルミナス」原画（佐藤 利幸、松本元気）、[前編]マミ変身シーン原画（寺尾洋之）、[後編]杏子変身シーン原画（阿部厳一郎）も掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>語ろう!クウガ・アギト・龍騎（永遠の平成仮面ライダーシリーズ）</book-name>
+							<book-release>2013-07-02</book-release>
+							<book-isbn>978-4-86255-178-8</book-isbn>
+							<book-amazon asin="4862551785" image-id="51nGDRUjE2L" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.57-94: 虚淵玄インタビュー。『仮面ライダー』シリーズについての話が中心だが、佐倉杏子の最初 のイメージが浅倉威だったことなど『まどか☆マギカ』に関するトークもあり。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>劇場版魔法少女まどか☆マギカ [前編]始まりの物語/[後編]永遠の物語　公式ガイドブック　with you.</book-name>
+							<book-release>2013-07-27</book-release>
+							<book-isbn>978-4-8322-4332-3</book-isbn>
+							<book-amazon asin="4832243322" image-id="51ipp3OnVfL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>公式ガイドブック（劇場版[前編][後編]）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>劇場版 魔法少女まどか☆マギカ LOVE!　まどか&amp;ほむら ver.</book-name>
+							<book-release>2013-08-08</book-release>
+							<book-isbn>978-4-8002-1348-8</book-isbn>
+							<book-amazon asin="4800213487" image-id="51rvr7DA1xL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか&amp;ほむら（原画: 渡邊和夫）</p>
+									<p>まどか&amp;ほむらセリフ集、キャストインタビュー（悠木碧、斎藤千和）、松井玲奈（SKE48）&amp; 生駒里奈（乃木坂46）のコスプレなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>小池一夫対談集　キャラクター60年</book-name>
+							<book-release>2013-08-24</book-release>
+							<book-isbn>978-4-86225-865-6</book-isbn>
+							<book-amazon asin="4862258654" image-id="51TFFALVXGL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>小池一夫×虚淵玄の対談（<a href="https://live.nicovideo.jp/watch/lv77366564" class="htmlbuild-host">ニコニコ生放送で2012年1月29日に行われた対談</a>の書き起こし）。キャラクターの命名、1〜3話の構成の根拠、世界観をキャラクター化（キュゥべえ）したこと、執筆にあた り影響を受けた作品など。</p>
+								</div>
+								<ul class="p-notes">
+									<li>内容は雑誌<a href="https://www.amazon.co.jp/dp/4862258239/" class="htmlbuild-host htmlbuild-amazon-associate">「カイト vol.4」</a>の再掲。また、2014年6月には分冊化のうえ<a href="https://www.amazon.co.jp/dp/B00LC2A81G/" class="htmlbuild-host htmlbuild-amazon-associate">電子書籍版</a>が発売されている。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカぴあ</book-name>
+							<book-release>2013-10-12</book-release>
+							<book-isbn>978-4-8356-2267-5</book-isbn>
+							<book-amazon asin="4835622677" image-id="61RCQrbFshL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>『[新編]叛逆の物語』情報、キャストインタビュー、スタッフインタビュー、シャフト制作現場潜入レ ポート、TVシリーズ設定資料など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>映画館パンフレット（[新編]叛逆の物語）</book-name>
+							<book-release>2013-10-25</book-release>
+							<book-amazon asin="B00GKA4MXU" image-id="41Kiu93lirL" width="160" height="112"></book-amazon>
+							<book-contents>
+								<div class="p-text"><p>キャラクター紹介、スタッフ・キャストインタビューなど。</p></div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>劇場版 魔法少女まどか☆マギカ LOVE!　さやか&amp;杏子 ver.</book-name>
+							<book-release>2013-12-28</book-release>
+							<book-isbn>978-4-8002-1889-6</book-isbn>
+							<book-amazon asin="4800218896" image-id="51pEyl+BmlL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: さやか&amp;杏子（原画: 渡邊和夫）</p>
+									<p>さやか&amp;杏子セリフ集、キャストインタビュー（喜多村英梨、野中藍）、蒼樹うめメッセージ、キ ュゥべえ絵描き歌（監修: 谷口淳一郎）など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>pixiv×魔法少女まどか☆マギカ ILLUST COLLECTION</book-name>
+							<book-release>2013-12-29</book-release>
+							<book-amazon asin="B00HUOL3TG" image-id="51qlWGHOiaL" width="160" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pixivにて『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』の公開を記念して開催されたイラスト コンテストの受賞作品、全61作品を収録。</p>
+									<p><a href="https://goods.pixiv.net/c85/" class="htmlbuild-host">コミックマーケット85（2013年12月）の pixiv ブース</a>にて販売。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2014年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>劇場版魔法少女まどか☆マギカ [新編]叛逆の物語　公式ガイドブック　only you.</book-name>
+							<book-release>2014-04-12</book-release>
+							<book-isbn>978-4-8322-4429-0</book-isbn>
+							<book-amazon asin="4832244299" image-id="61oIrxBA5xL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>公式ガイドブック（劇場版[新編]）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメスタイル 005（2014.05）</book-name>
+							<book-release>2014-04-30</book-release>
+							<book-isbn>978-4-89610-576-6</book-isbn>
+							<book-amazon asin="4896105761" image-id="61emtbNgfXL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.139-142: 「新房昭之の四方山話　番外編」新編に関するインタビュー、「シャフト角度（シャフ度 ）」についてのコラム。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>劇場版 魔法少女まどか☆マギカ LOVE!　マミ&amp;なぎさ ver.</book-name>
+							<book-release>2014-05-26</book-release>
+							<book-isbn>978-4-8002-2503-0</book-isbn>
+							<book-amazon asin="4800225035" image-id="51+UHqSK1pL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: マミ&amp;なぎさ（原画: 谷口淳一郎）</p>
+									<p>虚淵玄インタビュー（百江なぎさに関する話が中心）、キャストインタビュー（水橋かおり、阿澄佳奈 ）、「ちんかめ」とのコラボイラスト（谷口淳一郎による水着姿のマミ）、「劇場版 魔法少女まどか☆マギカ　オーケストラ・コンサート」レポートなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>劇場版 魔法少女まどか☆マギカ LOVE!　悪魔ほむら&amp;キュゥべえ ver.</book-name>
+							<book-release>2014-08-21</book-release>
+							<book-isbn>978-4-8002-2727-0</book-isbn>
+							<book-amazon asin="4800227275" image-id="51LyQ5Qj1ZL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 悪魔ほむら&amp;キュゥべえ（原画: 谷口淳一郎）</p>
+									<p>キャストインタビュー（斎藤千和、加藤英美里）、新房昭之インタビュー、「劇場版 魔法少女まどか☆マギカ展」新潟会場初日レポートなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>決定版! TVタブー 2014 総決算号</book-name>
+							<book-release>2014-11-17</book-release>
+							<book-isbn>978-4-8130-7155-6</book-isbn>
+							<book-amazon asin="4813071554" image-id="61RYgz5j5dL" width="119" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.37: 「封印アニメの大問題シーン17TITLE!」で東日本大震災で放送休止になった件が紹介。第11話で の体育館のシーンなどを再編集して放送したことに触れられる。2011年4月の一挙放送時の読売新聞広告も掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2015年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>いま、幸福について語ろう　宮台真司「幸福学」対談集</book-name>
+							<book-release>2015-02-25</book-release>
+							<book-isbn>978-4-86436-599-4</book-isbn>
+							<book-amazon asin="4864365997" image-id="51Gd9zGrLpL" width="107" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.21-83: 著者の宮台真司と虚淵玄との対談（2013年3月、2014年1月収録）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語　プロダクションノート</book-name>
+							<book-release>2015-02-28</book-release>
+							<book-amazon asin="4896109376" image-id="41V36rJiKWL" width="116" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>[新編]のキャラクター設定、武器小物設定、美術設定、美術ボードほか。「劇団イヌカレー　イメージ ノート2」付属。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>別冊カドカワ　総力特集 Kalafina</book-name>
+							<book-release>2015-02-28</book-release>
+							<book-isbn>978-4-04-731709-3</book-isbn>
+							<book-amazon asin="4047317098" image-id="51fc8Fy9ZYL" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.160-162: 岩上敦宏のインタビューで「君の銀の庭」の依頼時に、梶浦由記に脚本を読んでもらった だけで具体的なことを言わなかったことなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>インスパイアード背景画集</book-name>
+							<book-release>2015-03-27</book-release>
+							<book-amazon asin="4862462685" image-id="41bNxudu-iL" width="137" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.26-47: <em>TVシリーズの背景素材を20点紹介。</em></p>
+									<p>p.131: インスパイアード社が2011年の『魔法少女まどか☆マギカ』において作品全般の美術を担当する ことになったこと、稲葉邦彦氏がこのタイミングで美術監督として同社に加わったことに言及。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>「蒼樹うめ展」公式図録</book-name>
+							<book-release>2015-10-03</book-release>
+							<book-amazon asin="B07B9PZMZ9" image-id="41wqBZndYkL" width="160" height="75"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>会場で展示されたイラストやラフを掲載。</p>
+									<p>蒼樹うめ、新房昭之、蒼樹うめ×悠木碧のインタビュー。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>「MADOGATARI展」パンフレット</book-name>
+							<book-release>2015-11-27</book-release>
+							<book-amazon asin="B018NVUL10" image-id="51OGbCiDJYL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>原画や美術ボードの掲載、久保田光俊×新房昭之×岩上敦宏インタビュー、「PRODUCTION NOTE」はじめ 過去のアイテムセレクション、記念イラストなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2016年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>「MADOGATARI展」図録</book-name>
+							<book-release>2016-09-22</book-release>
+							<book-amazon asin="B01LZLCCFB" image-id="51jKmWdTPXL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>東京、大阪、札幌、名古屋会場の様子、会場で展示された原画、コンセプトムービー原画&amp;絵コン テ、物販アイテム一覧などを掲載。</p>
+									<p>付録 Blu-ray には[新編]叛逆の物語ダイジェストムービー、コンセプトムービーを収録。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>FictionJunction CLUB 会報　Vol.31</book-name>
+							<book-release>2016-10</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.10-13: 梶浦由記×鶴岡陽太インタビューの前半で『まどか☆マギカ』TVシリーズの話。「Sis puella magica!」を鶴岡の判断でテーマ音楽化していたこと、EDは当初バラードを求められていたことなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>日本語のロゴ・メイキング</book-name>
+							<book-release>2016-10-07</book-release>
+							<book-isbn>978-4-7661-2957-1</book-isbn>
+							<book-amazon asin="4766129571" image-id="51V1wjNC6qL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.140-143: TVシリーズ、前後編のロゴのラフ、完成イラスト掲載。「まマ」と略されたラフや、TV版 ロゴ制作時のスタジオ側からの修正依頼内容。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2017年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>PRO-VISION English Communication Ⅰ NEW EDITION</book-name>
+							<book-release>2017-02-25</book-release>
+							<book-isbn>978-4-342-04122-8</book-isbn>
+							<book-amazon asin="4342041227" image-id="510muQzSkYL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.18-19: LESSON 2「Oh Bento!」にて「How about a piece of karaage?」などのセリフ。 [新編] の 屋上で弁当を食べるシーンのキャプチャー画像3枚掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>新房昭之Walker 〜打ち上げ花火、下から見るか? 横から見るか?〜</book-name>
+							<book-release>2017-09-25</book-release>
+							<book-isbn>978-4-04-896081-6</book-isbn>
+							<book-amazon asin="4048960814" image-id="613mXsT8FyL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.52: 「新房昭之百語」Q&amp;A形式でTVシリーズやコンセプトムービーの話。</p>
+									<p>pp.90-111: <em>「新房昭之作品を知る!」</em>ストーリー解説、コンセプトムービー絵コンテ掲載、 メインキャラクター紹介、異空間ボードギャラリー。</p>
+									<p>pp.130-131: 「厳選イラストギャラリー」に過去の版権イラスト4枚掲載（「ニュータイプ」2011年3月 号、2012年5月号、2012年12月号、2013年8月号）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -120,14 +694,39 @@
 						</div>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女ほむら☆マギカ×ぴあ</book-name>
-							<book-release>2018-12-18</book-release>
-							<book-isbn>978-4-8356-3517-0</book-isbn>
-							<book-amazon asin="4835635175" image-id="51znJNp4-lL" width="113" height="160"></book-amazon>
+							<book-name>ホビージャパン フィギュアJAPANマニアックス（ホビージャパンムック 857）</book-name>
+							<book-release>2018-04-03</book-release>
+							<book-isbn>978-4-7986-1667-4</book-isbn>
+							<book-amazon asin="4798616672" image-id="51eIq9wMQYL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>暁美ほむらにフォーカスを置いた本。版権イラスト集、斎藤千和インタビュー、全セリフ集など。</p>
-									<p>斎藤千和のインタビューではオーディション時の話、10話のみ劇場版で新録にしなかった経緯、[新編]ファーストテイク版の演技の理由（コンテ絵の表情が怖かった）などが語られている。</p>
+									<p>p.48: 「アニプレックス」の紹介記事で会社入口のショーケース写真（Ultimate Bestや各種フィギュ アが展示）、環いろはのフィギュア写真掲載。</p>
+									<p>p.77: 「デジタル技術&amp;等身大フィギュア」デザインココの取材記事で、展示用等身大フィギュア でアルティメットまどかを制作したことが記載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>マチ★アソビ　アルバム</book-name>
+							<book-release>2018-05</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>マチ★アソビ vol.1 〜 vol.19 の写真が多数掲載。『魔法少女まどか☆マギカ』関連は下記3点。</p>
+									<p>vol.8: 魔法少女まどか☆マギカポータブル　アートワーク展</p>
+									<p>vol.9: 眉山ロープウェイアナウンス</p>
+									<p>vol.11: ゲーム試遊</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>魔法少女まどか☆マギカの塗り絵</book-name>
+							<book-release>2018-08-23</book-release>
+							<book-isbn>978-4-309-27965-7</book-isbn>
+							<book-amazon asin="4309279651" image-id="51OqiuvC-eL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>既存版権イラスト16枚の塗り絵。カラーの完成イラストも掲載。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -147,687 +746,88 @@
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカの塗り絵</book-name>
-							<book-release>2018-08-23</book-release>
-							<book-isbn>978-4-309-27965-7</book-isbn>
-							<book-amazon asin="4309279651" image-id="51OqiuvC-eL" width="124" height="160"></book-amazon>
+							<book-name>魔法少女ほむら☆マギカ×ぴあ</book-name>
+							<book-release>2018-12-18</book-release>
+							<book-isbn>978-4-8356-3517-0</book-isbn>
+							<book-amazon asin="4835635175" image-id="51znJNp4-lL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>既存版権イラスト16枚の塗り絵。カラーの完成イラストも掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>マチ★アソビ　アルバム</book-name>
-							<book-release>2018-05</book-release>
-							<book-contents>
-								<div class="p-text">
-									<p>マチ★アソビ vol.1 〜 vol.19 の写真が多数掲載。『魔法少女まどか☆マギカ』関連は下記3点。</p>
-									<p>vol.8: 魔法少女まどか☆マギカポータブル　アートワーク展</p>
-									<p>vol.9: 眉山ロープウェイアナウンス</p>
-									<p>vol.11: ゲーム試遊</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ホビージャパン フィギュアJAPANマニアックス（ホビージャパンムック 857）</book-name>
-							<book-release>2018-04-03</book-release>
-							<book-isbn>978-4-7986-1667-4</book-isbn>
-							<book-amazon asin="4798616672" image-id="51eIq9wMQYL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.48: 「アニプレックス」の紹介記事で会社入口のショーケース写真（Ultimate Bestや各種フィギュアが展示）、環いろはのフィギュア写真掲載。</p>
-									<p>p.77: 「デジタル技術&amp;等身大フィギュア」デザインココの取材記事で、展示用等身大フィギュアでアルティメットまどかを制作したことが記載。</p>
+									<p>暁美ほむらにフォーカスを置いた本。版権イラスト集、斎藤千和インタビュー、全セリフ集など。</p>
+									<p>斎藤千和のインタビューではオーディション時の話、10話のみ劇場版で新録にしなかった経緯、[新編]ファーストテイク版の演技の理由（コンテ絵の表情が怖かった）などが語られている。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 					</section>
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
-							<h2>2017年</h2>
+							<h2>2019年</h2>
 						</div>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>新房昭之Walker 〜打ち上げ花火、下から見るか? 横から見るか?〜</book-name>
-							<book-release>2017-09-25</book-release>
-							<book-isbn>978-4-04-896081-6</book-isbn>
-							<book-amazon asin="4048960814" image-id="613mXsT8FyL" width="113" height="160"></book-amazon>
+							<book-name>谷口淳一郎　アニメーション画集</book-name>
+							<book-release>2019-01-19</book-release>
+							<book-isbn>978-4-902948-25-7</book-isbn>
+							<book-amazon asin="4902948257" image-id="511cGO68yuL" width="118" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.52: 「新房昭之百語」Q&amp;A形式でTVシリーズやコンセプトムービーの話。</p>
-									<p>pp.90-111: <em>「新房昭之作品を知る!」</em>ストーリー解説、コンセプトムービー絵コンテ掲載、メインキャラクター紹介、異空間ボードギャラリー。</p>
-									<p>pp.130-131: 「厳選イラストギャラリー」に過去の版権イラスト4枚掲載（「ニュータイプ」2011年3月号、2012年5月号、2012年12月号、2013年8月号）。</p>
+									<p>表紙: まどか、ほむら。</p>
+									<p>p.3: 表紙と同じイラスト。</p>
+									<p>pp.4-51: 『魔法少女まどか☆マギカ』のイラスト、原画、ラフ。</p>
+									<p>pp.52-65: 『マギアレコード 魔法少女まどか☆マギカ外伝』のイラスト、原画、ラフ。</p>
+									<p>p.239: インタビューの中で、岸田隆宏のシャープな画に影響を受けたことに触れられる。</p>
+									<p>裏表紙: キュゥべえ。</p>
+									<p>小冊子（谷口淳一郎のうすい本）: Twitterで発表したイラスト、宮本幸裕からのコメントが掲載。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>PRO-VISION English Communication Ⅰ NEW EDITION</book-name>
-							<book-release>2017-02-25</book-release>
-							<book-isbn>978-4-342-04122-8</book-isbn>
-							<book-amazon asin="4342041227" image-id="510muQzSkYL" width="113" height="160"></book-amazon>
+							<book-name>「MBSアニメヒストリアー平成ー」パンフレット</book-name>
+							<book-release>2019-03-17</book-release>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.18-19: LESSON 2「Oh Bento!」にて「How about a piece of karaage?」などのセリフ。 [新編] の屋上で弁当を食べるシーンのキャプチャー画像3枚掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2016年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>日本語のロゴ・メイキング</book-name>
-							<book-release>2016-10-07</book-release>
-							<book-isbn>978-4-7661-2957-1</book-isbn>
-							<book-amazon asin="4766129571" image-id="51V1wjNC6qL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.140-143: TVシリーズ、前後編のロゴのラフ、完成イラスト掲載。「まマ」と略されたラフや、TV版ロゴ制作時のスタジオ側からの修正依頼内容。</p>
+									<p>2019年3月17日に幕張メッセで開催された<a href="https://www.mbs.jp/anime-historia/" class="htmlbuild-host">MBSアニメヒストリアー平成ー supported by LIVE DAM STADIUM</a>のパンフレット。</p>
+									<p>登壇者から悠木碧、斎藤千和のインタビュー（それぞれ2ページ）。</p>
+									<p>また、『まどか☆マギカ』プロデューサーとして久保田光俊のインタビュー（1ページ）。企画立ち上げ 時、東日本大震災、[新編]悪魔ほむらの再アフレコなどの振り返り。続編は制作準備中とのこと。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>FictionJunction CLUB 会報　Vol.31</book-name>
-							<book-release>2016-10</book-release>
+							<book-name>マギアアーカイブ　マギアレコード 魔法少女まどか☆マギカ外伝　設定資料集　Vol.1</book-name>
+							<book-release>2019-09-11</book-release>
+							<book-isbn>978-4-8322-7116-6</book-isbn>
+							<book-amazon asin="4832271164" image-id="51U1g7casxL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.10-13: 梶浦由記×鶴岡陽太インタビューの前半で『まどか☆マギカ』TVシリーズの話。「Sis puella magica!」を鶴岡の判断でテーマ音楽化していたこと、EDは当初バラードを求められていたことなど。</p>
+									<p>キャラクターのイラスト、衣装設定、原案者によるコメント、ドッペル設定、魔女とウワサの設定。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>「MADOGATARI展」図録</book-name>
-							<book-release>2016-09-22</book-release>
-							<book-amazon asin="B01LZLCCFB" image-id="51jKmWdTPXL" width="112" height="160"></book-amazon>
+							<book-name>新房昭之×シャフト　クロニクル</book-name>
+							<book-release>2019-11-23</book-release>
+							<book-isbn>978-4-8354-5701-7</book-isbn>
+							<book-amazon asin="4835457013" image-id="510waYsj0oL" width="119" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>東京、大阪、札幌、名古屋会場の様子、会場で展示された原画、コンセプトムービー原画&amp;絵コンテ、物販アイテム一覧などを掲載。</p>
-									<p>付録 Blu-ray には[新編]叛逆の物語ダイジェストムービー、コンセプトムービーを収録。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2015年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>「MADOGATARI展」パンフレット</book-name>
-							<book-release>2015-11-27</book-release>
-							<book-amazon asin="B018NVUL10" image-id="51OGbCiDJYL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>原画や美術ボードの掲載、久保田光俊×新房昭之×岩上敦宏インタビュー、「PRODUCTION NOTE」はじめ過去のアイテムセレクション、記念イラストなど。</p>
+									<p>pp.119-140: TVシリーズに関する新房昭之インタビュー。3話、5話の絵コンテ、オープニングのまどか 変身シーン原画掲載。（「季刊エス」2011年春号・第34号の再掲）</p>
+									<p>pp.119-140: TVシリーズに関する新房昭之インタビュー。9話、10話の絵コンテ、10話ほむらゴルフク ラブ練習シーン&amp;まどほむ抱きつきシーンの原画掲載。（「季刊エス」2012年冬号・第37号の再掲だが、原画、絵コンテは本誌で削除／追加されたものがある）</p>
+									<p>pp.181-192: [新編]に関する新房昭之インタビュー。一部シーンの原画、美術ボード掲載。（「季刊エ ス」2014年春号・第46号の再掲）</p>
+									<p>pp.225-230: 新房昭之、久保田光俊、岩上敦宏の対談。『まどか』での蒼樹うめと虚淵玄の人選経緯、 TV放送時の回想、『マギレコ』のTVアニメ化についてなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>「蒼樹うめ展」公式図録</book-name>
-							<book-release>2015-10-03</book-release>
-							<book-amazon asin="B07B9PZMZ9" image-id="41wqBZndYkL" width="160" height="75"></book-amazon>
+							<book-name>マギアレコード　魔法少女変身原画集　Vol.1</book-name>
+							<book-release>2019-12-27</book-release>
+							<book-amazon asin="B0834SSCMR" image-id="51okJd8J-nL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>会場で展示されたイラストやラフを掲載。</p>
-									<p>蒼樹うめ、新房昭之、蒼樹うめ×悠木碧のインタビュー。</p>
+									<p>原画集。<a href="https://www.aniplexplus.com/itemjTNSiCGd" class="htmlbuild-host">Aniplex+の 商品ページ</a>にサンプル掲載。</p>
 								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>インスパイアード背景画集</book-name>
-							<book-release>2015-03-27</book-release>
-							<book-amazon asin="4862462685" image-id="41bNxudu-iL" width="137" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.26-47: <em>TVシリーズの背景素材を20点紹介。</em></p>
-									<p>p.131: インスパイアード社が2011年の『魔法少女まどか☆マギカ』において作品全般の美術を担当することになったこと、稲葉邦彦氏がこのタイミングで美術監督として同社に加わったことに言及。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>別冊カドカワ　総力特集 Kalafina</book-name>
-							<book-release>2015-02-28</book-release>
-							<book-isbn>978-4-04-731709-3</book-isbn>
-							<book-amazon asin="4047317098" image-id="51fc8Fy9ZYL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.160-162: 岩上敦宏のインタビューで「君の銀の庭」の依頼時に、梶浦由記に脚本を読んでもらっただけで具体的なことを言わなかったことなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語　プロダクションノート</book-name>
-							<book-release>2015-02-28</book-release>
-							<book-amazon asin="4896109376" image-id="41V36rJiKWL" width="116" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>[新編]のキャラクター設定、武器小物設定、美術設定、美術ボードほか。「劇団イヌカレー　イメージノート2」付属。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>いま、幸福について語ろう　宮台真司「幸福学」対談集</book-name>
-							<book-release>2015-02-25</book-release>
-							<book-isbn>978-4-86436-599-4</book-isbn>
-							<book-amazon asin="4864365997" image-id="51Gd9zGrLpL" width="107" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.21-83: 著者の宮台真司と虚淵玄との対談（2013年3月、2014年1月収録）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2014年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>決定版! TVタブー 2014 総決算号</book-name>
-							<book-release>2014-11-17</book-release>
-							<book-isbn>978-4-8130-7155-6</book-isbn>
-							<book-amazon asin="4813071554" image-id="61RYgz5j5dL" width="119" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.37: 「封印アニメの大問題シーン17TITLE!」で東日本大震災で放送休止になった件が紹介。第11話での体育館のシーンなどを再編集して放送したことに触れられる。2011年4月の一挙放送時の読売新聞広告も掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>劇場版 魔法少女まどか☆マギカ LOVE!　悪魔ほむら&amp;キュゥべえ ver.</book-name>
-							<book-release>2014-08-21</book-release>
-							<book-isbn>978-4-8002-2727-0</book-isbn>
-							<book-amazon asin="4800227275" image-id="51LyQ5Qj1ZL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 悪魔ほむら&amp;キュゥべえ（原画: 谷口淳一郎）</p>
-									<p>キャストインタビュー（斎藤千和、加藤英美里）、新房昭之インタビュー、「劇場版 魔法少女まどか☆マギカ展」新潟会場初日レポートなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>劇場版 魔法少女まどか☆マギカ LOVE!　マミ&amp;なぎさ ver.</book-name>
-							<book-release>2014-05-26</book-release>
-							<book-isbn>978-4-8002-2503-0</book-isbn>
-							<book-amazon asin="4800225035" image-id="51+UHqSK1pL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: マミ&amp;なぎさ（原画: 谷口淳一郎）</p>
-									<p>虚淵玄インタビュー（百江なぎさに関する話が中心）、キャストインタビュー（水橋かおり、阿澄佳奈）、「ちんかめ」とのコラボイラスト（谷口淳一郎による水着姿のマミ）、「劇場版 魔法少女まどか☆マギカ　オーケストラ・コンサート」レポートなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメスタイル 005（2014.05）</book-name>
-							<book-release>2014-04-30</book-release>
-							<book-isbn>978-4-89610-576-6</book-isbn>
-							<book-amazon asin="4896105761" image-id="61emtbNgfXL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.139-142: 「新房昭之の四方山話　番外編」新編に関するインタビュー、「シャフト角度（シャフ度）」についてのコラム。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>劇場版魔法少女まどか☆マギカ [新編]叛逆の物語　公式ガイドブック　only you.</book-name>
-							<book-release>2014-04-12</book-release>
-							<book-isbn>978-4-8322-4429-0</book-isbn>
-							<book-amazon asin="4832244299" image-id="61oIrxBA5xL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>公式ガイドブック（劇場版[新編]）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2013年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>pixiv×魔法少女まどか☆マギカ ILLUST COLLECTION</book-name>
-							<book-release>2013-12-29</book-release>
-							<book-amazon asin="B00HUOL3TG" image-id="51qlWGHOiaL" width="160" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pixivにて『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』の公開を記念して開催されたイラストコンテストの受賞作品、全61作品を収録。</p>
-									<p><a href="https://goods.pixiv.net/c85/" class="htmlbuild-host">コミックマーケット85（2013年12月）の pixiv ブース</a>にて販売。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>劇場版 魔法少女まどか☆マギカ LOVE!　さやか&amp;杏子 ver.</book-name>
-							<book-release>2013-12-28</book-release>
-							<book-isbn>978-4-8002-1889-6</book-isbn>
-							<book-amazon asin="4800218896" image-id="51pEyl+BmlL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: さやか&amp;杏子（原画: 渡邊和夫）</p>
-									<p>さやか&amp;杏子セリフ集、キャストインタビュー（喜多村英梨、野中藍）、蒼樹うめメッセージ、キュゥべえ絵描き歌（監修: 谷口淳一郎）など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>映画館パンフレット（[新編]叛逆の物語）</book-name>
-							<book-release>2013-10-25</book-release>
-							<book-amazon asin="B00GKA4MXU" image-id="41Kiu93lirL" width="160" height="112"></book-amazon>
-							<book-contents>
-								<div class="p-text"><p>キャラクター紹介、スタッフ・キャストインタビューなど。</p></div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカぴあ</book-name>
-							<book-release>2013-10-12</book-release>
-							<book-isbn>978-4-8356-2267-5</book-isbn>
-							<book-amazon asin="4835622677" image-id="61RCQrbFshL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>『[新編]叛逆の物語』情報、キャストインタビュー、スタッフインタビュー、シャフト制作現場潜入レポート、TVシリーズ設定資料など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>小池一夫対談集　キャラクター60年</book-name>
-							<book-release>2013-08-24</book-release>
-							<book-isbn>978-4-86225-865-6</book-isbn>
-							<book-amazon asin="4862258654" image-id="51TFFALVXGL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>小池一夫×虚淵玄の対談（<a href="https://live.nicovideo.jp/watch/lv77366564" class="htmlbuild-host">ニコニコ生放送で2012年1月29日に行われた対談</a>の書き起こし）。キャラクターの命名、1〜3話の構成の根拠、世界観をキャラクター化（キュゥべえ）したこと、執筆にあたり影響を受けた作品など。</p>
-								</div>
-								<ul class="p-notes">
-									<li>内容は雑誌<a href="https://www.amazon.co.jp/dp/4862258239/" class="htmlbuild-host htmlbuild-amazon-associate">「カイト vol.4」</a>の再掲。また、2014年6月には分冊化のうえ<a href="https://www.amazon.co.jp/dp/B00LC2A81G/" class="htmlbuild-host htmlbuild-amazon-associate">電子書籍版</a>が発売されている。</li>
-								</ul>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>劇場版 魔法少女まどか☆マギカ LOVE!　まどか&amp;ほむら ver.</book-name>
-							<book-release>2013-08-08</book-release>
-							<book-isbn>978-4-8002-1348-8</book-isbn>
-							<book-amazon asin="4800213487" image-id="51rvr7DA1xL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか&amp;ほむら（原画: 渡邊和夫）</p>
-									<p>まどか&amp;ほむらセリフ集、キャストインタビュー（悠木碧、斎藤千和）、松井玲奈（SKE48）&amp;生駒里奈（乃木坂46）のコスプレなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>劇場版魔法少女まどか☆マギカ [前編]始まりの物語/[後編]永遠の物語　公式ガイドブック　with you.</book-name>
-							<book-release>2013-07-27</book-release>
-							<book-isbn>978-4-8322-4332-3</book-isbn>
-							<book-amazon asin="4832243322" image-id="51ipp3OnVfL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>公式ガイドブック（劇場版[前編][後編]）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>語ろう!クウガ・アギト・龍騎（永遠の平成仮面ライダーシリーズ）</book-name>
-							<book-release>2013-07-02</book-release>
-							<book-isbn>978-4-86255-178-8</book-isbn>
-							<book-amazon asin="4862551785" image-id="51nGDRUjE2L" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.57-94: 虚淵玄インタビュー。『仮面ライダー』シリーズについての話が中心だが、佐倉杏子の最初のイメージが浅倉威だったことなど『まどか☆マギカ』に関するトークもあり。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメスタイル 003（2013.03）</book-name>
-							<book-release>2013-03-27</book-release>
-							<book-isbn>978-4-89610-543-8</book-isbn>
-							<book-amazon asin="4896105435" image-id="51mamzDin2L" width="114" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.46-75: <em>「新房昭之3万文字インタビュー」</em>後編キービジュアル、「ルミナス」原画（佐藤利幸、松本元気）、[前編]マミ変身シーン原画（寺尾洋之）、[後編]杏子変身シーン原画（阿部厳一郎）も掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE extra 始まりの物語／永遠の物語</book-name>
-							<book-release>2013-02-28</book-release>
-							<book-amazon asin="4896106768" image-id="51X1+Ul732L" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>原画集（劇場版[前編][後編]）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2012年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ピアノソロ　魔法少女まどか☆マギカ</book-name>
-							<book-release>2012-11-26</book-release>
-							<book-isbn>978-4-636-89258-1</book-isbn>
-							<book-amazon asin="4636892585" image-id="51HbzOzutrL" width="119" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>ClariS と Kalafina のインタビュー、楽譜（ルミナス、ひかりふる、コネクト、Magia、Credens justitiam、Sis puella magica!）、歌詞（ルミナス、ひかりふる、コネクト、Magia）など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>映画館パンフレット（[後編]永遠の物語）</book-name>
-							<book-release>2012-10-13</book-release>
-							<book-amazon asin="B009PT90PS" image-id="31ZSNb1gOTL" width="160" height="111"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p><em>映画館パンフレット</em>　スタッフインタビュー、魔女図鑑、オープニング原画集など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>映画館パンフレット（[前編]始まりの物語）</book-name>
-							<book-release>2012-10-06</book-release>
-							<book-amazon asin="B009MFMFAM" image-id="41sVjFXXjoL" width="160" height="115"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p><em>映画館パンフレット</em>　キャラクター紹介、スタッフインタビューなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.6</book-name>
-							<book-release>2012-09-30</book-release>
-							<book-amazon asin="489610644X" image-id="41l3uy+VTCL" width="114" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>原画集（TVシリーズ第11話〜第12話）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>コレクション（ClariS）</book-name>
-							<book-release>2012-09-14</book-release>
-							<book-isbn>978-4-7897-3542-1</book-isbn>
-							<book-amazon asin="4789735427" image-id="51GloAydDnL" width="160" height="113"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.4-5: ClariSインタビューで「コネクト」と『まどか☆マギカ』に言及。「コネクト」CD情報も掲載。</p>
-									<p>pp.16-17: 「コネクト」紹介。ハノカゲによるClariSイラスト掲載（イラスト自体は『まどか☆マギカ』とは無関係）。</p>
-									<p>p.43: 「プロミス」紹介。「コネクト」に対するアンサーソングであり、「鹿目まどかの視点で、TVシリーズ最終話の世界から返答するような歌詞になっている」とのこと。</p>
-									<p>pp.58-60: 渡辺翔インタビュー。「コネクト」制作時は声の資料がほぼない状態で楽曲の方向性だけあったこと、当時アニメの展開は知らなかったこと、「プロミス」は鹿目まどかを意識したこと、など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.5</book-name>
-							<book-release>2012-07-31</book-release>
-							<book-amazon asin="4896106431" image-id="41dl27EhJYL" width="114" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>原画集（TVシリーズ第4話〜第10話）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>新房語</book-name>
-							<book-release>2012-07-27</book-release>
-							<book-isbn>978-4-7580-1259-1</book-isbn>
-							<book-amazon asin="4758012598" image-id="61E8sMCR3+L" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>雑誌「キャラ☆メル」「キャラ☆メル Febri」（現在の「Febri」）での対談企画「新房語」（2007年〜2012年分）を単行本化したもの。</p>
-									<p>『まどか☆マギカ』の話題が出てくるのは第15回（あおきえい）、第16回（虚淵玄、宮本幸裕）、第18回（鈴木博文）、および新規収録の久保田光俊との対談、劇団イヌカレー筆談会。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.4</book-name>
-							<book-release>2012-05-31</book-release>
-							<book-amazon asin="4896106423" image-id="51LYpJE-QpL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>原画集（TVシリーズ第7話〜第9話）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ film memories</book-name>
-							<book-release>2012-05-26</book-release>
-							<book-isbn>978-4-8322-4151-0</book-isbn>
-							<book-amazon asin="4832241516" image-id="51QR77WCweL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>TVシリーズ全話のフィルムコミック。巻末に用語集を掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.3</book-name>
-							<book-release>2012-04-30</book-release>
-							<book-amazon asin="4896106415" image-id="519ORaGVjKL" width="110" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>原画集（TVシリーズ第4話〜第6話）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>SKE48　放課後、二次元同好会</book-name>
-							<book-release>2012-04-20</book-release>
-							<book-amazon asin="4904209206" image-id="51-Re48iMbL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.98-101: 「サイゾー」2011年6月号掲載記事の再構成。SKE48メンバーの平松可奈子、古川愛李がコスプレを披露（ほむら、マミ）。</p>
-									<p>pp.140-143: <em>「古川愛李×シナリオライター・虚淵玄」</em>マミが死ぬことは名前が付く前に決まっていたこと、主人公が最終話まで変身しないこと、「ティロ・フィナーレ」の名称をアフレコ現場で変更したこと、など。</p>
-									<p>その他のページでもほむらのコスプレ衣装を着たメンバーの写真が複数掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカポータブル　ザ・コンプリートガイド</book-name>
-							<book-release>2012-04-20</book-release>
-							<book-isbn>978-4-04-886580-7</book-isbn>
-							<book-amazon asin="4048865803" image-id="61Qq0j5OJxL" width="115" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>ストーリー攻略、ダンジョン攻略、エクストラ（イベントCG、原画、プロモーションイラスト、開発者インタビューなど）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.2</book-name>
-							<book-release>2012-03-31</book-release>
-							<book-amazon asin="4896106407" image-id="516s9KLD0OL" width="110" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>原画集（TVシリーズ第1話〜第3話）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　KEY ANIMATION NOTE Vol.1</book-name>
-							<book-release>2012-02-29</book-release>
-							<book-amazon asin="4896106393" image-id="51PFYZHCEeL" width="110" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>原画集（TVシリーズ　オープニング）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>平成23年度[第15回]文化庁メディア芸術祭受賞作品集</book-name>
-							<book-release>2012-02-01</book-release>
-							<book-contents>
-								<div class="p-text"><p>pp.18-21: アニメーション部門大賞の贈賞理由、作品概要。作中カット13点のほか、TVシリーズのキービジュアルと蒼樹うめによるアルティメットまどか、リボンほむらのイラスト（「ニュータイプ」2011年12月号表紙）も掲載。</p></div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2011年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　The Beginning Story</book-name>
-							<book-release>2011-12-10</book-release>
-							<book-isbn>978-4-04-110045-5</book-isbn>
-							<book-amazon asin="4041100453" image-id="51RPvmUHnmL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>全話のシナリオ決定稿、一部シーン（3話、6話、7話、10話）のシナリオ0稿、一部シーン（1話〜4話、6話、10話、12話）の絵コンテが掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>月刊アニメスタイル　第4号</book-name>
-							<book-release>2011-11-11</book-release>
-							<book-isbn>978-4-902948-10-3</book-isbn>
-							<book-amazon asin="4902948109" image-id="61bC6VgVwqL" width="160" height="119"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.102-108: <em>「新房昭之のアニメスタイル」</em>小黒祐一郎×新房昭之の対談。映像的には『コゼットの肖像』の延長線上として『まどか☆マギカ』を考えていたこと、演出が宮本さん以外新しい人達ばかりだった（岩城忠雄が中心になって人を集めた）こと、『ef』の経験でドラマとキャラクターが乖離しても成立することに気付いたことなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>夜想bis+　新房監督㊙インタビュー 番外篇</book-name>
-							<book-release>2011-11-03</book-release>
-							<book-isbn>978-4-902916-23-2</book-isbn>
-							<book-amazon asin="4902916231" image-id="51uFqAqcdXL" width="106" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.4-48: 新房昭之×飯田孝×たまごまご×吉田アミ×橋本淳子×今野裕一の対談。ほむらの家のY字路や、9話の街灯の髑髏模様、ほむらのオーディション、劇団イヌカレー起用の話が挙がる。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>100人がしゃべり倒す! 「魔法少女まどか☆マギカ」</book-name>
-							<book-release>2011-10-14</book-release>
-							<book-isbn>978-4-7966-8525-2</book-isbn>
-							<book-amazon asin="4796685251" image-id="61v0hG6jFpL" width="115" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>様々な立場の人々による感想、考察をまとめた本。</p>
-									<p>山川賢一によるコラム「魔法少女と成熟」および「『成熟という檻』誕生秘話」も掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　プロダクションノート</book-name>
-							<book-release>2011-09-30</book-release>
-							<book-amazon asin="4896106261" image-id="51sH-ibbNuL" width="158" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>TVシリーズのキャラクター設定、異空間設定、武器・小物設定、美術設定ほか。「劇団イヌカレー　イメージノート」付属。</p>
-									<p>2014年3月には<a href="https://www.amazon.co.jp/dp/4896109163/" class="htmlbuild-host htmlbuild-amazon-associate">新装版</a>が発売されている。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女マガジン（別冊オトナアニメ）</book-name>
-							<book-release>2011-09-22</book-release>
-							<book-isbn>978-4-86248-810-7</book-isbn>
-							<book-amazon asin="4862488102" image-id="61CSyqJifML" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>折込ポスター:　Vol.21表紙のアルティメットまどかイラスト（中村直人）。</p>
-									<p>pp.6-25: <em>「10年代の魔法少女アニメ　魔法少女まどか☆マギカ」</em>作品概要、キャラクター紹介、悠木碧インタビュー、ストーリー解説（1話、5話、7話、10話の絵コンテ掲載）、新房昭之インタビュー（タイトルに「魔法少女」を入れたこだわりなど）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>魔法少女まどか☆マギカ　公式ガイドブック　you are not alone.</book-name>
-							<book-release>2011-08-27</book-release>
-							<book-isbn>978-4-8322-4061-2</book-isbn>
-							<book-amazon asin="4832240617" image-id="51+K2ltzGxL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>公式ガイドブック（TVシリーズ）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>成熟という檻 『魔法少女まどか☆マギカ』論</book-name>
-							<book-release>2011-08-10</book-release>
-							<book-isbn>978-4-87376-374-3</book-isbn>
-							<book-amazon asin="4873763746" image-id="51eEqZZKe4L" width="109" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>山川賢一によるオフィシャル評論。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>BLACK PAST</book-name>
-							<book-release>2011-06-12</book-release>
-							<book-amazon asin="B008F6Y5LG" image-id="51TSD8MDIEL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.6-21: 「すれ違いの先にある奇跡」宇野常寛×虚淵玄対談。</p>
-									<p>pp.147-158: 「受胎の記憶――ループと忘却のメカニズム」村上裕一による、『涼宮ハルヒの憂鬱』の「エンドレスエイト」編と比較しつつ、登場キャラクターの立場についての考察など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>@2.5</book-name>
-							<book-release>2011-03-31</book-release>
-							<book-isbn>978-4-04-894080-1</book-isbn>
-							<book-amazon asin="4048940805" image-id="51+ojV0aDoL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.34-41: <em>「『魔法少女まどか☆マギカ』」</em>岩上敦宏インタビュー。脚本制作時の話など。</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>本書は2011年3月31日の発売だが、インタビューは12話までの放送が終了していることを前提とした会話であり、また10話までの本編画像も掲載されているため、震災前に取材、編集が行われたものと思われる。</li>
-								</ul>
 							</book-contents>
 						</htmlbuild-book>
 					</section>

--- a/html/madoka/library/book.html
+++ b/html/madoka/library/book.html
@@ -3,6 +3,7 @@
 	<head>
 		<title>まどか書籍ライブラリ | 図書</title>
 
+		<meta itemprop="dateModified" content="2019-12-27" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<%- include('./_include/_head_ogp_madoka') %>
 
@@ -28,6 +29,7 @@
 
 					<div class="p-title">
 						<h1 itemprop="name">図書</h1>
+						<%- include('./_include/_contents_header_date') %>
 					</div>
 
 					<nav class="p-local-nav htmlbuild-localnav">

--- a/html/madoka/library/magazine.html
+++ b/html/madoka/library/magazine.html
@@ -3,6 +3,7 @@
 	<head>
 		<title>まどか書籍ライブラリ | 雑誌</title>
 
+		<meta itemprop="dateModified" content="2021-02-17" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<%- include('./_include/_head_ogp_madoka') %>
 
@@ -28,6 +29,7 @@
 
 					<div class="p-title">
 						<h1 itemprop="name">雑誌</h1>
+						<%- include('./_include/_contents_header_date') %>
 					</div>
 
 					<nav class="p-local-nav htmlbuild-localnav">

--- a/html/madoka/library/magazine.html
+++ b/html/madoka/library/magazine.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja" itemscope="" itemtype="http://schema.org/WebPage">
 	<head>
-		<title>まどか書籍ライブラリ | 雑誌</title>
+		<title>『魔法少女まどか☆マギカ』が雑誌で紹介された例</title>
 
 		<meta itemprop="dateModified" content="2021-02-17" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/html/madoka/library/magazine.html
+++ b/html/madoka/library/magazine.html
@@ -28,7 +28,7 @@
 					</div>
 
 					<div class="p-title">
-						<h1 itemprop="name">雑誌</h1>
+						<h1 itemprop="name">メディア紹介 — 雑誌</h1>
 						<%- include('./_include/_contents_header_date') %>
 					</div>
 

--- a/html/madoka/library/magazine.html
+++ b/html/madoka/library/magazine.html
@@ -43,1059 +43,386 @@
 				<main class="l-content__main">
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
-							<h2>2021年</h2>
+							<h2>2010年</h2>
 						</div>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.43.1「ClariS音楽大全“クラリスアニ！”」</book-name>
-							<book-release>2021-02-17</book-release>
-							<book-isbn>978-4-7897-7320-1</book-isbn>
-							<book-amazon asin="4789773205" image-id="515eM01TpCL" width="113" height="160"></book-amazon>
+							<book-name>メガミマガジン　2010年12月号</book-name>
+							<book-release>2010-10-30</book-release>
+							<book-amazon asin="B00474KL90" image-id="61XR55tA6hL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.116-119: 湯浅篤インタビュー。あえて『まどマギ』を観ていない、「カラフル」制作時も予告編しか観ていない。</p>
-									<p>pp.120-123: 渡辺翔インタビュー。「コネクト」制作時のバイト先でのエピソード、ClariSメンバーと初めて会った時の話、「コネクト」のみならず「カラフル」もストーリーは知らされていなかった（ただしストーリーとリンクはさせて欲しいというオーダーだった）こと。</p>
+									<p>p.115: <em>「1大プロジェクト始動! 魔法少女まどか★マギカ」</em>岩上敦宏プロデューサーインタビュー、蒼樹うめ原案の魔法少女（鹿目まどか）のシルエット掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2010年12月号</book-name>
+							<book-release>2010-11-10</book-release>
+							<book-amazon asin="B0048G6Q50" image-id="61wmVHTjAwL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.147: 新作紹介。鹿目まどか原案イラスト（蒼樹うめ）掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメディア　2010年12月号</book-name>
+							<book-release>2010-11-10</book-release>
+							<book-amazon asin="B00494QTV2" image-id="61EKYWR6dqL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.164: 新作紹介で『魔法少女まどか☆マギカ』。鹿目まどか制服、魔法少女服の原案イラスト（蒼樹うめ）掲載。「声／花澤香菜」と誤記（翌号で訂正）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2010年12月号</book-name>
+							<book-release>2010-11-10</book-release>
+							<book-amazon asin="B0049HV5K4" image-id="61del3RH6UL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.48-49: 「SUPERNOVA 新星現わる 魔法少女まどか☆マギカ」新房昭之、虚淵玄のインタビュー。蒼樹うめによるまどか、ほむらのイラスト掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきららフォワード　2011年1月号</book-name>
+							<book-release>2010-11-24</book-release>
+							<book-amazon asin="B0049B6F6Y" image-id="61ETPBiiWvL" width="110" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.3-4: 『魔法少女まどか☆マギカ』2011年1月より放送予定。鹿目まどか、暁美ほむら、巴マミのキャラクターイラストとキャスト情報掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>娘TYPE　Vol.14</book-name>
+							<book-release>2010-11-30</book-release>
+							<book-amazon asin="B004CS4C96" image-id="6121drAzClL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.58: 新番紹介。まどか、ほむら、マミ、さやかのキャラクター紹介（蒼樹うめによるキャラ設定イラスト）。虚淵玄コメント。キャストはまどかとほむらのみ掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2011年1月号</book-name>
+							<book-release>2010-11-30</book-release>
+							<book-amazon asin="B004CFGQM0" image-id="61xg7Qh2XgL" width="122" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.17-18: 魔法少女服のまどか、ほむら、さやか、マミのピンナップポスター（原画: 谷口淳一郎）。</p>
+									<p>pp.32-33: <em>「魔法少女まどか☆マギカ　魔法少女名鑑」</em>蒼樹うめインタビュー、まどか、ほむら、マミ、さやかのキャラクター原案、設定絵が掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2011年1月号</book-name>
+							<book-release>2010-12-10</book-release>
+							<book-amazon asin="B004AX9QVW" image-id="61Yrd+SCsaL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.38-39: <em>「魔法少女になってみる?」</em>まどか&amp;ほむら&amp;さやか&amp;マミ&amp;キュゥべえのイラスト（高橋美香）、新房昭之監督Q&amp;A。</p>
+									<p>p.134: 第1話の放送データ。放送局の記載はMBS、TBSのみ（CBCなし）。脚本、演出、絵コンテ等のスタッフのみ掲載（p.39にはキャストも掲載されている）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメディア　2011年1月号</book-name>
+							<book-release>2010-12-10</book-release>
+							<book-amazon asin="B004DPEH0W" image-id="61l5ajbPWML" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.38-39: 「新房昭之×蒼樹うめ×虚淵玄×シャフトで新感覚魔法少女！」 ほむら、まどか、さやか、マミ、キュゥべえのイラスト（原画: 谷口淳一郎）、キャラクター紹介、岩上敦宏のコメント。</p>
+									<p>p.74: 1話の番組情報（あらすじ、サブタイトルは非公開）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2011年1月号</book-name>
+							<book-release>2010-12-10</book-release>
+							<book-amazon asin="B004EBH7MK" image-id="616ijp-wvLL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.36-37: 「想像の最前線2011」制服で抱きつくまどかとほむらのイラスト（高橋美香）、新房昭之、虚淵玄、岩上敦宏、宮本幸裕のコメント。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきららフォワード　2011年2月号</book-name>
+							<book-release>2010-12-24</book-release>
+							<book-amazon asin="B004EKI7PC" image-id="61c0rtkFS8L" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.6-7: 『まどか☆マギカ』放送予告（キービジュアル掲載）。美樹さやか、キュゥべえのイラスト公開（蒼樹うめ）。コミックス発売、『おりこ☆マギカ』発売、『かずみ☆マギカ』連載予告。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>娘TYPE　Vol.15</book-name>
+							<book-release>2010-12-27</book-release>
+							<book-amazon asin="B004GI13E4" image-id="61bJTVjwXYL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.54: 新番紹介。まどか、さやか、マミ、ほむらのキャラクター紹介（蒼樹うめによるキャラ設定イラスト）。1話場面カット。</p>
+									<p>p.123: 4話までの放送スケジュール（MBS、TBS、CBC）。サブタイトルは非公開。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>電撃G's magazine　2011年2月号</book-name>
+							<book-release>2010-12-27</book-release>
+							<book-amazon asin="B004FO4RAQ" image-id="61t-rbyPyOL" width="132" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.66-67: 「ドキドキの魔法少女タイム♥」まどか、ほむら、キュゥべえの版権イラスト（谷口淳一郎）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2011年2月号</book-name>
+							<book-release>2010-12-27</book-release>
+							<book-amazon asin="B004F0LMOO" image-id="61aBtNoYToL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 鹿目まどか（原画: 谷口淳一郎）。</p>
+									<p>pp.13-14: 「運命の4人」まど&amp;さやか&amp;キュゥべえ他のピンナップポスター（原画: 高橋美香）。</p>
+									<p>pp.15-16: 表紙イラストのピンナップポスター。</p>
+									<p>pp.24-29: <em>「魔法少女まどか☆マギカ Magical Girl Start of Legend」</em>作品紹介、新房昭之インタビュー、キャラクター設定イラスト、関係者39人のメッセージ、蒼樹うめイラストメッセージ。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 					</section>
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
-							<h2>2020年</h2>
+							<h2>2011年</h2>
 						</div>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ダ・ヴィンチ　2020年10月号</book-name>
-							<book-release>2020-09-04</book-release>
-							<book-amazon asin="B08F6TF7MK" image-id="51sDX7GUblL" width="113" height="160"></book-amazon>
+							<book-name>オトナアニメ　Vol.19</book-name>
+							<book-release>2011-01-08</book-release>
+							<book-isbn>978-4-86248-679-0</book-isbn>
+							<book-amazon asin="4862486797" image-id="61nmwSf8AWL" width="115" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、いろは（原画: 谷口淳一郎）</p>
-									<p>pp.168-177: <em>「特別企画　マギアレコード魔法少女まどか☆マギカ外伝」</em>スタッフインタビュー、キャスト座談会。このうち、「ダ・ヴィンチニュース」のサイトで<a href="https://ddnavi.com/interview/668574/a/" class="htmlbuild-host">劇団イヌカレーが語るクリエイティブの原点</a>、<a href="https://ddnavi.com/interview/668197/a/" class="htmlbuild-host">みかづき荘座談会</a>、<a href="https://ddnavi.com/interview/668561/a/" class="htmlbuild-host">見滝原魔法少女座談会</a>が公開されている。</p>
+									<p>pp.110-114: <em>「シャフト☆ワークス 2010-2011」</em>の記事内で蒼樹うめ、虚淵玄のインタビュー。企画立ち上げ時の話、キャラクターについてなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年10月号</book-name>
-							<book-release>2020-08-28</book-release>
-							<book-amazon asin="B08FTLNM7L" image-id="61ScgQI3DpL" width="127" height="160"></book-amazon>
+							<book-name>アニメージュ　2011年2月号</book-name>
+							<book-release>2011-01-08</book-release>
+							<book-amazon asin="B004FO4S7S" image-id="61FqNwVOrdL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>掲載ページ未確認: さやかのピンナップイラスト（<a href="https://twitter.com/MegamiMAGAZINE/status/1298545722594226176" class="htmlbuild-host">原画未確認</a>）。</p>
+									<p>pp.42-43: <em>「切り札は友情物語!!」</em>まどか&amp;ほむら&amp;マミ&amp;さやか&amp;キュゥべえのイラスト（高橋美香）、1話に関する虚淵玄インタビュー（雑誌の発売日はMBS、TBSでの1話放送直後）。1話ラストのマミが銃を撃つシーンは絵コンテでは大砲的なものを1発撃つだけだったが、映像では100丁くらいの銃が出てきて一斉砲火になったことなど。</p>
+									<p>p.130: 第6話までの放送データ。サブタイトルはいずれも非公開、メインキャストに杏子なし。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年9月号</book-name>
-							<book-release>2020-07-30</book-release>
-							<book-amazon asin="B08CWJ4WFY" image-id="61Z8Nhz5QAL" width="126" height="160"></book-amazon>
+							<book-name>アニメディア　2011年2月号</book-name>
+							<book-release>2011-01-08</book-release>
+							<book-amazon asin="B004FV7QWU" image-id="6196BfJ1dBL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>掲載ページ未確認: 里見灯花のピンナップイラスト（<a href="https://twitter.com/MegamiMAGAZINE/status/1288011537613901830" class="htmlbuild-host">原画未確認</a>）。</p>
+									<p>pp.24-25: <em>「魔女っ娘まる見え　マジカルスコープ!」</em>まどか&amp;ほむら&amp;さやか&amp;マミ&amp;キュゥべえのイラスト（岸田隆宏）、作品紹介、キャラクター紹介、岩上敦宏コメント。</p>
+									<p>p.102: 2〜5話の番組情報（あらすじ、サブタイトルは非公開）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年8月号</book-name>
-							<book-release>2020-06-30</book-release>
-							<book-amazon asin="B08BWT8BQ1" image-id="61O0lul+4TL" width="127" height="160"></book-amazon>
+							<book-name>ニュータイプ　2011年2月号</book-name>
+							<book-release>2011-01-08</book-release>
+							<book-amazon asin="B004GUXVQA" image-id="61uYFfbAwqL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>掲載ページ未確認: みふゆのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1278987717406154753" class="htmlbuild-host">原画未確認</a>）。</p>
+									<p>pp.118-123: 「Creation Archive 魔法少女まどか☆マギカ」まどか&amp;ほむら&amp;マミ&amp;キュゥべえのイラスト（高橋美香）、杏子を除く4人とキュゥべえのキャラクター紹介、岸田隆宏の一言コメント、蒼樹うめキャラクター原案集。</p>
+									<p>p.136: 2〜5話の番組情報（サブタイトル、あらすじが非公開のため欄外に掲載）。</p>
+									<p>p.151: 「新房昭之とおシゴトな仲間達」冒頭で『魔法少女まどか☆マギカ』に関する話題。</p>
+									<p><a href="https://www.youtube.com/watch?v=4EJF1o-Ah5E" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年7月号</book-name>
-							<book-release>2020-05-29</book-release>
-							<book-amazon asin="B0897F5LC6" image-id="61KX1ncCAiL" width="127" height="160"></book-amazon>
+							<book-name>まんがタイムきららフォワード　2011年3月号</book-name>
+							<book-release>2011-01-24</book-release>
+							<book-amazon asin="B004GEFQCS" image-id="615GjarKv0L" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>掲載ページ未確認: さなのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1266695964200275968" class="htmlbuild-host">原画未確認</a>）。</p>
+									<p>pp.6-7: Blu-ray&amp;DVD 1巻発売予告（キービジュアル掲載）。コミカライズ1巻発売予告（表紙イラスト掲載）、『かずみ☆マギカ』連載開始情報（キャラクターイラスト掲載）。</p>
+									<p>pp.8-52: 『かずみ☆マギカ』第1話（巻頭カラー）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年6月号</book-name>
-							<book-release>2020-04-30</book-release>
-							<book-amazon asin="B087Q2W7MX" image-id="61AJ9JBbGzL" width="127" height="160"></book-amazon>
+							<book-name>リスアニ!　Vol.04</book-name>
+							<book-release>2011-01-25</book-release>
+							<book-isbn>978-4-7897-7119-1</book-isbn>
+							<book-amazon asin="4789771199" image-id="51yjxIz-0SL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>掲載ページ未確認: フェリシアのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1255839038914744320" class="htmlbuild-host">原画未確認</a>）。</p>
+									<p>表2: 「コネクト」の広告。まどか、ほむらのアニメ盤ジャケットイラスト掲載。</p>
+									<p>pp.24-32: <em>「[特集2] 魔法少女まどか☆マギカ」</em>第1話速報レビュー（前田久）、CllariS、Kalafinaインタビュー。「コネクト」の収録はハロウィンの時期だったことなど。</p>
+									<p>p.70: 「2011冬クール放送アニメOP×EDレビュー」で冨田明宏（音楽評論家）による「コネクト」「Magia」の解説。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2020年5月号</book-name>
-							<book-release>2020-04-10</book-release>
-							<book-amazon asin="B085RQN3L1" image-id="617eD50dDqL" width="127" height="160"></book-amazon>
+							<book-name>娘TYPE　Vol.16</book-name>
+							<book-release>2011-01-29</book-release>
+							<book-amazon asin="B004K8VTJY" image-id="612VFous5TL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.92-95: <em>「魔法少女のそのウワサ」</em>水橋かおりインタビュー、ディレクター座談会（宮本幸裕×岡田堅二郎×吉澤翠）。</p>
-									<p>いろは&amp;やちよイラストのB2ポスター（原画未確認）。</p>
+									<p>pp.42-45: <em>「まどか☆マジか!?」</em>3話までの場面カット、杏子のキャラクター紹介、虚淵玄インタビュー（オーディションで斎藤千和は別キャラクターで参加していたが、土壇場でほむらのセリフを演じ、結果的にそれが功を奏した話など）。</p>
+									<p>p.139: 5〜7話の放送スケジュール（MBS、TBS、CBC）。サブタイトルは非公開。1話の場面カット掲載。</p>
+									<p>p.155: 「コネクト」発売情報。ジャケットイラスト掲載。</p>
+									<p>pp.187-188: ピンナップ: 水着まどか、マミ（潮月一也）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年5月号</book-name>
-							<book-release>2020-03-30</book-release>
-							<book-amazon asin="B086D88XL9" image-id="51R-5b5xHkL" width="127" height="160"></book-amazon>
+							<book-name>メガミマガジン　2011年3月号</book-name>
+							<book-release>2011-01-29</book-release>
+							<book-amazon asin="B004IOZAEU" image-id="61Esmmri3UL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>掲載ページ未確認: ホーリーマミのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1244588014136745984" class="htmlbuild-host">原画未確認</a>）。</p>
+									<p>pp.3-5: 水着のまどか、ほむら、さやか、マミのピンナップポスター（原画: 高橋美香）。</p>
+									<p>p.60: ClariSインタビュー、「コネクト」についてなど。</p>
+									<p>pp.75-79: <em>「鬼才・虚淵玄の魅力に迫る!!輝き・衝撃・感銘 ディープインパクト」</em>3話までの紹介、「第4話のラストで登場した新たな魔法少女」として杏子の私服、魔法少女服のイラスト掲載、虚淵玄インタビュー。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2020年4月号</book-name>
-							<book-release>2020-03-10</book-release>
-							<book-amazon asin="B084Z4K32C" image-id="61l7I7Gbr7L" width="127" height="160"></book-amazon>
+							<book-name>アニメージュ　2011年3月号</book-name>
+							<book-release>2011-02-10</book-release>
+							<book-amazon asin="B004J0A5DE" image-id="61MJXjM-BnL" width="126" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.34-37: 「Their branch point」やちよ&amp;みふゆ&amp;マミのイラスト（<a href="https://twitter.com/shaft_official/status/1237355188203077632" class="htmlbuild-host">原画: Izumi Takuya（漢字表記不明）</a>）、雨宮天インタビュー。</p>
+									<p>pp.3-5: 「F（不機嫌な）K（彼女から）C（チョコをもらおう）大作戦」チョコを抱えたまどかとほむらのイラスト（潮月一也）、斎藤千和コメント（ほむらがバレンタインチョコをあげるとしたら）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2020年4月号</book-name>
-							<book-release>2020-03-10</book-release>
-							<book-amazon asin="B084Z4K3BG" image-id="61iorSBt9sL" width="126" height="160"></book-amazon>
+							<book-name>アニメディア　2011年3月号</book-name>
+							<book-release>2011-02-10</book-release>
+							<book-amazon asin="B004K8VTGM" image-id="6186iS3uj-L" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>掲載ページ未確認: いろは&amp;さなのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1237355188203077632" class="htmlbuild-host">原画未確認</a>）。</p>
+									<p>pp.28-29: 「あの娘のハートをキャッチ! バレンタイン❤大作戦」虚淵玄インタビュー。原子力のリスクに言及（※雑誌発売は東日本大震災前）。</p>
+									<p>p.103: 6〜9話の番組情報（あらすじ、サブタイトルは非公開）。</p>
+									<p>裏表紙: Blu-ray&amp;DVD第1巻の広告。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>声優アニメディア　2020年4月号</book-name>
-							<book-release>2020-03-10</book-release>
-							<book-amazon asin="B084QCYBFC" image-id="51wto0ffzqL" width="127" height="160"></book-amazon>
+							<book-name>ニュータイプ　2011年3月号</book-name>
+							<book-release>2011-02-10</book-release>
+							<book-amazon asin="B004L5NE44" image-id="61F8HZY+1iL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>裏表紙: ドレス姿のいろは&amp;やちよ&amp;鶴乃。</p>
+									<p>pp.30-35: <em>「魔女か、魔法少女」</em>5人とキュゥべえのイラスト（高橋美香）、悠木碧×斎藤千和、宮本幸裕のインタビュー、「劇団イヌカレーさんに17の質問」。</p>
+									<p>p.128: 6〜9話の番組情報（サブタイトル、あらすじが非公開のため欄外に掲載）。</p>
+									<p>p.142: Blu-ray&amp;DVD 1巻広告、2月14日アニメイトバレンタインチョコプレゼント情報。</p>
 								</div>
-
-								<ul class="p-notes">
-									<li>本の中身は未確認。</li>
-								</ul>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年4月号</book-name>
-							<book-release>2020-02-29</book-release>
-							<book-amazon asin="B084WMGWYP" image-id="61ATxCfuoYL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>掲載ページ未確認: 鶴乃のピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1233700879460515841" class="htmlbuild-host">原画: 渥美智也</a>）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2020年3月号</book-name>
-							<book-release>2020-02-10</book-release>
-							<book-amazon asin="B083XVFP4M" image-id="51uwAsPac-L" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.34-37: 「Source of Rumor」TVアニメ・マギアレコードの紹介記事。いろは&amp;フェリシアのイラスト（<a href="https://twitter.com/shaft_official/status/1226852281993154561" class="htmlbuild-host">原画: 宮嶋仁志</a>）、佐倉綾音インタビュー（『まどか』1話に出演していたことなど）。</p>
-									<p>折り込みポスター: いろは&amp;フェリシア（原画: 宮嶋仁志）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2020年3月号</book-name>
-							<book-release>2020-02-10</book-release>
-							<book-amazon asin="B083XTGVLJ" image-id="61vXBjQjc1L" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.62-63: 「やさしい孤高」TVアニメ・マギアレコードの紹介記事。やちよイラスト（<a href="https://twitter.com/shaft_official/status/1226852281993154561" class="htmlbuild-host">原画: 宮嶋仁志</a>）、雨宮天のインタビュー（第6話までの振り返りなど）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年3月号</book-name>
-							<book-release>2020-01-30</book-release>
-							<book-amazon asin="B0848KP7QM" image-id="51Q1wCDVYjL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>掲載ページ未確認: やちよのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1222824376799678465" class="htmlbuild-host">原画: 秋葉徹</a>）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2020年2月号</book-name>
-							<book-release>2020-01-10</book-release>
-							<book-amazon asin="B082PPJCM6" image-id="51Ginn8ofbL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.44-45: 「秘々解明」TVアニメ・マギアレコードの紹介記事。いろは&amp;うい&amp;みたま&amp;小さいキュゥべえのイラスト（<a href="https://twitter.com/shaft_official/status/1215575061479821312" class="htmlbuild-host">原画: 高野晃久</a>）、麻倉もものコメント。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2019年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2020年2月号</book-name>
-							<book-release>2019-12-27</book-release>
-							<book-amazon asin="B0833S9ZFQ" image-id="517K-MZeW2L" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.9-10: いろは&amp;小さいキュゥべえのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1210492551179862016" class="htmlbuild-host">原画: 秋葉徹</a>）。</p>
-									<p>p.79: 「2020年冬のチュウ目作品23選」でTVアニメ・マギアレコードの紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2020年1月号</book-name>
-							<book-release>2019-12-10</book-release>
-							<book-amazon asin="B081KQLJGT" image-id="51AL5oOS67L" width="128" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.82-83: <em>「表情豊かな少女たちの姿」</em>TVアニメ・マギアレコードの紹介記事。いろは&amp;やちよのイラスト（<a href="https://twitter.com/shaft_official/status/1204709708239474688" class="htmlbuild-host">原画: 杉山延寛</a>）、久保田光俊インタビュー（ゲームの企画段階から関わっていた、『まどか』の続きではなく新作のTVアニメとして作っているなど）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2020年1月号</book-name>
-							<book-release>2019-12-10</book-release>
-							<book-amazon asin="B081KQ4M5D" image-id="61YGvlChxeL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.66-67: <em>「ウワサの街で…」</em>TVアニメ・マギアレコードの紹介記事。いろは&amp;黒江のイラスト（<a href="https://twitter.com/shaft_official/status/1204709708239474688" class="htmlbuild-host">原画: 山村洋貴</a>）、宮本幸裕インタビュー（黒江について、ウワサ空間のデザインにJ.A.シーザーが参加していること、章ごとに監督が異なることなど）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2019年12月号</book-name>
-							<book-release>2019-11-09</book-release>
-							<book-amazon asin="B07Z761RN8" image-id="51P0+yId6xL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.107: 「新房昭之のあの人とヒミツの話」で冒頭に『マギアレコード』のTVアニメのアフレコがすでに終わっていることが一言だけ語られた。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2019年11月号</book-name>
-							<book-release>2019-10-10</book-release>
-							<book-amazon asin="B07XV719XK" image-id="510g5Ii9WHL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.115: 「新房昭之のあの人とヒミツの話」で金沢利幸（アニプレックス）との対談。マギレコではゲームの手伝いを少しだけしている、[新編]公開時の新房昭之監督の取材は店で食事をしながら行うことが多かった、ほかにも[新編]の話。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2019年10月号</book-name>
-							<book-release>2019-09-10</book-release>
-							<book-amazon asin="B07WYC2XF1" image-id="51eGW0Ez5vL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.60-61: 「約束を探して…」いろは&amp;やちよ&amp;ももこ&amp;レナ&amp;かえでのイラスト（篠原健二）、石川達也プロデューサーのコメント。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2019年5月号</book-name>
-							<book-release>2019-04-10</book-release>
-							<book-amazon asin="B07P8B9LW5" image-id="51DbxIQwE3L" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.121: 「新房昭之のあの人とヒミツの話」で蒼樹うめとの対談。『マギアレコード』でキャラクター数が増えてきたことによる苦悩（蒼樹）、TVアニメのシナリオ会議に顔を出している（新房）など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2019年4月号</book-name>
-							<book-release>2019-03-09</book-release>
-							<book-amazon asin="B07NRF18Y5" image-id="510BJziYb7L" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.123: 「新房昭之のあの人とヒミツの話」で岩上敦宏との対談。新作に向けての打ち合わせは続いていること、TVシリーズ制作時の回想話。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2018年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>デザインノート　No.82</book-name>
-							<book-release>2018-11-26</book-release>
-							<book-amazon asin="4416518609" image-id="61su1hODxQL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.40: 草野剛が手掛けたデザイン例として「ニッポンのマンガ＊アニメ＊ゲーム」展（国立新美術館、2015年）の展示エリア写真。</p>
-									<p>p.47: 「BALCPLONY.」が手掛けたデザイン例として『マギアレコード』公式サイト。</p>
-									<p>pp.48-49: 染谷洋平インタビューで『まどか☆マギカ』に関わるきっかけなどが掲載。</p>
-									<p>p.58: 「BALCPLONY.」が手掛けたデザイン例として『SHAFT TEN』『MADOGATARI展』公式サイトなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2018年11月号</book-name>
-							<book-release>2018-10-10</book-release>
-							<book-amazon asin="B07H5VTZXQ" image-id="61mAb3Zv2iL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.151: マギアレコードアニメ化の情報（スタッフ、キャストは「未定」）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>MARQUEE　Vol.129</book-name>
-							<book-release>2018-10-10</book-release>
-							<book-isbn>978-4-434-25266-2</book-isbn>
-							<book-amazon asin="4434252666" image-id="51iX8HIlLOL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.52-53: けやき坂46の柿崎芽実と丹生明里による『舞台 マギアレコード』のインタビュー。柿崎は小学生の時に『まどか☆マギカ』を見ていたてマミがいちばん好き、フェリシアのハンマーは張りぼてではなく2kgくらいあった、など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2018年10月号</book-name>
-							<book-release>2018-09-10</book-release>
-							<book-amazon asin="B07G1XXX1M" image-id="61UkYYcxSdL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.127: 「新房昭之のあの人とヒミツの話」で草川啓造との対談。『コゼットの肖像』の話の中で、新房昭之が[前編]（※[後編]の間違いと思われる）で1分くらいの長回しカットを入れた（鈴木博文が担当）ことに言及。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきららフォワード　2018年10月号</book-name>
-							<book-release>2018-08-24</book-release>
-							<book-amazon asin="B07F7RSQNG" image-id="61MFCVOgYlL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.6: マギアレコードの広告。アルティメットまどか降臨、「Magia Day 2018」など。</p>
-									<p>pp.7-44: 『マギアレコード 魔法少女まどか☆マギカ外伝』（巻頭カラー）</p>
-									<p>pp.261-280: 『巴マミの平凡な日常』</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>コンプティーク　2018年5月号</book-name>
-							<book-release>2018-04-10</book-release>
-							<book-amazon asin="B07C8ZPQ9S" image-id="61GGgu6ba1L" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.120-121: マギアレコードの紹介記事。アリナ・グレイ実装「生と死を描く魔法少女登場――」。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>コンプティーク　2018年4月号</book-name>
-							<book-release>2018-03-10</book-release>
-							<book-amazon asin="B07B12HM4W" image-id="61fYCVIGFVL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.176-177: マギアレコードの紹介記事。美樹さやか登場「思い出を胸に青き剣士は戦う――」。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>コンプティーク　2018年3月号</book-name>
-							<book-release>2018-02-10</book-release>
-							<book-amazon asin="B0794Y8FKT" image-id="610M0X8mqKL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.118-119: マギアレコードの紹介記事。やちよ★5解放「背負った想いが新たな力を導く」。</p>
-									<p>pp.160-161: スマートフォン用ゲーム<a href="http://www.projecttokyodolls.jp/" class="htmlbuild-host">『プロジェクト東京ドールズ』</a>とのコラボイベント紹介。まどか、ほむら、マミの衣装を着たキャラクターのコラボカード。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>コンプティーク　2018年2月号</book-name>
-							<book-release>2018-01-10</book-release>
-							<book-amazon asin="B0788XQ6WR" image-id="61AhnR30wkL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.114-117: マギアレコードの紹介記事。鶴乃★5解放「魔法少女の新たな力が解放される!」、<a href="http://www.bpnavi.jp/kuji/item/2281" class="htmlbuild-host">一番くじマギレコ第2弾</a>の情報、メモリア紹介。</p>
-									<p>p.177: スマートフォン用ゲーム<a href="http://lastperiod.happyelements.co.jp/" class="htmlbuild-host">『ラストピリオド』</a>とのコラボイベント紹介。アルティメットまどか、マミ（キュゥべえ衣装Ver）イラスト。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2017年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>コンプティーク　2018年1月号</book-name>
-							<book-release>2017-12-09</book-release>
-							<book-amazon asin="B077HP64CX" image-id="61XEXNIH0zL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.52-55: マギアレコードの紹介記事。まどか、いろは、ほむら、マミ、杏子、レナ、かえで、ももこ、やちよ、フェリシア、鶴乃のキャラクター紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.45</book-name>
-							<book-release>2017-11-25</book-release>
-							<book-amazon asin="B077YZFTHL" image-id="51POxH9m0uL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.62: マギレコ紹介（文: 本澤徹）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ダ・ヴィンチ　2017年12月号</book-name>
-							<book-release>2017-11-06</book-release>
-							<book-amazon asin="B076BS2CNX" image-id="511moTWbwRL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.179: 新房昭之、蒼樹うめのコメント。TVシリーズの脚本を書いていたときの話（新房）、虚淵玄と初めて会ったときの第一印象（蒼樹）など。蒼樹うめによる鹿目まどか、セイバー（Fate/Zero）、常守朱（PSYCHO-PASS）の描き下ろしイラストも掲載。</p>
-									<p>pp.185-186: 虚淵玄のロングインタビュー。TVシリーズ脚本打ち合わせ時のこと、キャラクターが露悪的にならないよう配慮したこと、新編の話作りのことなど。</p>
-									<p>pp.200-201: マギアレコードの紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.44</book-name>
-							<book-release>2017-10-13</book-release>
-							<book-amazon asin="B076F739V9" image-id="51xGSaBC+aL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 環いろは、暁美ほむら（原画: 谷口淳一郎）</p>
-									<p>pp.4-33: <em>「巻頭特集　マギアレコード　魔法少女まどか☆マギカ外伝」</em>ゲームシステム紹介、メモリアリスト、魔法少女名鑑。</p>
-									<p>pp.27-29: 沼田誠也、谷口淳一郎によるゲームオープニング解説（絵コンテ、修正原画掲載）。</p>
-									<p>pp.30-31: 劇団イヌカレー・泥犬による魔法少女変身シーン&amp;ドッペル解説（杏子の絵コンテ掲載）。</p>
-									<p>pp.32-33: 佐藤允紀インタビュー。メインキャラクターは最初に武器とイメージカラーを決めてから蒼樹うめに描き下ろしてもらったこと、やちよなど一部のメインキャラクターがレアリティをあえて低く設定されている理由など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>芸術新潮　2017年9月号</book-name>
-							<book-release>2017-08-25</book-release>
-							<book-amazon asin="B074JRWX4N" image-id="51v6K3nDqHL" width="118" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.62: 「私が愛したアニメ クリエイターズ・インタビュー」で新房昭之インタビュー。『まどか☆マギカ』と『コゼットの肖像』にY字路を出した話など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2017年9月号</book-name>
-							<book-release>2017-08-09</book-release>
-							<book-amazon asin="B073ZYRKNM" image-id="612XxYBmtjL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.38-39: マギアレコード紹介。いろは、やちよ、フェリシア、レナ、かえで、ももこ、鶴乃、さなのキャラクター紹介、いろはの変身シーン。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>SWITCH　2017年8月号　Vol.35　No.8</book-name>
-							<book-release>2017-07-20</book-release>
-							<book-isbn>978-4-88418-495-7</book-isbn>
-							<book-amazon asin="4884184955" image-id="51FA+pyPnBL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.64-68: <em>「HISTORY OF HEROINE BY SHAFT シャフトが描いたヒロイン」</em>で蒼樹うめ×新房昭之の対談。キャラクターデザインの話など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2017年8月号</book-name>
-							<book-release>2017-07-10</book-release>
-							<book-amazon asin="B072KPNKV4" image-id="61GH8caDhaL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.144-145: 「音楽と映像が、融合した日」 <a href="https://smemusictheater.jp/" class="htmlbuild-host">MUSIC THEATER 2017</a>のレポート記事。バックにアニメ作品の映像が流れるライブで、まどか☆マギカ関連では「コネクト」「Magia」の2曲が流れた。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2017年7月号</book-name>
-							<book-release>2017-05-30</book-release>
-							<book-amazon asin="B06XZS277C" image-id="51GJ6MCNXPL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.68-69: 「それはボクたちの希望」マギアレコードの紹介記事。まどか、いろは、ほむら、さな、やちよ、フェリシア、鶴乃のキャラクタービジュアルとキャスト掲載、「コネクト」「ドッペル」などのシステム説明。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>MdN　2017年5月号</book-name>
-							<book-release>2017-04-06</book-release>
-							<book-amazon asin="B01MSTEHIW" image-id="51n+oixrMkL" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.102: 「PORTFOLIO NO.46 BALCOLONY.」で制作実績としてMADOGATARI展キービジュアルやウェブサイトデザイン紹介。</p>
-									<p>p.107: 同じくBALCOLONY.社でMADOGATARI展のデザインを担当した野条友史のコメント。</p>
-									<p><a href="https://books.mdn.co.jp/magazine/3217101005/" class="htmlbuild-host">公式ページ</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.28</book-name>
-							<book-release>2017-02-09</book-release>
-							<book-isbn>978-4-7897-7262-4</book-isbn>
-							<book-amazon asin="4789772624" image-id="51-IpMGl81L" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.81: ClariSのアルバム「Faily Castle」に関するインタビューで、『まどか☆マギカ』の時にスタッフが物語について何も教えてくれない状態で収録したこと、カレンは3曲の新録にあたり前のClariSのマネにならないようにしたこと、など。</p>
-									<p>表3: ClariS「Faily Castle」の広告。限定版に『まどか☆マギカ』主題歌3作の 2017ver. が収録されることが記載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.30　2017年3月号</book-name>
-							<book-release>2017-02-09</book-release>
-							<book-amazon asin="B01N382U5A" image-id="51ouabljNLL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、ほむら（イラスト: 蒼樹うめ）</p>
-									<p>キャッチコピー: 「まどかがささやく魔法の呪文」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2016年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.29　2017年1月号</book-name>
-							<book-release>2016-12-10</book-release>
-							<book-amazon asin="B01N64P4VK" image-id="51gCe94T5dL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、さやか、杏子（イラスト: はりかも）</p>
-									<p>キャッチコピー: 「まどかとすごす魔法の時間♪」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.28　2016年11月号</book-name>
-							<book-release>2016-10-08</book-release>
-							<book-amazon asin="B01LWIA1R6" image-id="51WyIT-ku1L" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: アルティメットまどか、リボンほむら（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「まどかとなら、何処へでも――」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.27　2016年9月号</book-name>
-							<book-release>2016-08-09</book-release>
-							<book-amazon asin="B01IFI3HMQ" image-id="51SvRihhcfL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、ほむら、マミ、キュゥべえ（イラスト: 琴慈）</p>
-									<p>キャッチコピー: 「暑さを吹き飛ばすまどかの笑顔」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2016年7月号</book-name>
-							<book-release>2016-06-10</book-release>
-							<book-amazon asin="B01EVM3U3G" image-id="61a3RGJg-HL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.175-176: 水着の鹿目まどか、暁美ほむらA3ポスター（原画: 谷口淳一郎）。</p>
-									<p>付録: 同イラストのポストカード。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.26　2016年7月号</book-name>
-							<book-release>2016-06-10</book-release>
-							<book-amazon asin="B01FWHCSP0" image-id="61+fz4mAUuL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: リボンほむら（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「全ては、まどかのために――」（※背表紙は「ハノカゲ[魔獣編]大好評連載中！」）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>MdN　2016年6月号</book-name>
-							<book-release>2016-05-06</book-release>
-							<book-amazon asin="B01E50ROE0" image-id="61WbBcCzXQL" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.73: 「惚れる悪の造形」でキュゥべえ紹介。</p>
-									<p><a href="https://books.mdn.co.jp/magazine/3216101006/" class="htmlbuild-host">公式ページ</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.25　2016年5月号</book-name>
-							<book-release>2016-04-09</book-release>
-							<book-amazon asin="B01C908MA8" image-id="51VGaI+g-CL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: バレエまどか（イラスト: 蒼樹うめ）</p>
-									<p>キャッチコピー: 「まどかと踊る?」</p>
-									<p>付録: 表紙イラストクリアファイル</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Cut　2016年4月号</book-name>
-							<book-release>2016-03-19</book-release>
-							<book-amazon asin="B01BCF8XZK" image-id="51C64EiF6nL" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.97: 梶浦由記の『僕だけがいない街』でのインタビュー内で『まどか☆マギカ』を『Fate/Zero』と比較したコメント。『まどか』は主人公が中学生で視野が狭いので、（視聴者寄りではなく）主人公目線を意識した話。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2016年4月号</book-name>
-							<book-release>2016-03-10</book-release>
-							<book-amazon asin="B01BY5LRFG" image-id="61j8rMpPPyL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>付録: B2ポスター: マミ、アルティメットまどか、悪魔ほむら（谷口淳一郎）。</p>
-									<p><a href="https://www.youtube.com/watch?v=c4YPtbsolOY" class="htmlbuild-host">発売CM</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2016年3月号</book-name>
-							<book-release>2016-02-10</book-release>
-							<book-amazon asin="B01AXOUUFC" image-id="61IlkLZ6K5L" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.157: 「新房昭之のあの人とヒミツの話」で、淀明子（アニプレックスプロデューサー）と対談、初めて新房監督に関わったのが『まどか☆マギカ』。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.24　2016年3月号</book-name>
-							<book-release>2016-02-10</book-release>
-							<book-amazon asin="B01AM8KWVG" image-id="51ZG2dzsM4L" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、さやか（イラスト: 原悠衣）</p>
-									<p>キャッチコピー: 「2016年もまどかで決まり!!」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ゲームラボ　2016年2月号</book-name>
-							<book-release>2016-01-16</book-release>
-							<book-amazon asin="B000DZID9C" image-id="616KMBlvFNL" width="114" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.99: 「発売&amp;放送禁止アニメ大全」で、災害を連想させる作品としてTV版11話で体育館に避難している鹿目家のキャプチャーが掲載（本放送では放送されず、パッケージ版に収録されたカット）。</p>
-									<p>p.104: 東日本大震災で『まどか☆マギカ』が4月に一挙放送という形になったことに言及。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2015年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2016年2月号</book-name>
-							<book-release>2015-12-26</book-release>
-							<book-amazon asin="B018XBUPHU" image-id="610ZyO9NdxL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.111: 「MADOGATARI展」広告。展示内容概略と札幌会場の予告。コンセプトムービーの場面カット。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2016年1月号</book-name>
-							<book-release>2015-12-10</book-release>
-							<book-amazon asin="B0188TZKVI" image-id="61+ImMYI+SL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.176: <em>「"魔法少女"の可能性」</em>新房昭之、久保田光俊による「コンセプトムービー」に関するインタビュー。</p>
-									<p>付録: バレエまどか&amp;マミ&amp;制服ほむらのB2ポスター（潮月一也）。</p>
-									<p><a href="https://www.youtube.com/watch?v=d0Ct1MXx2JE" class="htmlbuild-host">発売CM</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.23　2016年1月号</book-name>
-							<book-release>2015-12-10</book-release>
-							<book-amazon asin="B017XY63VU" image-id="61bJi1Y4hUL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、さやか、マミ、ベベ、キュゥべえ（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「まどか達からのとっておきのプレゼント♪」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.22　2015年11月号</book-name>
-							<book-release>2015-10-09</book-release>
-							<book-amazon asin="B0158X17CS" image-id="61j1ROldSPL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、杏子（イラスト: 川井マコト）</p>
-									<p>キャッチコピー: 「秋の夜長はまどかと一緒に！」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>MdN　2015年11月号</book-name>
-							<book-release>2015-10-06</book-release>
-							<book-amazon asin="B015Z53XYO" image-id="61y837PwCgL" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.7: 「蒼樹うめ展」開催情報とキービジュアル掲載。</p>
-									<p>p.102: 「フォントのショーケース」で「蒼樹うめ展」キービジュアルのタイトルロゴやキャッチコピーのフォント解説。</p>
-									<p><a href="https://books.mdn.co.jp/magazine/3215101011/" class="htmlbuild-host">公式ページ</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2015年10月号</book-name>
-							<book-release>2015-09-07</book-release>
-							<book-amazon asin="B0148CNZ9I" image-id="51KG65G+RKL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.143: 「新房昭之のあの人とヒミツの話」で岩上敦宏（アニプレックス）と対談。後編のまどかとほむらの宇宙空間のシーンで服を着せる変更を行ったことに言及。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.21　2015年9月号</book-name>
-							<book-release>2015-08-10</book-release>
-							<book-amazon asin="B010TKKMWQ" image-id="61YCd6du51L" width="110" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、ほむら（原画: 中村直人）</p>
-									<p>キャッチコピー: 「まどかのまぶしい――夏!!」</p>
-									<p>付録: 表紙イラストクリアファイル</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2015年9月号</book-name>
-							<book-release>2015-07-30</book-release>
-							<book-amazon asin="B00ZD9F4U4" image-id="61FK57sEokL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.45: 「業界著名人はアニメをかく語りき」新房昭之インタビュー。「美少女」の話題で『宇宙戦艦ヤマト』から始まり、『まどか☆マギカ』も（「美少女モノ」ではないという意味で）例に挙げられる。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.29</book-name>
-							<book-release>2015-06-17</book-release>
-							<book-amazon asin="B00YAC8OP2" image-id="61V++H3OJHL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.119-120: 「新房語（最終回）」大沼心がゲスト。オリジナル作品の話題で『まどか☆マギカ』の名前が挙がり、虚淵玄へ「『ジョジョの奇妙な冒険』のような異能力バトルものにしたい」というお願いをした話など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2015年7月号</book-name>
-							<book-release>2015-06-10</book-release>
-							<book-amazon asin="B00Y27U13I" image-id="61QLgqAwPIL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.107: 「新房昭之のあの人とヒミツの話」で金庭こず恵（ムービック）と対談、『まどか☆マギカ』を含む新房作品のグッズ展開の話。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.20　2015年7月号</book-name>
-							<book-release>2015-06-10</book-release>
-							<book-amazon asin="B00WN3XVQC" image-id="61nG7cmPBsL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: アルティメットまどか（イラスト: 蒼樹うめ）</p>
-									<p>キャッチコピー: 「The Third Anniversary 祝☆3周年!!」</p>
-									<p>付録: 表紙イラストクリアファイル</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>「魔獣編」連載開始。</li>
-								</ul>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>MdN　2015年6月号</book-name>
-							<book-release>2015-05-07</book-release>
-							<book-amazon asin="B00TYLC14E" image-id="51kGnuqlEML" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.64-67: 「少女の表現史」で鹿目まどか紹介（談: 篠田利隆）。</p>
-									<p><a href="https://books.mdn.co.jp/magazine/3215101006/" class="htmlbuild-host">公式ページ</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2015年5月号</book-name>
-							<book-release>2015-04-10</book-release>
-							<book-amazon asin="B00URAYHSO" image-id="51G7y+oRCfL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.7-8: アルティメットまどか、新魔法少女服(?)まどかのピンナップ（蒼樹うめ）。</p>
-									<p><a href="https://www.youtube.com/watch?v=3E6ewo6BaVQ" class="htmlbuild-host">発売CM</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.19　2015年5月号</book-name>
-							<book-release>2015-04-10</book-release>
-							<book-amazon asin="B00UXLY444" image-id="617yOEp1HSL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、なぎさ 他（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「2015年も、"まどか"だけ――」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.18　2015年3月号</book-name>
-							<book-release>2015-02-10</book-release>
-							<book-amazon asin="B00S9X6I88" image-id="61FGoVstVoL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: リボンほむら（悪魔）（イラスト: 得能正太郎）</p>
-									<p>キャッチコピー: 「2015年も、"まどか"だけ――」</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2014年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.17　2015年1月号</book-name>
-							<book-release>2014-12-10</book-release>
-							<book-amazon asin="B00PM7313E" image-id="61OUJNQVQdL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、眼鏡ほむら（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「"まどか"と、ぽかぽか。」（※背表紙は「まどかと一緒なら心も体もぽかぽか。」）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきららフォワード　2015年1月号</book-name>
-							<book-release>2014-11-22</book-release>
-							<book-amazon asin="B00OYUMWL2" image-id="61I8onBN-dL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.199-224: 『すずね☆マギカ』最終話</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2014年12月号</book-name>
-							<book-release>2014-11-10</book-release>
-							<book-amazon asin="B00FC0Z3J6" image-id="61q8W8SxISL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.32: 「hello world」虚淵玄インタビュー内で『魔法少女まどか☆マギカ』をやる経緯などの話。</p>
-									<p>p.118: 「新房昭之のあの人とヒミツの話」で大澤信博（アニメプロデュース会社・ジェンコ）との対談。『ヴァンパイアバンド』で悠木碧と斎藤千和がシャフト作品で初共演し、『魔法少女まどか☆マギカ』でのコンビネーションに繋がったであろう話。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.16　2014年11月号</book-name>
-							<book-release>2014-10-10</book-release>
-							<book-amazon asin="B00MX42KGS" image-id="614xzoC4JNL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 悪魔ほむら（イラスト: 蒼樹うめ）</p>
-									<p>キャッチコピー: 「"まどか"があれば何もいらない。」</p>
-									<p>付録: 表紙イラストクリアファイル</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>MdN EXTRA　Vol.1</book-name>
-							<book-release>2014-08-30</book-release>
-							<book-amazon asin="4844364391" image-id="61wS0NthGFL" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.94: 「BALCOLONY.に学ぶ美少女とデザイン。」でTV版、劇場版、[新編]の3タイプのロゴについて、染谷洋平によるコメント。（2013年9月号の再録）</p>
-									<p>p.106-115: 「デザイナーの思考や制作プロセスがわかるデザインのラフ案&amp;別案」で「叛逆の物語」BDパッケージの紹介。染谷洋平インタビュー。（2014年5月号の再録）</p>
-									<p>pp.140-141: 「終わりのあとの始まり 印刷の魔法をもう一度信じてみる?」で「劇場版 魔法少女まどか☆マギカ 総集編 Keyanimation ClearFile」の紹介（談: 浅見啓介）。（2013年12月号の再録）</p>
-									<p><a href="https://books.mdn.co.jp/books/3214102001/" class="htmlbuild-host">公式ページ</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.15　2014年9月号</book-name>
-							<book-release>2014-08-08</book-release>
-							<book-amazon asin="B00LFW7BKY" image-id="61mt7bgv+4L" width="110" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: アラサーマミ（イラスト: あらたまい）</p>
-									<p>キャッチコピー: 「巴マミの平凡な日常 最新コミックス②8月11日発売!!」（※背表紙は「巴マミの平凡な日常 ドアプレート付き!!」）</p>
-									<p>付録: 「巴マミの平凡な日常」ドアプレート（現物写真 <a href="https://twitpic.com/e9pmx9" class="htmlbuild-host">その1</a>、<a href="https://twitpic.com/e9pn4b" class="htmlbuild-host">その2</a>）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2014年9月号</book-name>
-							<book-release>2014-07-30</book-release>
-							<book-amazon asin="B009FRJKV4" image-id="61R2SgCcdzL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.8: 「メガミマガジン15周年記念企画 人気ヒロイン変遷史」で鹿目まどか掲載（蒼樹うめ設定イラスト掲載）。</p>
-								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.14　2014年7月号</book-name>
-							<book-release>2014-06-10</book-release>
-							<book-amazon asin="B00KCUXXGQ" image-id="61hSbgEhhUL" width="111" height="160"></book-amazon>
+							<book-name>娘TYPE　Vol.17</book-name>
+							<book-release>2011-02-28</book-release>
+							<book-amazon asin="B004OSXHNG" image-id="61RKdFIXAEL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 魔法少女6人、キュゥべえ（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「ここにくれば逢える――」（※背表紙は「ここにくればまどかに逢える」）</p>
+									<p>表紙: ドレスを着たまどか&amp;ほむら（原画: 谷口淳一郎）</p>
+									<p>p.7: パジャマ姿のまどか折り込みポスター（原画: 今村亮）</p>
+									<p>pp.34-40: <em>「とまどうまどかに愛の手を!!」</em>各魔法少女の戦い方分析、新房昭之×虚淵玄×蒼樹うめの座談会など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>オトナアニメ　Vol.34</book-name>
-							<book-release>2014-05-30</book-release>
-							<book-amazon asin="4800304156" image-id="51gHlkmxdwL" width="113" height="160"></book-amazon>
+							<book-name>メガミマガジン　2011年4月号</book-name>
+							<book-release>2011-02-28</book-release>
+							<book-amazon asin="B004N77PB8" image-id="61jzNGztROL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.34-37: 「シャフト演出作品、ここを観る!」特集で [新編] のキャプチャーが2枚掲載。また『メカクシティアクターズ』のコラムでは、アニメーターの阿部厳一郎について、TV版オープニングのまどか走りや、 [後編] でほむらと杏子の変身シーンを手掛けたことを紹介。</p>
-									<p>pp.50-52: <em>『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』のおさらい。</em>ガン=カタシーンの撮影方法（手描き/CG）への言及や阿澄佳奈のコメント。50ページ下部の「魔女の井戸」のキャプチャー画像は、ほむらに光が当たった上映版を使用。</p>
+									<p>表紙: ほむらと黒猫（原画: 谷口淳一郎）。</p>
+									<p>pp.19-20: 表紙イラストのピンナップポスター。</p>
+									<p>pp.30-39: <em>「魔法少女たちの光と闇」</em>7話までの概要、宮本幸裕インタビュー、劇団イヌカレーQ&amp;A、蒼樹うめ描き下ろし4コマ漫画、虚淵玄&amp;ハノカゲインタビュー、一肇によるオフィシャルノベル。</p>
+									<p>付録: 白いスクール水着を着たまどかのロングポスター。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2014年5月号</book-name>
-							<book-release>2014-04-10</book-release>
-							<book-amazon asin="B00J4T7KII" image-id="61YjouHyNyL" width="123" height="160"></book-amazon>
+							<book-name>アニメージュ　2011年4月号</book-name>
+							<book-release>2011-03-10</book-release>
+							<book-amazon asin="B004NVB4IE" image-id="61PiiDR0iOL" width="127" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.9-10: アルティメットまどか&amp;悪魔ほむらのピンナップ（菊田幸一）。</p>
-									<p><a href="https://www.youtube.com/watch?v=A4jIvFs1idk" class="htmlbuild-host">発売CM</a></p>
+									<p>pp.70-71: <em>「魔法少女の想いは哀しく、儚く」</em> 9話までの紹介、悠木碧インタビュー。</p>
+									<p>p.72: インターネットラジオ「あにめじ湯」（Vol.81）のゲストに悠木碧。ペットの猫「エイミー」の写真掲載。</p>
+									<p>pp.84-86: 「設定資料FILE」各キャラクターの設定イラスト掲載。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.13　2014年5月号</book-name>
-							<book-release>2014-04-10</book-release>
-							<book-amazon asin="B00ITYI5KG" image-id="61vTonESm9L" width="111" height="160"></book-amazon>
+							<book-name>アニメディア　2011年4月号</book-name>
+							<book-release>2011-03-10</book-release>
+							<book-amazon asin="B004OSXGZK" image-id="61stIzEf8xL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、マミ、なぎさ（イラスト: Koi）</p>
-									<p>キャッチコピー: 「劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語 Blu-ray&amp;DVD絶賛発売中!!」（※背表紙は「[新編]叛逆の物語 BD&amp;DVD 大好評発売中!!」）</p>
+									<p>p.97: 10〜12話の番組情報（あらすじ、サブタイトルは非公開）。</p>
+									<p>pp.132-135: <em>「『まどか』特集 ふたつの願い」</em> 9話までの振り返り、斎藤千和インタビュー、岩上敦宏コメント。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>MdN　2014年5月号</book-name>
-							<book-release>2014-04-05</book-release>
-							<book-amazon asin="B00J496WUA" image-id="51sgs+ia4RL" width="118" height="160"></book-amazon>
+							<book-name>ニュータイプ　2011年4月号</book-name>
+							<book-release>2011-03-10</book-release>
+							<book-amazon asin="B004PIZX6O" image-id="61MSS3P63+L" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.48-55: 「デザイナーのもとに眠っていたラフや別案と出会う」で [新編] Blu-rayパッケージの紹介。染谷洋平インタビュー。</p>
-									<p><a href="https://books.mdn.co.jp/magazine/3214101005/" class="htmlbuild-host">公式ページ</a></p>
+									<p>p.130: 10〜12話の番組情報（サブタイトル、あらすじが非公開のため欄外に掲載）。</p>
+									<p>pp.180-183: 「最後の願い」制服&amp;魔法少女姿の2人のまどかイラスト（高橋美香）、キュゥべえに関して、新房昭之、虚淵玄、蒼樹うめによるコメント、加藤英美里インタビュー。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>季刊エス　2014年春号（第46号）</book-name>
-							<book-release>2014-03-15</book-release>
-							<book-amazon asin="B00I9H1X16" image-id="61LTQnPbgHL" width="119" height="160"></book-amazon>
+							<book-name>季刊エス　2011年春号（第34号）</book-name>
+							<book-release>2011-03-15</book-release>
+							<book-amazon asin="B004OSXHD6" image-id="61n6fx9MhxL" width="122" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.74-79: <em>『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』新房昭之インタビュー</em>　ほむら変身シーンの原画が掲載。</p>
+									<p>pp.48-53: <em>『魔法少女まどか☆マギカ』新房昭之インタビュー</em>　3話、5話の絵コンテ、オープニングのまどか変身シーン原画掲載。</p>
 								</div>
 
 								<ul class="p-notes">
@@ -1105,813 +432,711 @@
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>MdN　2014年4月号</book-name>
-							<book-release>2014-03-06</book-release>
-							<book-amazon asin="B00IRX1SEY" image-id="51eWlOGnr3L" width="121" height="160"></book-amazon>
+							<book-name>Febri　Vol.5</book-name>
+							<book-release>2011-03-28</book-release>
+							<book-amazon asin="B004QGYZHI" image-id="51KCW4Sk6KL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.24-25: 「PRODUCTION NOTE 新装版-TV series」の装丁について、作者のミルキィ・イソベによる解説。</p>
+									<p>pp.4-29: <em>「虚淵玄大特集!!」</em>で虚淵玄×高橋龍也（シナリオライター・脚本家）×高山箕犀（イラストレーター）の座談会（2011年2月8日）。序盤（1〜3話）の構成が“黒田メソッド”であること、脚本ではアクションシーンは一切書かなかったことなど。</p>
+									<p>pp.100-105: 「新房語」（第5回）あおきえいがゲスト。劇団イヌカレーの作業内容や、虚淵玄の脚本についての話。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ストレンジャーソレント　2014年4月号</book-name>
-							<book-release>2014-03-01</book-release>
-							<book-amazon asin="B00IPCVMN4" image-id="61zhBjEBUEL" width="112" height="160"></book-amazon>
+							<book-name>娘TYPE　2011年5月号</book-name>
+							<book-release>2011-03-30</book-release>
+							<book-amazon asin="B004TB6SKM" image-id="61rxCoHXa8L" width="121" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.265-269: <em>「ストレンジャーソレント特別対談！ 虚淵玄×小池一夫 『魔法少女まどか☆マギカ　叛逆の物語』を語る」</em><a href="https://live.nicovideo.jp/watch/lv162841750" class="htmlbuild-host">ニコニコ生放送で2013年12月22日に行われた対談</a>の書き起こし。</p>
+									<p>pp.29-30: ピンナップ: パジャマ姿のまどか、ほむら、マミ、さやか、杏子（潮月一也）。</p>
+									<p>p.35: 独立創刊のお祝いコメントでVol.17表紙のまどかとほむらからメッセージ。</p>
+									<p>p.38: Blu-ray&amp;DVD1巻広告。</p>
+									<p>p.92: 「いっしょにお花見したい娘」の1位: 鹿目まどか、7位: 巴マミ。「いっしょに卒業旅行したい娘」の4位: 暁美ほむら、6位: 美樹さやか、9位: 巴マミ。</p>
+									<p>p.112:　Vol.17の表紙ギャラリー。</p>
+									<p>pp.158-161: <em>「魔のトライアングルにご用心♥」</em> 8〜10話などの場面ショット複数掲載、岩上敦宏の一言コメント、キャストコメント。</p>
+									<p>p.212: 「いまときのムスメ力」明貴美加（メカデザイナー）による時間制御ウィングを装備した暁美ほむらイラスト。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2014年3月号</book-name>
-							<book-release>2014-02-10</book-release>
-							<book-amazon asin="B00I11AZZU" image-id="51seO+Q8HEL" width="124" height="160"></book-amazon>
+							<book-name>メガミマガジン　2011年5月号</book-name>
+							<book-release>2011-03-30</book-release>
+							<book-amazon asin="B004SBIH5C" image-id="61-C1Ai59WL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.147: 「新房昭之の恐縮ですが……」で『まどか☆マギカ』発表時のニュータイプ誌面での掲載記事の話。</p>
+									<p>pp.173-174: まどか&amp;ほむら&amp;さやか&amp;杏子&amp;キュゥべえの折り込みピンナップ（イラスト: ゆーぽん）。</p>
+									<p>別冊付録: <em>「魔法少女まどか☆マギカ スペシャルブック」</em>1話〜10話の虚淵玄コメント付きストーリー解説、次回予告イラスト集、設定イラスト（まどかのパジャマ姿や杏子の家族、モブキャラなどの蔵出し）、イラストギャラリー（Blu-ray店舗特典）、スタッフコメント集。</p>
+									<p>別冊付録: 水着イラストのB2ポスター（原画: 谷口淳一郎）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.12　2014年3月号</book-name>
-							<book-release>2014-02-10</book-release>
-							<book-amazon asin="B00HWCJF0A" image-id="51MyWq10s1L" width="114" height="160"></book-amazon>
+							<book-name>リスアニ!　Vol.4.1 （アニソンクリエイターズⅠ）</book-name>
+							<book-release>2011-03-31</book-release>
+							<book-isbn>978-4-7897-7125-2</book-isbn>
+							<book-amazon asin="4789771253" image-id="51kS+GX+QdL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、悪魔ほむら（原画: 山村洋貴）</p>
-									<p>キャッチコピー: 「『[新編]叛逆の物語』 BD&amp;DVD 4/2発売決定!!」（※背表紙は「[新編]叛逆の物語 BD&amp;DVD 4/2発売決定!!」）</p>
-									<p>付録: 表紙イラストB3ポスター</p>
+									<p>pp.20-25: <em>『魔法少女まどか☆マギカ』特集ページ。</em>ClariS、Kalafinaの紹介（文はそれぞれ冨田明宏、有村悠）。</p>
+									<p>p.141: 「コネクト」の広告。</p>
+									<p>p.151: 「Magia」の広告。</p>
+									<p>裏表紙: Blu-ray&amp;DVD1巻の広告。パッケージイラスト掲載。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2014年2月号</book-name>
-							<book-release>2014-01-10</book-release>
-							<book-amazon asin="B00HFD3P0M" image-id="61t0wA+LD3L" width="124" height="160"></book-amazon>
+							<book-name>オトナアニメ　Vol.20</book-name>
+							<book-release>2011-04-09</book-release>
+							<book-isbn>978-4-86248-711-7</book-isbn>
+							<book-amazon asin="4862487114" image-id="51X7yWzHwwL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.150: 「新房昭之の恐縮ですが……」で『まどか☆マギカ』のシナリオが放送よりずいぶん前にできあがっていた話。</p>
-									<p>pp.168-171: <em>「永遠の絶望を」</em>悪魔ほむら&amp;ほむらのイラスト（菊田幸一）、斎藤千和インタビュー。ラストシーンの録り直しの話など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2013年</h2>
-						</div>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ストレンジャーソレント　2014年2月号</book-name>
-							<book-release>2013-12-28</book-release>
-							<book-amazon asin="B00HFMMIFQ" image-id="61vgU+hqnML" width="109" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.272: 大阪芸術大学のコラボイベント「まどか☆マギカ's Magica」のレポート。トークショー、展示の情報、ラッピングスクールバスの写真掲載。</p>
+									<p>表紙: 鹿目まどか（TVシリーズ第2弾キービジュアルの一部）</p>
+									<p>pp.6-39: <em>「特集　魔法少女まどか☆マギカ」</em>キャラクター紹介、各話解説（10話まで）、演出の考察、劇団イヌカレー&amp;宮本幸裕へのQ&amp;A形式の質問、劇団イヌカレーのコラージュ紹介、梶浦由記の作品史。</p>
+									<p>pp.18-20: 新房昭之インタビュー。虚淵玄との出会い、絵コンテの描き方など。</p>
+									<p>pp.34-36: 虚淵玄インタビュー。ほむらの盾の構造解説、フィクションに含まれる毒の要素に関する持論など。</p>
+									<p>p.39: 岩上敦宏インタビュー。主要スタッフの採用経緯など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2014年2月号</book-name>
-							<book-release>2013-12-27</book-release>
-							<book-amazon asin="B00H8X84KA" image-id="61Vm0qmyLyL" width="125" height="160"></book-amazon>
+							<book-name>アニメージュ　2011年5月号</book-name>
+							<book-release>2011-04-09</book-release>
+							<book-amazon asin="B004TB6T6A" image-id="61tzh0piqvL" width="127" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.84: <em>「MADOKA'S HIGH」</em> 新編の情報、「暁美ほむら 晴れ着ver.」フィギュア、「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。</p>
-									<p>p.85: 日日日（あきら・小説家）による [新編] のレビュー。作品の話よりは、虚淵玄やニトロプラス社の話がメイン。</p>
+									<p>pp.32-37: <em>「少女たちの決意」</em>まどか&amp;ほむら&amp;キュゥべえのイラスト（潮月一也）、新房昭之×虚淵玄インタビュー（8〜10話に関する内容）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2014年1月号</book-name>
-							<book-release>2013-12-10</book-release>
-							<book-amazon asin="B00GUP6QU2" image-id="61AN-e9TRQL" width="123" height="160"></book-amazon>
+							<book-name>アニメディア　2011年5月号</book-name>
+							<book-release>2011-04-09</book-release>
+							<book-amazon asin="B004TGPZH4" image-id="61FjzoqMCrL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>別冊付録: <em>「……in dream」</em>谷口淳一郎、寺尾洋之×谷口淳一郎×山村洋貴、宮本幸裕×泥犬のインタビュー。</p>
-									<p><a href="https://www.youtube.com/watch?v=Ktz6Y9oGIM8" class="htmlbuild-host">発売CM</a></p>
+									<p>pp.120-121: 「Dear Magical Girls」10話のまどか、ほむらの場面ショットが大きく掲載。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.20</book-name>
-							<book-release>2013-12-10</book-release>
-							<book-amazon asin="B00FPBRX36" image-id="51ludySS96L" width="113" height="160"></book-amazon>
+							<book-name>ニュータイプ　2011年5月号</book-name>
+							<book-release>2011-04-09</book-release>
+							<book-amazon asin="B004U5MOZK" image-id="61Blr2Rn9GL" width="123" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.113-120: <em>「新房語」</em>宮本幸裕、谷口淳一郎がゲストで[新編]の話。"べべ"は本当の名前ではないという話、各シーンの担当スタッフ、総カット数など。</p>
-									<p>p.157: 「今月の女神」に巴マミ。</p>
+									<p>p.124: 「新房昭之とおシゴトな仲間達」（最終回）で虚淵玄との対談。「奇跡」の取り扱い、<a href="https://www.amazon.co.jp/dp/B00E1C77IQ/" class="htmlbuild-host htmlbuild-amazon-associate">サンデルの政治哲学</a>との関係性などについて。</p>
+									<p>特別付録: <em>描き下ろしB2ポスター&amp;特集記事「魔法少女まどか☆マギカ」</em>まどか&amp;眼鏡ほむらのイラスト（住本悦子）、虚淵玄、新房昭之による第10話までの振り返り。</p>
+									<p><a href="https://www.youtube.com/watch?v=8PPpUkaAehc" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.11　2014年1月号</book-name>
-							<book-release>2013-12-10</book-release>
-							<book-amazon asin="B00GCFRR4Y" image-id="61IluNPpzYL" width="111" height="160"></book-amazon>
+							<book-name>B.L.T.　2011年6月号</book-name>
+							<book-release>2011-04-23</book-release>
+							<book-amazon asin="B004W8DUNU" image-id="51fLLpUtXpL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: マミ、なぎさ（イラスト: 蒼樹うめ）</p>
-									<p>キャッチコピー: 「3カ月連続刊行 いよいよ第3弾!!」（※背表紙は「[新編]叛逆の物語 絶賛公開中――!!」）</p>
-									<p>付録: 表紙イラストホログラム下敷き</p>
+									<p>表紙: 鹿目まどか（ゲーマーズ版のみ）、暁美ほむら（アニメイト版のみ）、美樹さやか（とらのあな版のみ）。</p>
+									<p>p130-133: <em>「魔法少女まどか☆マギカ」大特集</em>まどか&amp;ほむら&amp;さやかのイラスト（谷口淳一郎）、悠木碧コメント（11話の演技について）、虚淵玄インタビュー。</p>
+									<p>特典: 表紙イラストブロマイド（ゲーマーズ版、アニメイト版、とらのあな版のみ）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2014年1月号</book-name>
-							<book-release>2013-11-30</book-release>
-							<book-amazon asin="B00GNG8052" image-id="61MydVQLeiL" width="126" height="160"></book-amazon>
+							<book-name>リスアニ!　Vol.05</book-name>
+							<book-release>2011-04-25</book-release>
+							<book-isbn>978-4-7897-7126-9</book-isbn>
+							<book-amazon asin="4789771261" image-id="51a05+jM7ML" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.42-44: <em>「[新編]叛逆の物語 SWEET &amp; BITTER BATTLES」</em> メインスタッフからのメッセージ、公開初日舞台挨拶レポート、「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。鋼屋ジンによる [新編] のレビュー。</p>
+									<p>表紙: 鹿目まどか、暁美ほむら（中村直人）</p>
+									<p>pp.7-19: <em>「[特集1]『魔法少女まどか☆マギカ』」</em> 最速! 全12話駆け足ストーリーレビュー、梶浦由記インタビュー（9話冒頭の魔女が変身するシーンで飛んでいる譜線は9話最後に流れる曲の譜面）、ClariSインタビュー（ClariSの2人がテレビを見ている蒼樹うめイラスト掲載）。</p>
+									<p>pp.20-22: 「Kalafina LIVE Spring TOUR 2011 “Magia”」ライブレポート。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2014年1月号</book-name>
-							<book-release>2013-11-30</book-release>
-							<book-amazon asin="B00GR6GXPM" image-id="61WzcZnZk-L" width="124" height="160"></book-amazon>
+							<book-name>月刊メガストア　2011年6月号</book-name>
+							<book-release>2011-04-30</book-release>
 							<book-contents>
 								<div class="p-text">
-									<p>p.136: 新編情報。場面カット複数掲載。</p>
-									<p>p.143: Blu-ray BOX情報。</p>
-									<p>p.144: 「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。</p>
-									<p>p.147: 新編コミカライズ1巻情報。</p>
-									<p>付録: 制服の眼鏡ほむら&amp;杏子のB2ポスター（2013年12月号表紙イラスト）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>オトナアニメ　Vol.32</book-name>
-							<book-release>2013-11-27</book-release>
-							<book-isbn>978-4-8003-0284-7</book-isbn>
-							<book-amazon asin="4800302846" image-id="51lp2mu1XfL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: [新編]第1弾キービジュアル</p>
-									<p>pp.2-27: <em>「特集　劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語」</em>初日舞台挨拶レポート（新宿バルト9）、キャラクター紹介、絵づくりにおけるセル・背景・コラージュの3要素の解説。</p>
-									<p>pp.14-17: 宮本幸裕インタビュー（上映10日後）。新房監督の強い思いでさやかは生き返ることになったこと、マミとほむらの戦闘シーンは絵コンテの笹木信作に映画『リベリオン』のイメージを伝えたこと、「ガン=カタ」や「マジカルバナナ」のシーンのCGについてなど。</p>
-									<p>pp.22-27: 新房昭之インタビュー。企画の成り立ち、公開前の情報の出し方（これまでの続編であることを告知したこと）、[新編]は（TVシリーズではなく）[前・後編]の続きであるという考え方、「叛逆の物語」の副題の決定経緯など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Cut　2013年12月号</book-name>
-							<book-release>2013-11-19</book-release>
-							<book-amazon asin="B00GDIKBPM" image-id="51klYF9MbeL" width="123" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.38-43: <em>「『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』2号連続徹底特集、後編!」</em>新房昭之インタビュー。「（脚本の虚淵玄に対し）5人の魔法少女が一緒に行動するシーンを作るというのが一番のオーダー」「銃撃戦とかが派手になったのはコンテを描いてくれた笹木さんのお陰」など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>WHAT's IN?　2013年12月号</book-name>
-							<book-release>2013-11-14</book-release>
-							<book-amazon asin="B00GBB3S92" image-id="51R3efwEGpL" width="114" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.110: 「君の銀の庭」リリースに関してのKalafinaインタビュー。梶浦由記の「この曲はある少女の空想の世界」という発言が Hikaru の口から語られる。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2013年12月号</book-name>
-							<book-release>2013-11-09</book-release>
-							<book-amazon asin="B00G4T7ULI" image-id="51QQoC2YAgL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.36-39: <em>「それは、わたしの願った世界」</em>加藤英美里、谷口淳一郎インタビュー。キャラデザの際、なぎさはまどか達と同世代バージョンと、幼い現バージョンがあったことなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2013年12月号</book-name>
-							<book-release>2013-11-09</book-release>
-							<book-amazon asin="B00G2FBWI6" image-id="61KXrLuOeYL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.40-41: 「映画館で味わおう　最高のお・も・て・な・し」宮本幸裕、谷口淳一郎、山村洋貴のコメント掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.10　2013年12月号</book-name>
-							<book-release>2013-11-08</book-release>
-							<book-amazon asin="B00FBKF5X6" image-id="61JmzqfCKML" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: さやか、杏子（イラスト: 蒼樹うめ）</p>
-									<p>キャッチコピー: 「3カ月連続刊行第2弾!!」（※背表紙は「[新編]叛逆の物語 絶賛公開中―!!」）</p>
-									<p>付録: 表紙イラストホログラム下敷き</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>MdN　2013年12月号</book-name>
-							<book-release>2013-11-06</book-release>
-							<book-amazon asin="B00GD3NX8Y" image-id="61pVWryIAUL" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.40-41: 「終わりのあとの始まり 印刷の魔法をもう一度信じてみる?」で「劇場版 魔法少女まどか☆マギカ 総集編 Keyanimation ClearFile」の紹介（談: 浅見啓介）。</p>
-									<p><a href="https://books.mdn.co.jp/magazine/3213101012/" class="htmlbuild-host">公式ページ</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>VOICE GIRLS　Vol.16</book-name>
-							<book-release>2013-10-31</book-release>
-							<book-isbn>978-4-86336-351-9</book-isbn>
-							<book-amazon asin="4863363516" image-id="51zocRTcuPL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.16-17: 悠木碧インタビューで[新編]の話題（インタビューは公開前、本の発売は公開直後）。前半の収録から後半の収録まで間があったことなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2013年12月号</book-name>
-							<book-release>2013-10-30</book-release>
-							<book-amazon asin="B00FRMSZTY" image-id="61aDu+kndPL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: マミ&amp;なぎさ（原画: 谷口淳一郎）。</p>
-									<p>pp.4-11: <em>「RESTART MAGICA」</em>水橋かおり×阿澄佳奈インタビュー、劇場グッズやコラボキャンペーンの紹介、「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」の紹介と富澤祐介プロデューサーのインタビューなど。</p>
-									<p>p.15: 表紙イラストの挟み込みポスター。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>電撃G's magazine　2013年12月号</book-name>
-							<book-release>2013-10-30</book-release>
-							<book-amazon asin="B00FSQ9WDW" image-id="61BrjH19YkL" width="129" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 鹿目まどか（原画: 住本悦子）。</p>
-									<p>pp.28-39: <em>「劇場版魔法少女まどか☆マギカ」</em>[新編]情報、悠木碧インタビュー、「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。</p>
-									<p>付録: にいてんご 暁美ほむら 水着Ver. フィギュア</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2013年12月号</book-name>
-							<book-release>2013-10-30</book-release>
-							<book-amazon asin="B00FQPJPLO" image-id="61swYkUbu0L" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 制服の眼鏡ほむら&amp;杏子（原画: 中村直人）</p>
-									<p>pp.32-37: <em>「魔法少女は魔女の夢を見るか？」</em>[新編]の紹介記事、斎藤千和×野中藍のインタビュー、宮本幸祐、悠木碧、喜多村英梨、水橋かおりのコメント、「劇場版 魔法少女まどかマギカ The Battle Pentagram」の紹介。</p>
-									<p>付録: 水着のまどか&amp;ほむらのB2ポスター（2013年10月号表紙イラスト）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.15</book-name>
-							<book-release>2013-10-30</book-release>
-							<book-isbn>978-4-7897-7201-3</book-isbn>
-							<book-amazon asin="4789772012" image-id="51yh6r1HwHL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、ほむら（潮月一也）</p>
-									<p>pp.6-29: <em>「[特集1] 劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語 "物語は奏で音楽は語る"」</em>ClariSインタビュー、渡辺翔インタビュー（[新編]のシナリオを知らずに歌詞を書いたこと、リテイク箇所など）、Kalafinaインタビュー（“銀の庭”の意味など）、梶浦由記×鶴岡陽太インタビュー。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>デジモノステーション　2013年12月号</book-name>
-							<book-release>2013-10-25</book-release>
-							<book-amazon asin="B00FL2T4YA" image-id="61tDfcB6HcL" width="119" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.174-177: 「ビジョメガネSP まどか&amp;ほむら」眼鏡を掛けたまどか、ほむらの描き下ろしイラスト（原画: 中村直人）、「”まどか☆マギカ”を知る15のアレコレ」。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>smart　2013年12月増刊号　No.288</book-name>
-							<book-release>2013-10-24</book-release>
-							<book-amazon asin="B00FOVYR36" image-id="619sF7mr0JL" width="110" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 暁美ほむら&amp;キュゥべえ（作画: 中村直人）。</p>
-									<p>pp.174-179: 「著名人&amp;ファッション業界人ファンが語りつくす! [新編]ストーリーも大予想! 『魔法少女まどか☆マギカ』」（松井玲奈、サンキュータツオ、ほか）、悠木碧への一問一答など。</p>
-									<p>付録1: 描き下ろしクリアファイル（表紙イラスト、中村直人）。</p>
-									<p>付録2: 魔法少女大集合ステッカー（p.90とp.91の間に挟み込み）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>週刊スピリッツ　2013年11月4日号　No.47</book-name>
-							<book-release>2013-10-21</book-release>
-							<book-amazon asin="B00FOVYSH6" image-id="51rjSFGD4NL" width="108" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどかとほむらのコスプレ写真。</p>
-									<p>pp.3-7: 上間美緒（女優）、秋本帆華（チームしゃちほこ）による、版権イラストを元にしたコスプレ写真3枚。</p>
-									<p>p.10: 上間、秋本インタビュー。コスプレ撮影や作品の感想など。</p>
-									<p>折り込み: ポストカード（水着姿の魔法少女5人）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>SWITCH　2013年11月号　Vol.31　No.11</book-name>
-							<book-release>2013-10-20</book-release>
-							<book-isbn>978-4-88418-350-9</book-isbn>
-							<book-amazon asin="4884183509" image-id="51+HP1pbLgL" width="117" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.98-103: <em>「新房昭之 [オーバーランも辞さない覚悟]」</em> 公開間近の新編に関するインタビュー。時系列として前後編の続きであること、絵コンテの段階でシナリオからかなり膨らんだこと、劇団イヌカレーにオファーを出した経緯など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Cut　2013年11月号</book-name>
-							<book-release>2013-10-19</book-release>
-							<book-amazon asin="B00FK9ZX1W" image-id="51aArRaipcL" width="123" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.74-81: <em>「『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』2号連続徹底特集、第1弾!」</em>悠木碧インタビュー、斎藤、加藤、喜多村、野中へのアンケート。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2013年11月号</book-name>
-							<book-release>2013-10-10</book-release>
-							<book-amazon asin="B00FAS9062" image-id="51ooYdimYeL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: リボンほむら（原画: 谷口淳一郎）。</p>
-									<p>pp.14-23: <em>「The Only Neat Thing To Do」</em>リボンほむらのイラスト（谷口淳一郎、表紙とは別物）、新房昭之×虚淵玄、阿澄佳奈、加藤英美里、西尾維新×虚淵玄のインタビュー。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2013年11月号</book-name>
-							<book-release>2013-10-10</book-release>
-							<book-amazon asin="B00FA4Q4TW" image-id="612wht0mr4L" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.120-121: 「運命への叛逆が導くのは希望か絶望か」 [新編] 特集記事。第3弾キービジュアル。斎藤千和、阿澄佳奈のコメント。スマートフォンアプリ「嫁コレ」紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.19</book-name>
-							<book-release>2013-10-10</book-release>
-							<book-amazon asin="B00F08HEKQ" image-id="51oFwG3sMLL" width="109" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.114: 「新房語」大嶋実句（シャフト）がゲスト。[新編]の実写弁当はシャフト社内で制作し、ソウルジェムはうずらの卵で作ったことなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.9　2013年11月号</book-name>
-							<book-release>2013-10-10</book-release>
-							<book-amazon asin="B00EV9RMO8" image-id="61theKeMvuL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、ほむら（イラスト: 蒼樹うめ）</p>
-									<p>キャッチコピー: 「3カ月連続刊行スタート!!」（※背表紙は「[新編]公開直前―― 3カ月連続刊行開始!!」）</p>
-									<p>付録: 表紙イラストホログラム下敷き</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>日経エンタテインメント!　2013年11月号</book-name>
-							<book-release>2013-10-04</book-release>
-							<book-amazon asin="B00F9CO5XW" image-id="61WcyXc-YSL" width="120" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.53: 「1980's 90's 00's 名作遺産200」で『まどか☆マギカ』紹介（半ページほど）。新編第2弾キービジュアル、新編のナイトメア戦の場面カット（23m03s）、岩上敦宏の写真掲載。</p>
-									<p>p.117: 「声優核心バイオグラフィー!」（第4回）で悠木碧がゲスト。新編に関するコメント。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2013年11月号</book-name>
-							<book-release>2013-09-30</book-release>
-							<book-amazon asin="B00F496J52" image-id="61t7QPiH1HL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.4-5: <em>「NEW MEGA HEROINES SCOOP」</em>で [新編] の情報。百江なぎさの設定絵掲載。「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2013年11月号</book-name>
-							<book-release>2013-09-30</book-release>
-							<book-amazon asin="B00F496IG2" image-id="611jKaUtG+L" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.92: 新編情報。主題歌情報、百江なぎさキャラクター紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>SPA!　2013年10月1日号</book-name>
-							<book-release>2013-09-24</book-release>
-							<book-amazon asin="B00HWLIDTA" image-id="61XnwemisfL" width="122" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: リボンほむら（原画: 中村直人）。</p>
-									<p>折込ポスター: 表紙イラスト、[新編]第1弾キービジュアル。</p>
-									<p>p.9: 「今週の顔」で虚淵玄の[新編]に関して「TV版終了の前から続編の話は出ていた」「（TV版の時に）新房さんにこのままではハッピーエンドにならないと言われたが、自分はハッピーエンドのつもりだった」などのコメント。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>smart　2013年11月号</book-name>
-							<book-release>2013-09-24</book-release>
-							<book-amazon asin="B00EUGDIJ0" image-id="51UBhasoCSL" width="109" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.172-175: 「BEAMS Tを着た魔法少女まどか☆マギカ」コラボTシャツを着たまどか、ほむらの描き下ろしイラスト（山村洋貴）と男女モデルの写真。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>シアターカルチャーマガジンT. [ティー.]　2013 AUTUMN　No.23</book-name>
-							<book-release>2013-09-20</book-release>
-							<book-amazon asin="B00G4V9BNQ" image-id="514eoi7pj-L" width="109" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>裏表紙: [新編]のほむら原画。</p>
-									<p>pp.113-102: <em>「アニメ界に波紋を呼ぶ、新たな伝説「劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語」」</em>悠木碧と斎藤千和のインタビュー、シャフト社内風景、後編の絵コンテ掲載（9話パート杏子「独りぼっちは」、10話パートほむら「くり返す私は何度でも」、キュゥべえ「僕と契約して」）。</p>
-									<p>pp.103-102: 新房昭之インタビュー。最初の脚本からまどかの出番を増やしたこと、TVシリーズ12話のまどほむ空間は『2001年宇宙の旅』の白い部屋のイメージがあったこと、作品に反映されなかった設定の話など。</p>
+									<p>pp.10-11: 「虚淵玄 緊急インタビュー」で『まどか☆マギカ』についても語られる。放送前に「虚淵玄」の名前が出たことは予定外だったこと、新房さんは『ジョジョの奇妙な冒険』のような能力者バトルを期待していたらしいこと、結末は自分なりにハッピーエンドであることなど。</p>
 								</div>
 
 								<ul class="p-notes">
-									<li>ページ番号が逆になっているのは、本記事のみ裏表紙から続く形で逆向きに読ませる作りになっているため。</li>
+									<li>発売日は正確でない可能性。</li>
 								</ul>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>KERA　2013年11月号</book-name>
-							<book-release>2013-09-14</book-release>
-							<book-amazon asin="B00EZ6M9TK" image-id="515HAqAeg-L" width="112" height="160"></book-amazon>
+							<book-name>娘TYPE　2011年6月号</book-name>
+							<book-release>2011-04-30</book-release>
+							<book-amazon asin="B004WOTBP0" image-id="61O-EUL9JZL" width="122" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.146: 「劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語を先どり」斎藤千和インタビュー。</p>
+									<p>p.32: AT-X広告。放送中作品に『まどか☆マギカ』（画像付き）。</p>
+									<p>pp.142-143: <em>「出没！ギャル街っく天国！」</em> 10〜11話などの場面ショット多数。</p>
+									<p>p.169: 『かずみ☆マギカ』1巻の情報。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2013年10月号</book-name>
-							<book-release>2013-09-10</book-release>
-							<book-amazon asin="B00ET8MVJC" image-id="6199qxdSc3L" width="125" height="160"></book-amazon>
+							<book-name>メガミマガジン　2011年6月号</book-name>
+							<book-release>2011-04-30</book-release>
+							<book-amazon asin="B004WDQ7CG" image-id="61iy04LPrmL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>別冊付録: 「マジカル☆ニュータイプ」[新編]情報、新房昭之×草川啓造×大沼心の座談会。</p>
-									<p><a href="https://www.youtube.com/watch?v=4HbAjF77XmM" class="htmlbuild-host">発売CM</a></p>
+									<p>pp.17-18: TV版キービジュアルの折り込みピンナップ（原画: 岸田隆宏）。</p>
+									<p>pp.44-46: <em>「魔法少女が選んだ世界」</em>岩上敦宏インタビュー。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2013年10月号</book-name>
-							<book-release>2013-09-10</book-release>
-							<book-amazon asin="B00ENMGQWW" image-id="510WEUEc79L" width="127" height="160"></book-amazon>
+							<book-name>アニメージュ　2011年6月号</book-name>
+							<book-release>2011-05-10</book-release>
+							<book-amazon asin="B004WDQ6UY" image-id="612rEVYWRNL" width="126" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.69: [新編] の紹介「待つのは希望か、それとも――。」（第2弾キービジュアル）。</p>
+									<p>pp.58-61: <em>「彼女の決意を忘れない――」</em>11話〜12話の画面ショット多数掲載（震災対応で差し替えられた体育館のカットも掲載）、悠木碧、斎藤千和インタビュー、新房昭之×虚淵玄コメント。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2013年10月号</book-name>
-							<book-release>2013-08-30</book-release>
-							<book-amazon asin="B00EDR7TBY" image-id="61mcyeC2DGL" width="125" height="160"></book-amazon>
+							<book-name>アニメディア　2011年6月号</book-name>
+							<book-release>2011-05-10</book-release>
+							<book-amazon asin="B004XCWW02" image-id="61LNNxriFYL" width="126" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.25-26: アルティメットまどか&amp;さやかのピンナップポスター（石原恵治）</p>
-									<p>p.44: 新編情報、「Loppi限定描き下ろし前売り券」イラスト掲載。</p>
+									<p>pp.3-6（折込）: アルティメットまどかイラスト（高橋美香）、虚淵玄インタビュー。</p>
+									<p>pp.72-73: 最終回アフレコレポート漫画（出口由美子）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2013年10月号</book-name>
-							<book-release>2013-08-30</book-release>
-							<book-amazon asin="B00ED1QZ0Q" image-id="51-qBOKGJyL" width="124" height="160"></book-amazon>
+							<book-name>ニュータイプ　2011年6月号</book-name>
+							<book-release>2011-05-10</book-release>
+							<book-amazon asin="B004XIWD2I" image-id="61aJzOaTWvL" width="123" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 水着のまどか&amp;ほむら（原画: 篠原健二）</p>
-									<p>pp.28-31: <em>「PRELUDE...」</em>[新編]紹介記事。新房昭之×虚淵玄のインタビュー、ClariS、Kalafinaのメッセージ。</p>
+									<p>pp.182-185: <em>「それは、とっても嬉しいなって……」</em>肩にキュゥべえを乗せたほむらのイラスト（高橋美香）、第11話〜12話オンエアを終了しての虚淵玄、新房昭之インタビュー（5月号の続き）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2013年9月号</book-name>
-							<book-release>2013-08-10</book-release>
-							<book-amazon asin="B00E3W4KXY" image-id="61WbgRMqQhL" width="124" height="160"></book-amazon>
+							<book-name>Cut　2011年6月号</book-name>
+							<book-release>2011-05-19</book-release>
+							<book-amazon asin="B004Y0AIJ0" image-id="61lgSXZ5Q+L" width="123" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.148: 「新房昭之の恐縮ですが……」で草川啓造との対談。TVシリーズで脚本が仕上がってから、実際に制作が始まるまで時間が空いたことが紹介。</p>
-									<p>pp.168-171: <em>「あなたに会いたい。」</em>新房昭之×虚淵玄のインタビュー。</p>
+									<p>p.11: 特集「マクロス、そしていま出会うべきアニメたち」で『まどか☆マギカ』のカット2点掲載。</p>
+									<p>pp.54-59: <em>「問題作こそ大ヒット作!? 驚異のヒットメーカー、新房昭之の脳内に迫る」</em>個々の作品の話よりは、アニメ制作全般に関する話が多い。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.8　2013年9月号</book-name>
-							<book-release>2013-08-09</book-release>
-							<book-amazon asin="B00DWAANC0" image-id="61oJgZSeCjL" width="111" height="160"></book-amazon>
+							<book-name>Febri　Vol.6</book-name>
+							<book-release>2011-05-25</book-release>
+							<book-amazon asin="B004WY9RNQ" image-id="51XcxgTHZ6L" width="114" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、ほむら、さやか、キュゥべえ（イラスト: 浜弓場双）</p>
-									<p>キャッチコピー: 「準備はいい――？」（※背表紙は「[新編]叛逆の物語 10月26日(土)公開!!」）</p>
+									<p>pp.86-93: <em>「新房語」</em>虚淵玄がゲスト。放送延期決定後も4月の放送直前まで11話、12話の制作を続けていた（新房）、11話の戦闘シーンは脚本ではほむらがタンクローリーをぶつけたところで終わっていた（虚淵）、ワルプルギスの夜の周りにいる魔女の手下は絵コンテ段階では他の魔法少女になっていた（新房）、マミの必殺技「アルティマ・シュート」をアフレコ現場で変えた、などの話題。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>MdN　2013年9月号</book-name>
-							<book-release>2013-08-06</book-release>
-							<book-amazon asin="B00GD3NX70" image-id="61iIdX61OGL" width="121" height="160"></book-amazon>
+							<book-name>メガミマガジン　2011年7月号</book-name>
+							<book-release>2011-05-30</book-release>
+							<book-amazon asin="B0050IQPF6" image-id="61OjEJ597hL" width="123" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.50: TV版、劇場版、[新編]の3タイプのロゴについて、染谷洋平によるコメント。</p>
+									<p>折込ロングポスター: 水着ほむら（原画: 中村直人）、水着マミ（原画: 潮月一也）。</p>
+									<p>別冊付録: <em>「魔法少女まどか☆マギカ COMPLETE BOOK」</em>虚淵玄インタビュー、11〜12話概要、新房昭之インタビュー、キャストによる座談会。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>日経エンタテインメント!　2013年9月号</book-name>
-							<book-release>2013-08-03</book-release>
-							<book-amazon asin="B00DYWNVMU" image-id="51cUh6THkUL" width="117" height="160"></book-amazon>
+							<book-name>プレイボーイ　2011年6月13日号</book-name>
+							<book-release>2011-05-30</book-release>
+							<book-amazon asin="B007EIAIIU" image-id="51SR8NfuyUL" width="120" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.26-27: 「アニメ・アニソン・声優の新常識30」記事内で『まどか☆マギカ』の名も挙がる。新編第1弾キービジュアル掲載。</p>
-									<p>pp.124-125: Japan Expo 2013 の記事で UltraBook のコラボPCが紹介。展示ブースでの記念写真掲載。</p>
+									<p>pp.46-47: <em>「虚淵玄が明かす『魔法少女まどか☆マギカ』の真実」</em>武器がたくさん出てくるのは、当時蒼樹うめ共々『モンスターハンター』にハマっていたからお互いの共通言語として脚本に入れたということ、（キャラクターとして）ほむらだけは蒼樹うめの作品から取ったわけではないこと、続編は「やってくれ」とは言われているがどう展開させるか悩んでいることなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>うぶモード　2013年8月号</book-name>
-							<book-release>2013-08-01</book-release>
+							<book-name>アニメージュ　2011年7月号</book-name>
+							<book-release>2011-06-10</book-release>
+							<book-amazon asin="B0052ETRLC" image-id="61oA-CdcfWL" width="126" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.42: 「宮台式幸福学対話篇 TALK#04 vs.虚淵玄」宮台真司と虚淵玄の対談。まどかとほむらの対比、"幸福"の価値観に関する話題など。虚淵曰く、ほむら的な生き方よりまどか的な生き方の方が断然幸せ。</p>
+									<p>p.8: 「無敵のツインテール❤」で鹿目まどかが取り上げられる。蒼樹うめによるコメント掲載（まどかのビジュアルで悩んだ点など）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2013年9月号</book-name>
-							<book-release>2013-07-30</book-release>
-							<book-amazon asin="B00DVMU93M" image-id="61V2Dd35Y5L" width="126" height="160"></book-amazon>
+							<book-name>ニュータイプ　2011年7月号</book-name>
+							<book-release>2011-06-10</book-release>
+							<book-amazon asin="B0052YKEFK" image-id="61v2FN6qNPL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.99: <em>「進撃の美人たち」</em> [新編] の紹介記事。</p>
-									<p>p.113: 「劇場版まどか☆マギカ【番外編】宝物語」<a href="http://1kuji.bpnavi.jp/item/558" class="htmlbuild-host">一番くじ 劇場版 魔法少女まどか☆マギカ</a>のきゅんキャラびねっと紹介。</p>
+									<p>別冊付録: 「for promise」（加藤英美里×新房昭之、劇団イヌカレー×宮本幸裕、虚淵玄のインタビュー）</p>
+									<p><a href="https://www.youtube.com/watch?v=gWoOr_LtRYU" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2013年9月号</book-name>
-							<book-release>2013-07-30</book-release>
-							<book-amazon asin="B00DUZABPQ" image-id="51TXGUBhWjL" width="124" height="160"></book-amazon>
+							<book-name>SWITCH　2011年7月号　Vol.29　No.7</book-name>
+							<book-release>2011-06-20</book-release>
+							<book-isbn>978-4-88418-322-6</book-isbn>
+							<book-amazon asin="4884183223" image-id="51DEl-kh8pL" width="119" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.74: 次号予告。新編第1弾キービジュアル（ほむら）。</p>
-									<p>p.88: 新編情報。第1弾前売り鑑賞券。</p>
+									<p>表紙: 鹿目まどか（イラスト: 岸田隆宏）。</p>
+									<p>p.18: <em>「【特集】ソーシャルカルチャー ネ申100」</em>新房昭之インタビュー。震災の話、（震災とは無関係に）放送時期を延期していたこと、キュゥべえが口を動かさない理由など。</p>
+									<p>p.19: 同上、虚淵玄インタビュー。Twitterで気を遣ったこと、10話のループ設定など。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>SWITCH 編集部から通販で雑誌を買うと、表紙のイラストの A2 ポスターが付いてきた。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2011年8月号</book-name>
+							<book-release>2011-06-30</book-release>
+							<book-amazon asin="B0055OKZ9M" image-id="619ldq5b52L" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>別冊付録: <em>「魔法少女まどか☆マギカ SPECIAL FAN BOOK」</em>作家やイラストレーターによる論評&amp;イラスト集。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>smart　2013年9月号</book-name>
-							<book-release>2013-07-24</book-release>
-							<book-amazon asin="B00DP3I8UI" image-id="61MML2jUOSL" width="115" height="160"></book-amazon>
+							<book-name>オトナアニメ　Vol.21</book-name>
+							<book-release>2011-07-08</book-release>
+							<book-isbn>978-4-86248-772-8</book-isbn>
+							<book-amazon asin="4862487726" image-id="51jHPgfmBoL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.67-72: 生駒里奈（乃木坂46）と松井玲奈（SKE48）がそれぞれまどか、ほむらのコスプレをしてのインタビュー、新編公開情報、前後編DVD&amp;BD情報、ムック本「魔法少女まどか☆マギカ LOVE!」発売情報。</p>
+									<p>表紙: アルティメットまどか（原画: 中村直人）</p>
+									<p>pp.10-41: <em>「特集　徹底解明！魔法少女まどか☆マギカ」</em>ヒロイン解説、各話解説（11話〜12話）、演出の考察（7話、11話、12話の絵コンテ掲載）、外伝コミックレビュー。</p>
+									<p>pp.24-27: 悠木碧インタビュー。オーディション時の話、まどかのノートのイラストについてなど。</p>
+									<p>pp.32-35: 虚淵玄インタビュー。12話でマミの口から出た「円環の理」の伝承設定、各魔法少女の心情など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2013年8月号</book-name>
-							<book-release>2013-07-10</book-release>
-							<book-amazon asin="B00DMCSAXW" image-id="518RhMjWgQL" width="125" height="160"></book-amazon>
+							<book-name>ニュータイプ　2011年8月号</book-name>
+							<book-release>2011-07-08</book-release>
+							<book-amazon asin="B0057Y03GU" image-id="61lXtr7WuIL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.42-43: 「あなたの希む世界に……」鉄塔にたたずむほむら&amp;まどか&amp;キュゥべえのイラスト（坂本一也）、[新編]の紹介記事。</p>
+									<p>p.183: 「新房昭之のお恐縮ですが……」で吉野弘幸（脚本家）との対談。放送前の情報の出し方などの話。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.7　2013年7月号</book-name>
-							<book-release>2013-06-10</book-release>
-							<book-amazon asin="B00CPRCP0Y" image-id="61BxuO87CoL" width="111" height="160"></book-amazon>
+							<book-name>SPA!　2011年7月19日号</book-name>
+							<book-release>2011-07-12</book-release>
+							<book-amazon asin="B007NCZEOA" image-id="61+4VMhWryL" width="121" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、さやか、杏子 他（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「まどかといれば、笑顔。」（※背表紙は「[前編]&amp;[後編]BD&amp;DVD 2013年7月24日発売!!」）</p>
+									<p>pp.54-57 : 「大人気アニメ『まどか☆マギカ』の正体」宮台真司（社会学者）、宮崎哲弥（評論家）、八代嘉美（幹細胞生物学者）、森川嘉一郎（明治大学国際日本学部准教授）、磯崎哲也（公認会計士）の5名によるコメント。</p>
+									<p>p.101: 「アニメ定量分析　Vol.29」（山本幸治・ノイタミナプロデューサー）で『まどか☆マギカ』について語られる。2年前に企画書を見せてもらったことなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>うぶモード　2013年7月号</book-name>
-							<book-release>2013-06-07</book-release>
+							<book-name>メガミマガジン　2011年9月号</book-name>
+							<book-release>2011-07-30</book-release>
+							<book-amazon asin="B005C4HTOO" image-id="61ufrgQBNDL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.42: 「宮台式幸福学対話篇 TALK#03 vs.虚淵玄」宮台真司と虚淵玄の対談。不登校新聞社発行の「Fonte」に寄稿した生死感に関する話題など。</p>
+									<p>折込ロングポスター: 水着さやか（原画: 中村直人）、水着杏子（原画: 潮月一也）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>うぶモード　2013年6月号</book-name>
-							<book-release>2013-05-09</book-release>
+							<book-name>idea 348（2011年9月号）</book-name>
+							<book-release>2011-08-10</book-release>
+							<book-amazon asin="B0057Y03XS" image-id="61g0Lh-V89L" width="121" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.42: 「宮台式幸福学対話篇 TALK#02 vs.虚淵玄」宮台真司と虚淵玄の対談。最終話のまどかの選択は一神教よりも多神教的な解釈であること、『幼少期の終わり』（アーサー・C・クラーク）との関連、『エヴァンゲリオン』との対比など。</p>
+									<p>pp.2-3: 染谷洋平の紹介。TV版ロゴ、BD/DVDパッケージ、コミック3作品表紙に関するコメント。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2013年6月号</book-name>
-							<book-release>2013-04-30</book-release>
-							<book-amazon asin="B00CAZDFKU" image-id="61BG13IN7NL" width="124" height="160"></book-amazon>
+							<book-name>ニュータイプ　2011年9月号</book-name>
+							<book-release>2011-08-10</book-release>
+							<book-amazon asin="B005ESIXNY" image-id="61NM7XRh7PL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.46: [新編]情報。</p>
-									<p>p.94: ACEでの「『劇場版 魔法少女まどか☆マギカ』ステージ」レポート。</p>
-									<p>pp.116-117: 「『魔法少女まどか☆マギカ』プライズグッズのお部屋」、加藤英美里によるSQフィギュア（杏子）や各種キュゥべえグッズの紹介。</p>
+									<p>p.151: 「新房昭之の恐縮ですが……」で「ギャグ + 魔法少女作品」の話。久米田康治先生による魔法少女モノの提案や、「ひだまり☆マギカ」ネタなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2013年6月号</book-name>
-							<book-release>2013-04-30</book-release>
-							<book-amazon asin="B00CF0UKBW" image-id="61JAtAUsY3L" width="124" height="160"></book-amazon>
+							<book-name>電撃PlayStation　Vol.500</book-name>
+							<book-release>2011-08-11</book-release>
+							<book-amazon asin="B005EYQ0SI" image-id="512ApLzflVL" width="130" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.5: 『[新編]叛逆の物語』公開情報。暁美ほむらビジュアル掲載。</p>
+									<p>pp.6-15: <em>「まどか☆マギカポータブル」</em>キャラクター紹介、アドベンチャーパート、ダンジョンパート紹介。土居由直（ニトロプラス）、富澤祐介（バンダイナムコゲームズ）のインタビュー。悠木碧、加藤英美里コメント。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2013年5月号</book-name>
-							<book-release>2013-04-10</book-release>
-							<book-amazon asin="B00C2BSDPO" image-id="51-LR4A039L" width="123" height="160"></book-amazon>
+							<book-name>まんがタイムきららフォワード　2011年10月号</book-name>
+							<book-release>2011-08-24</book-release>
+							<book-amazon asin="B005EMLFFS" image-id="61OBGubBIhL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.40-41: 「私たちの物語」まどか&amp;リボンほむらのイラスト（寺尾洋之）、[新編]の紹介記事。</p>
+									<p>pp.3-4: 公式ガイドブック、アンソロジーコミック発売予告（表紙イラスト掲載）。『魔法少女まどか☆マギカ ポータブル』ゲーム化決定（悠木碧、加藤英美里コメント掲載）。Blu-ray&amp;DVD 6巻発売予告。</p>
+									<p>pp.109-134: 『かずみ☆マギカ』第8話</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.6　2013年5月号</book-name>
-							<book-release>2013-04-10</book-release>
-							<book-amazon asin="B00BJMAWXI" image-id="61HAAUlpADL" width="111" height="160"></book-amazon>
+							<book-name>メガミマガジン　2011年10月号</book-name>
+							<book-release>2011-08-30</book-release>
+							<book-amazon asin="B005GW4SFU" image-id="61tTVwjICIL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、キュゥべえ（原画: 蒼樹うめ）</p>
-									<p>キャッチコピー: 「劇場版 魔法少女まどか☆マギカ [新編]叛逆の物語 2013年秋公開!!」（※背表紙は「[新編]叛逆の物語 2013年秋公開!!」）</p>
-									<p>付録: 表紙イラストホログラム下敷き</p>
+									<p>pp.30-32: <em>「『魔法少女まどか☆マギカ』PSPゲーム化、それはとってもうれしいなって」</em>ポータブル情報。土居由直×富澤祐介のインタビュー、キャラクター画像、変身シーンの紹介など。</p>
+									<p>折込B2ポスター: 浴衣姿の5人+キュゥべえのイラスト（原画: 中村直人）</p>
+									<p>別冊付録: <em>『魔法少女まどか☆マギカ』グッズコンプリートカタログ2011夏</em></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>うぶモード　2013年5月号</book-name>
-							<book-release>2013-04-09</book-release>
+							<book-name>PLANETS SPECIAL 2011 夏休みの終わりに</book-name>
+							<book-release>2011-08-31</book-release>
+							<book-amazon asin="4905325021" image-id="41DPAb9gh3L" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.66: 「宮台式幸福学対話篇 TALK#01 vs.虚淵玄」宮台真司と虚淵玄の対談。魔法少女ものの基本である「主人公である魔法少女が世界から愛されている」という前提をひっくり返してストーリーを作ったことなど。</p>
+									<p>pp.40-51: 「「父殺し（の不可能性）」から「父赦し」へ―3.11後の世界とその意味」（宮台真司）のインタビューの中で散発的に言及される。</p>
+									<p>pp.94-105: 「誌上ニコ生 PLANETS」で『まどか☆マギカ』特集（石岡良治×黒瀬陽平×坂上秋成+司会: 宇野常寛）。2011年5月4日に<a href="http://live.nicovideo.jp/watch/lv47398722" class="htmlbuild-host">ニコ生で放送された番組</a>の誌面版。冒頭に ramco によるイラスト掲載。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン DELUXE　Vol.20</book-name>
-							<book-release>2013-03-28</book-release>
-							<book-amazon asin="B00BUSV1CW" image-id="51K6D9XxlcL" width="111" height="160"></book-amazon>
+							<book-name>コンプティーク　2011年10月号</book-name>
+							<book-release>2011-09-10</book-release>
+							<book-amazon asin="B005J5LR9E" image-id="61sFJIzME8L" width="130" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.90: 手を繋いだアルティメットまどか、リボンほむらのイラスト（原画: 谷口淳一郎）。</p>
-									<p>p.93: イラスト掲載作品の紹介（前後編）。</p>
+									<p>pp.50-53: 『魔法少女まどか☆マギカ ポータブル』紹介記事。杏子以外の立ち絵、悠木碧と加藤英美里のコメントなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>Cut　2013年4月号</book-name>
-							<book-release>2013-03-19</book-release>
-							<book-amazon asin="B00BNCAP04" image-id="51jL6nUOWlL" width="124" height="160"></book-amazon>
+							<book-name>ゲームラボ　2011年10月号</book-name>
+							<book-release>2011-09-16</book-release>
+							<book-amazon asin="B005K9UDX0" image-id="61XsQcw4jtL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.66: [新編]紹介。「編集部も新しい何かを知っているわけではない」としつつ、これまでの関係者のコメントから「3本目の映画で物語は終わりません」（虚淵）、「本当は『インキュベーターの逆襲』というタイトルにしたかった」（新房）を紹介。</p>
+									<p>p.138: 夏コミでの「ティロ・フィナーレ本」（まどか屋さん）頒布が紹介。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>日経エンタテインメント!　2013年4月号</book-name>
-							<book-release>2013-03-04</book-release>
-							<book-amazon asin="B00BI2YQHM" image-id="51TK2MOWwaL" width="120" height="160"></book-amazon>
+							<book-name>Febri　Vol.8</book-name>
+							<book-release>2011-09-24</book-release>
+							<book-amazon asin="B005GTJJZW" image-id="51a9YxOXbCL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.111: 「第4回 ヒットメーカー・オブ・ザ・イヤー 2012〜2013」で「ブレイクスルー章」を受賞した岩上敦宏の紹介。</p>
+									<p>pp.84-89: <em>「新房語」（第8回）</em>鈴木博文（EDアニメーション担当）がゲスト。EDで紙を一枚も使わずタブレットで描いた（鈴木）、魔女空間は劇団イヌカレーにお願いしたが発想の原点は『コゼット』だった（新房）、最初はEDに魔女を12〜13体出そうと思っていた（鈴木）、最後に出てくる「もやもやした光」は一瞬キュゥべえになるつもりで描いた（鈴木）、DVDではマミが食べられる音をリアルな音にするアイデアも音響サイドからあった（新房）など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2013年4月号</book-name>
-							<book-release>2013-02-28</book-release>
-							<book-amazon asin="B00BEZ37FK" image-id="61hAMIP6WbL" width="124" height="160"></book-amazon>
+							<book-name>電撃PlayStation　Vol.503</book-name>
+							<book-release>2011-09-29</book-release>
+							<book-amazon asin="B005MRM0ZE" image-id="61pmnoiQgmL" width="130" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.133: 「フィギュア★マイスター」でSQフィギュア〜美樹さやか〜の紹介。開発担当者コメント。</p>
+									<p>pp.54-55: 『魔法少女まどか☆マギカ ポータブル』紹介。</p>
+									<p>pp.56-57: 「figma 鹿目まどか 制服バージョン」に関する対談。富沢祐介（バンダイナムコゲームス）×金子雅文（マックスファクトリー）×秋山拓郎（グッドスマイルカンパニー）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2013年3月号</book-name>
-							<book-release>2013-02-09</book-release>
-							<book-amazon asin="B00B2OLV9W" image-id="61mMknc3iYL" width="127" height="160"></book-amazon>
+							<book-name>メガミマガジン DELUXE　Vol.17</book-name>
+							<book-release>2011-09-30</book-release>
+							<book-amazon asin="B005POI8ZA" image-id="61aVdVwkDeL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.146-149: 「この人に話を聞きたい 第百五十二回」谷口淳一郎顔出しインタビュー。『まどか☆マギカ』についての話（p.148）では、キャラクターデザイン（岸田隆宏）と作画の違い、シャフトの作業の特異性、劇場版での作画の変化などが語られる。</p>
+									<p>とじ込み付録: まどか&amp;ほむらのイラスト（原画: 滝山真哲）。</p>
+									<p>pp.17-29: 版権絵12枚収録（アニメディアとメガミマガジンからの再録）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.5　2013年3月号</book-name>
-							<book-release>2013-02-08</book-release>
-							<book-amazon asin="B00AYRDECK" image-id="615KX+knBjL" width="112" height="160"></book-amazon>
+							<book-name>メガミマガジン　2011年11月号</book-name>
+							<book-release>2011-09-30</book-release>
+							<book-amazon asin="B005MZI22G" image-id="61BCyP2TgWL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、ほむら（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「となりには、いつもまどか。」（※背表紙は「となりにはいつもまどか」）</p>
+									<p>pp.17-18: 弓道をするまどか、ほむらのイラスト（原画: 中村直人）。</p>
+									<p>p.128: 『魔法少女まどか☆マギカ ポータブル』情報。まどか、さやか、杏子、マミのキャラクター画像など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2013年2月号</book-name>
-							<book-release>2013-01-10</book-release>
-							<book-amazon asin="B00ARJ2ESK" image-id="51IfYsvmWUL" width="124" height="160"></book-amazon>
+							<book-name>ユリイカ　2011年11月臨時増刊号（総特集: 魔法少女まどか☆マギカ―魔法少女に花束を）</book-name>
+							<book-release>2011-10-20</book-release>
+							<book-isbn>978-4-7917-0229-9</book-isbn>
+							<book-amazon asin="4791702298" image-id="518g5f7ujQL" width="103" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>付録: アルティメットまどか&amp;まどか&amp;ほむら&amp;マミ&amp;さやか&amp;杏子のB3ポスター（寺尾洋之）。</p>
-									<p><a href="https://www.youtube.com/watch?v=PyJhZLibcQE" class="htmlbuild-host">発売CM</a></p>
+									<p>pp.24-38: 「この世でひとつだけの、かけがえのない絆」悠木碧×斎藤千和の対談。まどかとほむらの関係性やそれぞれの行動分析、オーディション時の話など。</p>
+									<p>pp.52-73: 「『まどか☆マギカ』へ至る道」虚淵玄×田中ロミオの対談。</p>
+									<p>その他、ライターなどによる考察記事、漫画家やイラストレーターによるイラスト寄稿などで構成。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>DENGEKI PSP　Vol.3</book-name>
+							<book-release>2011-10-21</book-release>
+							<book-amazon asin="B005UHZ2LA" image-id="61ZgaN5beCL" width="131" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 鹿目まどか（『魔法少女まどか☆マギカ ポータブル』の立ち絵）。</p>
+									<p>pp.3-11: <em>「巻頭特集 魔法少女のススメ」</em>魔法少女まどか☆マギカ ポータブル情報。</p>
+									<p>綴込付録: 『魔法少女まどか☆マギカ ポータブル』のデコレーションステッカー（鹿目まどか、マミのドキドキ ティロ・フィナーレ）。</p>
+									<p>p.81: 読者プレゼントにカラコレ（ムービック）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2011年12月号</book-name>
+							<book-release>2011-10-29</book-release>
+							<book-amazon asin="B005V0RFB6" image-id="61CDvMtCN1L" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.29: 「新作アニメカットに新ビジュアル PSP版『まどマギ』最新情報大公開!」描き下ろしキービジュアル公開、ほむらルート発表など。</p>
+									<p>pp.49-50: さやか、杏子、キュゥべえのピンナップポスター（原画: 潮月一也）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン リリィ（2011年12月号別冊）</book-name>
+							<book-release>2011-10-31</book-release>
+							<book-amazon asin="B005WWJPD4" image-id="61JHxfrb6GL" width="114" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.70-77: 「少女たちの輝かしき友情[非日常編]」寝間着姿のまどか＆ほむら描き下ろしイラスト（作画: 本八幡忠三）、TVシリーズのストーリーダイジェスト。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>日経エンタテインメント!　2011年12月号</book-name>
+							<book-release>2011-11-04</book-release>
+							<book-amazon asin="B005WK92K2" image-id="61eOE1ENMyL" width="120" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.32: 「マチ★アソビ」で展示された5人の等身大パネルの写真。</p>
+									<p>p.47: 「吉田尚記のアニメWiki」でクリエイターの話。虚淵玄を「オタクオブオタク」と評す。</p>
+									<p>pp.50-51: 松井玲奈（SKE48）のインタビューで『まどか』のヒロインのイメージカラーを表現するときに使われる光の描写が『さよなら絶望先生』で桜が出てくるシーンとそっくりという話。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2011年12月号</book-name>
+							<book-release>2011-11-10</book-release>
+							<book-amazon asin="B006071CUY" image-id="51-3EJ4SDTL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p><em>劇場プロジェクト発表</em></p>
+									<p>表紙: アルティメットまどか、リボンほむら、キュゥべえのイラスト（蒼樹うめ）。</p>
+									<p>pp.16-23: <em>「魔法少女達の伝説」</em>ほむら&amp;さやか&amp;杏子&amp;マミのイラスト（潮月一也）、新房昭之×蒼樹うめ×虚淵玄×岩上敦宏のインタビュー、庵野秀明、佐孝仁司、松井玲奈のコメント。</p>
+									<p>pp.202-205: <a href="https://webnewtype.com/special/animeaward/2011/" class="htmlbuild-host">ニュータイプアニメアワード2011</a>（12冠達成）。</p>
+									<p><a href="https://www.youtube.com/watch?v=6HgSGpiCjHc" class="htmlbuild-host">発売CM</a></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきららフォワード　2012年1月号</book-name>
+							<book-release>2011-11-24</book-release>
+							<book-amazon asin="B00629O220" image-id="61AIGmsLbYL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.3: 劇場化プロジェクト始動、ニュータイプ2011年12月号のイラスト掲載（アルまど、リボほむ、キュゥべえ）、蒼樹うめのコメント掲載。</p>
+									<p>pp.115-140: 『かずみ☆マギカ』第11話</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>娘TYPE　2012年1月号</book-name>
+							<book-release>2011-11-30</book-release>
+							<book-amazon asin="B0069SYUZI" image-id="61uv-lvsIKL" width="123" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.53: 「2012年MOVIE WAVE」劇場版プロジェクト制作決定。TVシリーズの場面ショット複数掲載。</p>
+									<p>p.162: 鹿目まどかスケールフィギュア（グッドスマイルカンパニー）。</p>
+									<p>pp.193-194: ピンナップ: 水着まどか、ほむら（中村直人）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2012年1月号</book-name>
+							<book-release>2011-11-30</book-release>
+							<book-amazon asin="B0065LRMJ0" image-id="61o2dY3iO-L" width="123" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.3-4: スケートをする5人とキュゥべえのイラストのピンナップポスター（原画: 潮月一也）。</p>
+									<p>p.27: 「萌えぴあ」劇場プロジェクト始動の記事。岩上敦宏のインタビュー（3本目の新作の脚本作業は終わっているとの発言）、虚淵玄とメインキャスト6人のコメント掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>日経エンタテインメント!　2012年1月号</book-name>
+							<book-release>2011-12-03</book-release>
+							<book-amazon asin="B00684UTBM" image-id="61-mzEmnvzL" width="119" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.30: 「2011年ヒット番付 TOP50」の39位に『まどか☆マギカ』。</p>
+									<p>pp.126-127: 「年間データバンク -2011 Hit Ranking-」で『まどか☆マギカ』の大ヒットに言及。「吉田尚記のアニメWiki」の号外という扱いで吉田尚記のコメントあり。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>クイック・ジャパン　Vol.99</book-name>
+							<book-release>2011-12-10</book-release>
+							<book-amazon asin="4778312929" image-id="51GilCO5B4L" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.114-117: 徹底特集「アニメこそリアルだ!」でTVシリーズのキービジュアルやキュゥべえのイラストが掲載。</p>
+									<p>pp.118-121: <em>「アニメはメジャーな娯楽になったのか?」</em>新房昭之インタビュー。3話でマミが喰われるシーンは、もし深夜放送でなければ子供にインパクトを与えられるように、もっと残酷な描写にしたかもしれないという話など。</p>
+									<p>pp.134-137: 「アニメの将来、テレビの未来」で岩上敦宏×山本幸治（「ノイタミナ」編集長）の対談。ストーリー性が濃い作品にもかかわらず、キャラクターが二次創作で一人歩きした話題など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメディア　2012年1月号</book-name>
+							<book-release>2011-12-10</book-release>
+							<book-amazon asin="B0069SYU7G" image-id="61UNZzjKhSL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.10-11: 「劇場版 魔法少女まどか☆マギカ(仮)」と題して劇場プロジェクト情報。餅を食べる5人*キュゥべえのイラスト（原画: 伊東良明）、虚淵玄のコメント。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>オトナアニメ年鑑2012</book-name>
+							<book-release>2011-12-14</book-release>
+							<book-isbn>978-4-86248-858-9</book-isbn>
+							<book-amazon asin="4862488587" image-id="51Qwlf600fL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: TVシリーズBlu-ray&amp;DVD第6巻パッケージイラスト。</p>
+									<p>pp.2-14: 「2011年のアニメシーンを振り返る」で2011年アニメの筆頭として紹介。</p>
+									<p>pp.26-29: <em>「オリジナルアニメはチャレンジであり賭けである」</em>岩上敦宏と神宮司学（アニプレックス宣伝プロデューサー）のインタビュー。オリジナルアニメについてや、読売新聞一面広告をはじめとする広報展開の話。</p>
+									<p>pp.30-33: 「新房昭之・幾原邦彦の“作家性”に耽溺する」で『まどか☆マギカ』と『輪るピングドラム』を例に両監督の画作りを検証した記事（文：廣田恵介）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>季刊エス　2012年冬号（第37号）</book-name>
+							<book-release>2011-12-15</book-release>
+							<book-amazon asin="B006E515M2" image-id="61MichkwUjL" width="122" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.72-77: <em>『魔法少女まどか☆マギカ』新房昭之インタビュー</em>　9話、10話の絵コンテ、10話まどほむ抱きつきシーンの原画掲載。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>2019年発行の「新房昭之×シャフト　クロニクル」に再掲（原画、絵コンテは増減している）。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>B.L.T.　2012年2月号</book-name>
+							<book-release>2011-12-16</book-release>
+							<book-amazon asin="B006IAZA4W" image-id="61Dlcm49EfL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.156: 「祝!!成人式 悠木碧」劇場版制作決定を受けてのコメント。続編の話はちょうど作品が終わった頃に聞いた。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>Cut　2012年1月号</book-name>
+							<book-release>2011-12-19</book-release>
+							<book-amazon asin="B006GCXLQ6" image-id="51MVtWOc59L" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.46:「2011年、TVアニメは何を革命したのか？」（TVシリーズからのカット数点）</p>
+									<p>pp.60-63: <em>「なぜアニメはいま、『まどか☆マギカ』を必要としたのか?」（新房昭之インタビュー）</em> ストーリー主義的なものとして作ったつもりがキャラクターも受け入れられたこと、キュゥべえは『スタートレック』（アメリカのSFテレビドラマ）のスポットのイメージだったこと、劇場版は最初はTVシリーズの『2』をやる話だったことなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>電撃PlayStation　Vol.509</book-name>
+							<book-release>2011-12-22</book-release>
+							<book-amazon asin="B006K1TZZ4" image-id="51gPdFI77XL" width="129" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.62-65: 『魔法少女まどか☆マギカ ポータブル』情報。マミルートの詳細、限定契約BOXのクリアカードイラスト公開、12月に収録された「お菓子が食べられたら嬉しいなって」の収録レポート。クリアプレートコレクション、「魔法少女まどか☆マギカ iP」配信情報。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -1922,122 +1147,820 @@
 						</div>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2013年2月号</book-name>
-							<book-release>2012-12-27</book-release>
-							<book-amazon asin="B00AO7G7EM" image-id="61fXe4k599L" width="124" height="160"></book-amazon>
+							<book-name>アニメディア　2012年2月号</book-name>
+							<book-release>2012-01-10</book-release>
+							<book-amazon asin="B006OAKCHG" image-id="61QI+eiV6NL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>付録: 「ドキッ! 丸ごと水着! 描き下ろしだらけのB1カレンダー2013」に水着まどか、ほむら（山村洋貴）。</p>
+									<p>別冊付録: まどか、ほむら、マミ、さやか、杏子の版権イラスト（2012年1月号記事）のクリアファイル。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>オトナアニメ年鑑2013</book-name>
-							<book-release>2012-12-14</book-release>
-							<book-isbn>978-4-8003-0071-3</book-isbn>
-							<book-amazon asin="4800300711" image-id="61GaarU7o6L" width="113" height="160"></book-amazon>
+							<book-name>ニュータイプ　2012年2月号</book-name>
+							<book-release>2012-01-10</book-release>
+							<book-amazon asin="B006OAKE2E" image-id="61pLXFK7VJL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: [後編]キービジュアル。</p>
-									<p>pp.10-15: <em>「特集　2012年劇場で観るアニメの最先端『劇場版 魔法少女まどか☆マギカ』」</em>前後編の紹介記事。</p>
+									<p>pp.7-8: 制服まどか、ほむら、メガネほむらのピンナップ（イラスト: 牧孝雄）。</p>
+									<p>付録: クリアファイル2枚セット。</p>
+									<p><a href="https://www.youtube.com/watch?v=hBodT8Gsdl0" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2013年1月号</book-name>
-							<book-release>2012-12-10</book-release>
-							<book-amazon asin="B00AEAZKS8" image-id="51aM4TryOpL" width="122" height="160"></book-amazon>
+							<book-name>SWITCH　Vol.30　No.2</book-name>
+							<book-release>2012-01-20</book-release>
+							<book-isbn>978-4-88418-329-5</book-isbn>
+							<book-amazon asin="4884183290" image-id="511jhxCmNrL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.46-49: <em>「奇跡の軌跡」</em>まどか&amp;アルティメットまどかが抱き合うイラスト（寺尾洋之）、新房昭之×寺尾洋之のインタビュー。劇場版に関わるきっかけやマミの変身シーンの話など。</p>
-									<p>p.170: 「新房昭之の恐縮ですが……」で高橋祐馬（アニプレックス宣伝プロデューサー）との対談。芳文社本社ビルの『ひだまりスケッチ×ハニカム』と『劇場版魔法少女まどか☆マギカ』コラボ垂れ幕の話題。</p>
-									<p>付録: ILLUSTRATION CALENDAR 2013（5-6月「魔法少女まどか☆マギカ」） まどか&amp;アルティメットまどか（寺尾洋之）。</p>
-									<p><a href="https://www.youtube.com/watch?v=1t8bjJ_5sW0" class="htmlbuild-host">発売CM</a></p>
+									<p>pp.38-39: 仁井将人（DeNAプロデューサー）のインタビュー。「Mobage」でのソーシャルゲーム化について。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.14</book-name>
-							<book-release>2012-12-10</book-release>
-							<book-amazon asin="B00A7ZCK2Y" image-id="51f5dq5zpdL" width="113" height="160"></book-amazon>
+							<book-name>かつくら　Vol.1　2012冬</book-name>
+							<book-release>2012-01-24</book-release>
+							<book-amazon asin="4775309854" image-id="61c+WGERDXL" width="117" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 鹿目まどか、暁美ほむら（原画: 谷口淳一郎）</p>
-									<p>pp.4-13: <em>「特集 シャフト“なう”」</em> 前後編オープニングの画面ショット（上映版）と絵コンテ掲載、宮本幸裕×寺尾洋之インタビューで担当カット（寺尾）、新房総監督からの修正指示内容など。</p>
-									<p>pp.27-28: 「新房昭之、2012年を大いに語る」新房昭之インタビュー。[前編]冒頭のまどかの夢のシーンを削除した理由、寺尾洋之を副監督にした訳など。</p>
+									<p>pp.53-54: <em>「虚淵玄インタビュー」</em>で『Fate/Zero』と共に『まどか☆マギカ』の話も。脚本家の領分が他のアニメとは違い、放任されていて、変更されるときは現場の判断で変えず自分に戻ってきたこと（最終イメージを脚本家に委ねる）、続編（新編）の制作時はTVシリーズとは異なり監督やプロデューサーもストーリーの確固たる希望があったこと、結末の受け止め方が自分と新房監督でずれていたから、そのずれを埋める発想で続きを生み出せたことなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.4　2013年1月号</book-name>
-							<book-release>2012-12-10</book-release>
-							<book-amazon asin="B00A7ZCKQA" image-id="61g97CXFxuL" width="112" height="160"></book-amazon>
+							<book-name>Febri　Vol.10</book-name>
+							<book-release>2012-01-25</book-release>
+							<book-amazon asin="B006QAQ0UC" image-id="516TJyLsLuL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、キュゥべえ（原画: 山村洋貴）</p>
-									<p>キャッチコピー: 「願いを叶えるとっておきの贈り物」（※背表紙は「まどかに叶うあなたの願い」）</p>
+									<p>p.88: 「新房語」大澤信博がゲスト。途中『まどか☆マギカ』の話題になり、『まどか☆マギカ』のヒットは時代が生んだ偶然の産物であること、大澤は千葉県柏市のコラボカフェに行ったこと、キュゥべえのファンであること、などを話す。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2013年1月号</book-name>
-							<book-release>2012-11-30</book-release>
-							<book-amazon asin="B00AAGOZQ4" image-id="61Yf6mxslkL" width="122" height="160"></book-amazon>
+							<book-name>リスアニ!　Vol.08</book-name>
+							<book-release>2012-01-25</book-release>
+							<book-isbn>978-4-7897-7157-3</book-isbn>
+							<book-amazon asin="4789771571" image-id="51Yx588dFML" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.19-20: サンタ姿のまどか、ほむら、キュゥべえのピンナップ（寺尾洋之）。</p>
-									<p>p.141: 「ピュアニーモキャラクターシリーズ No.064 佐倉杏子 私服Ver.」（アゾンインターナショナル）。</p>
+									<p>p.120: 「リスアニ! が振り返る2011年アニメ・アニソンシーン」で『まどか☆マギカ』も掲載。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきららフォワード　2013年1月号</book-name>
-							<book-release>2012-11-24</book-release>
-							<book-amazon asin="B009YZYKWQ" image-id="61zy4u5H68L" width="112" height="160"></book-amazon>
+							<book-name>電撃PlayStation　Vol.511</book-name>
+							<book-release>2012-01-26</book-release>
+							<book-amazon asin="B006WP6ETS" image-id="515l9vx6pCL" width="130" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.3-4: 前後編オープニングカット掲載、『魔法少女まどか☆マギカ 〜The different story〜』、アンソロジーコミック、4コマアンソロジーコミック発売広告。</p>
-									<p>pp.57-82: 『かずみ☆マギカ』最終話</p>
+									<p>pp.84-85: 『魔法少女まどか☆マギカ ポータブル』情報。さやかルートの詳細、斎藤千和、加藤英美里のコメント。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年12月号</book-name>
-							<book-release>2012-11-09</book-release>
-							<book-amazon asin="B009XFIRLW" image-id="51j3oUpLHnL" width="124" height="160"></book-amazon>
+							<book-name>メガミマガジン　2012年3月号</book-name>
+							<book-release>2012-01-30</book-release>
+							<book-amazon asin="B006YXYMGU" image-id="61IjBYretsL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.36-37: 「MOVIN' ON 『劇場版 魔法少女まどか☆マギカ』」5人とキュゥべえのイラスト（寺尾洋之）、公開中の前後編の紹介。</p>
-									<p>p.145: EVENT 新宿バルト9でのメインキャスト6人による[前編]舞台挨拶の写真。</p>
+									<p>pp.95-96: 「魔法少女まどか☆マギカ ポータブル」さやかルートの情報など。</p>
+									<p>別冊付録: 眼鏡ほむら&amp;キュゥべえのバレンタインイラストB2ポスター（原画: 中村直人）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2012年12月号</book-name>
-							<book-release>2012-11-09</book-release>
-							<book-amazon asin="B009T90W2O" image-id="61n6cUZiUyL" width="124" height="160"></book-amazon>
+							<book-name>ニュータイプ　2012年3月号</book-name>
+							<book-release>2012-02-10</book-release>
+							<book-amazon asin="B0072IBYTO" image-id="61hl-r5TsGL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.124-125: 「頑張れ美少女❤ EVERYGIRL GOING!」前後編の紹介、初日舞台挨拶（新宿バルト9）レポート。</p>
+									<p>p.197: 「新房昭之の恐縮ですが……」で2011年の振り返りとして、3話連続放送や芸能人が言及した例の紹介など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2012年12月号</book-name>
-							<book-release>2012-11-09</book-release>
-							<book-amazon asin="B009UXDBAY" image-id="61tiwVBousL" width="127" height="160"></book-amazon>
+							<book-name>娘TYPE　2012年4月号</book-name>
+							<book-release>2012-02-29</book-release>
+							<book-amazon asin="B00792TZLW" image-id="61VkD4huXHL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.56-57: 「終わらぬ物語」アルティメットまどか、リボンほむらのイラスト（寺尾洋之）、岩上敦宏インタビュー。</p>
+									<p>pp.21-22: ピンナップ: 水着さやか、杏子（潮月一也）。</p>
+									<p>p.111: 『魔法少女まどか☆マギカ ポータブル』発売情報。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>電撃G's magazine　2012年4月号</book-name>
+							<book-release>2012-02-29</book-release>
+							<book-amazon asin="B007AHRGB2" image-id="61Bk9VlReyL" width="131" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.58-89: 「俺の妹がこんなに可愛いわけがない×魔法少女まどか☆マギカ　着せ替えブロック崩し」のコラボ衣装掲載。</p>
+									<p>pp.60-65: 「魔法少女まどか☆マギカポータブル」の特集記事。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>電撃PlayStation　Vol.514</book-name>
+							<book-release>2012-03-08</book-release>
+							<book-amazon asin="B007D2OO5A" image-id="6123sEjSCaL" width="132" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、ほむら、キュゥべえ（イラスト: 守岡英行）</p>
+									<p>pp.16-25: <em>『魔法少女まどか☆マギカ ポータブル』特集。</em>ほむらルート、ボーナスルートの詳細、富澤祐介×虚淵玄×土居由直インタビュー。2011年1月のマチ★アソビで富澤が土居に話をして2月中旬くらいに企画書を渡した、新規に登場する魔女もすべて劇団イヌカレーによるデザイン、必殺技や魔法の名前は虚淵が考えた、など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>コンプティーク　2012年4月号</book-name>
+							<book-release>2012-03-10</book-release>
+							<book-amazon asin="B007C7QR2Y" image-id="61FbbpscGwL" width="129" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.112-115: <em>『魔法少女まどか☆マギカ ポータブル』紹介記事。</em>富澤祐介（バンダイナムコゲームズ）×土居由直（ニトロプラス）の対談。虚淵玄メッセージではゲームのエピソードは映画との関連性はないこと、アニメとの整合性は要求されていないこと、監修のポイントはキャラクターの性格や口調にまつわる部分だったことなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年4月号</book-name>
+							<book-release>2012-03-10</book-release>
+							<book-amazon asin="B007EWCJ42" image-id="51Y1W7ZI24L" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.127-134: 「第6回声優アワード　受賞者大発表!」（主演女優賞: 悠木碧、助演女優賞: 加藤英美里）両名ともコメント掲載。</p>
+									<p>付録: NEWTYPE SCHOOL CALENDAR 2012-2013（10-11月「魔法少女まどか☆マギカ」マミ、まどか、さやか イラスト: 松本元気）。</p>
+									<p>とじこみ付録: NEWTYPE SCHOOL CALENDAR 2012-2013 スペシャルシール（キュゥべえ、まどか、ほむら、マミ、さやか、杏子）。</p>
+									<p><a href="https://www.youtube.com/watch?v=oybwMQcSgyI" class="htmlbuild-host">発売CM</a></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン DELUXE　Vol.18</book-name>
+							<book-release>2012-03-22</book-release>
+							<book-isbn>978-4-05-606596-1</book-isbn>
+							<book-amazon asin="4056065969" image-id="61No04eVpPL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.24-30: <em>「2大アニメ特集 IS&lt;インフィニット・ストラトス&gt;&amp;魔法少女まどか☆マギカ特集」</em>で版権絵7枚掲載。</p>
+									<p>p.94: 本号掲載作品の紹介。BD&amp;DVD6巻ジャケット、1話と12話の場面カット掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>リスアニ!　Vol.8.2 （アニソン クリエイターズⅡ）</book-name>
+							<book-release>2012-03-24</book-release>
+							<book-isbn>978-4-7897-7161-0</book-isbn>
+							<book-amazon asin="478977161X" image-id="51I1p7pbM-L" width="110" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 鹿目まどかの原画（10話で芸術家の魔女に矢を放つカット）。</p>
+									<p>表2: 「劇場企画進行中」広告。「アニメ コンテンツ エキスポ 2012」情報。</p>
+									<p>p.12: 「[特集1] 梶浦由記」で表紙と同じまどかのイラストが掲載。</p>
+									<p>p.24: 「梶浦由記の音楽が聴けるアニメ23本!」で『まどか☆マギカ』あり（BD6巻のジャケットイラスト）。</p>
+									<p>p.69: 渡辺翔のインタビュー「新進気鋭の意外な音楽遍歴」で「コネクト」の歌詞の話題。</p>
+									<p>p.150: 編集後記の背景にオープニングの走る鹿目まどかの原画（本文での言及はなし）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>電撃PlayStation　Vol.515</book-name>
+							<book-release>2012-03-29</book-release>
+							<book-amazon asin="B007JWOCB0" image-id="61RJ1abCTKL" width="131" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.16-23: <em>『魔法少女まどか☆マギカ ポータブル』攻略特集第1弾。</em>アニメ準拠ルートとマミルートの攻略記事、富澤祐介×虚淵玄×土居由直インタビュー（前号の続き）。魔女同士が戦う案があった（ボツになった）、魔女のイメージ自体はアニメ制作段階から（劇団イヌカレーの中では）あったらしい、など。</p>
+									<p>付録: 『魔法少女まどか☆マギカ ポータブル』特大B2ポスター（前号の表紙イラスト）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>カイト　Vol.4</book-name>
+							<book-release>2012-03-30</book-release>
+							<book-isbn>978-4-86225-823-6</book-isbn>
+							<book-amazon asin="4862258239" image-id="51QvtFSIlcL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.6-12: <em>「小池一夫×虚淵玄 『魔法少女まどか☆マギカ』の世界とキャラクターを語る!」</em><a href="https://live.nicovideo.jp/watch/lv77366564" class="htmlbuild-host">ニコニコ生放送で2012年1月29日に行われた対談</a>の書き起こし。キャラクターの命名、1〜3話の構成の根拠、世界観をキャラクター化（キュゥべえ）したこと、執筆にあたり影響を受けた作品など。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>2013年発行の<a href="https://www.amazon.co.jp/dp/4862258654/" class="htmlbuild-host htmlbuild-amazon-associate">「小池一夫対談集　キャラクター60年」</a>に再録。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>電撃G's magazine　2012年5月号</book-name>
+							<book-release>2012-03-30</book-release>
+							<book-amazon asin="B007IV4RLW" image-id="61+QTjeMi+L" width="132" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか&amp;ほむら（原画: 青木雄）。</p>
+									<p>pp.22-31: <em>巻頭特集「魔法少女まどか☆マギカ」</em>「魔法少女まどか☆マギカ ポータブル」情報、本誌専用カスタムテーマ、関係者インタビュー。</p>
+									<p>付録: フォトスタンドクロック（水着のまどか&amp;マミ）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2012年5月号</book-name>
+							<book-release>2012-03-30</book-release>
+							<book-amazon asin="B007JWOBKC" image-id="61UP6fu6hSL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.53-54: 「ついに発売!! 『魔法少女まどか☆マギカ ポータブル』」虚淵玄インタビュー、劇団イヌカレーお祝いイラスト。</p>
+									<p>p.129: 『魔法少女まどか☆マガキ』×『俺妹』コラボレーションブロック崩し。（※"マガキ"との誤記）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>痛G―痛車グラフィックス　Vol.13</book-name>
+							<book-release>2012-03-31</book-release>
+							<book-isbn>978-4-86396-185-2</book-isbn>
+							<book-amazon asin="4863961855" image-id="61qA-fNB+ZL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.41: 「グッドスマイル&amp;カラオケの鉄人カフェ」（秋葉原）の店内写真。等身大パネルやフィギュア。</p>
+									<p>pp.46-48: <em>「痛車のいる風景」</em>メルセデス・ベンツ コネクション（東京・六本木）で展示中の「まどマギ・魔法少女バージョン」のスマート痛車の紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2012年5月号</book-name>
+							<book-release>2012-04-10</book-release>
+							<book-amazon asin="B007NLU59A" image-id="61teNKmBwkL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.52-53: 「まどか伝説、再臨」アルティメットまどかイラスト（潮月一也）、岩上敦宏のコメント掲載。公開時期は2012年秋、前編と後編のインターバルは「連続公開くらいのつもり」。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年5月号</book-name>
+							<book-release>2012-04-10</book-release>
+							<book-amazon asin="B007PSQAI6" image-id="61YxSxP8hFL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.7-10: 「いつかの、あの日に」前後編公開館、「アニメ コンテンツ エキスポ 2012」ステージ情報。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>リスアニ!　Vol.09</book-name>
+							<book-release>2012-04-25</book-release>
+							<book-isbn>978-4-7897-7166-5</book-isbn>
+							<book-amazon asin="4789771660" image-id="51QqM+Tc+RL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.76-78: ClariSのアルバム「BIRTHDAY」発売のインタビューで「コネクト」の話題。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2012年6月号</book-name>
+							<book-release>2012-04-28</book-release>
+							<book-amazon asin="B007T93QGU" image-id="611iIkb5XBL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.35: 前後編情報。ACE会場限定前売り券のイラスト掲載。</p>
+									<p>p.43: 「アニメ コンテンツ エキスポ 2012」のレポート。ステージでキャスト6人が初めて揃って登場したこと、等身大フィギュアが飾られたこと。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>日経エンタテインメント!　2012年6月号</book-name>
+							<book-release>2012-05-02</book-release>
+							<book-amazon asin="B007UQ58MM" image-id="61rh1XiSc4L" width="121" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.93-94: 「これが女優の生きる道」で悠木碧インタビュー。前半は『まどか☆マギカ』の話。</p>
+									<p>p.97: 「ゲームの王国」で 3/12 〜 4/18 のゲームランキングの10位に『魔法少女まどか☆マギカ ポータブル』（本文での言及はなし）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年6月号</book-name>
+							<book-release>2012-05-10</book-release>
+							<book-amazon asin="B007WTUTSA" image-id="61aqjBStksL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>付録: クリアファイル5枚セット（うち1枚が『魔法少女まどか☆マギカ』）。</p>
+									<p><a href="https://www.youtube.com/watch?v=6y2yshsEIwA" class="htmlbuild-host">発売CM</a></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>VOICE EYE　Vol.1</book-name>
+							<book-release>2012-05-18</book-release>
+							<book-isbn>978-4-8130-8160-9</book-isbn>
+							<book-amazon asin="4813081606" image-id="61xzRx5-LUL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.14-19: <em>「2011年度に飛躍した若手声優」</em>悠木碧インタビューで、マミが死ぬシーンはアフレコ時点では首をもがれた瞬間が映っていたが新房監督の判断で取りやめたことなど、新房昭之との対談では「おぎやはぎのメガネびいき」に出演した話、劇場版で10話パートの再アフレコの必要性に悩んでいること（新房）など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ウルトラジャンプ　2012年6月号</book-name>
+							<book-release>2012-05-19</book-release>
+							<book-amazon asin="B007ZFKA0I" image-id="51knzOxL0vL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.335-336: 巴マミとキュゥべえのカラーイラスト（西田亜沙子）。</p>
+									<p>p.338: アニメーターの西田亜沙子の紹介、『まどか☆マギカ』の作品紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン魂　Vol.1</book-name>
+							<book-release>2012-05-30</book-release>
+							<book-amazon asin="B0083IFS4E" image-id="51+iu66tRFL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 水着のまどか&amp;ほむら（原画: 中村直人）。</p>
+									<p>pp.2-13: <em>「2大魔法少女、銀幕を舞う!」</em>新房昭之&amp;岩上敦宏 対談、コミック紹介、プライズフィギュア紹介（開発担当の細田恵インタビュー）、『魔法少女まどか☆マギカ ポータブル』紹介（開発プロデューサーの富澤祐介、土居由直インタビュー）。</p>
+									<p>pp.110-111: 「突撃❤お部屋拝見!!」第1回、まどかとさやかの部屋の配置や小物を紹介、風水診断を実施。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2012年7月号</book-name>
+							<book-release>2012-05-30</book-release>
+							<book-amazon asin="B0082D3VCG" image-id="51Bw-i2k9CL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.125-126: <em>ピンナップポスター</em> 水着まどか・ほむら（「メガミマガジン魂」の表紙イラスト）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.1　2012年7月号</book-name>
+							<book-release>2012-06-08</book-release>
+							<book-amazon asin="B0083IFSJY" image-id="61-eUkk6Q2L" width="110" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、マミ、さやか（原画: 谷口淳一郎）</p>
+									<p>キャッチコピー: 「もっと、ずっと一緒。」（※背表紙は「一冊まるごとまどか☆マギカ」）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2012年7月号</book-name>
+							<book-release>2012-06-08</book-release>
+							<book-amazon asin="B0085MLYRI" image-id="61+blMYNaML" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.73: 「前後編、連続公開決定！」前編キービジュアル掲載、虚淵玄インタビュー。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメディア　2012年7月号</book-name>
+							<book-release>2012-06-08</book-release>
+							<book-amazon asin="B0085WZIZ2" image-id="61U273v3bNL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.108-109: 「魔法少女に大切なもの」劇場版紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年7月号</book-name>
+							<book-release>2012-06-08</book-release>
+							<book-amazon asin="B00865NP8K" image-id="61s0kk0TSyL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.40-43: <em>「再生する少女たち」</em>5人のイラスト（宇佐麻友美）、久保田光俊、岩上敦宏のインタビュー。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>大学漫画　Vol.20</book-name>
+							<book-release>2012-06-16</book-release>
+							<book-isbn>978-4-86225-833-5</book-isbn>
+							<book-amazon asin="4862258336" image-id="51vZpj6RdLL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.16-23: 「『魔法少女まどか☆マギカ』キャラクターをプロファイリングする」で魔法少女5人と魔女、キュゥべえについて、性格や特性からプロファイリング。まとめではほぼ3話ごとに主役キャラが変わる構成やキャラクターと世界観の関係について考察。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2012年8月号</book-name>
+							<book-release>2012-06-30</book-release>
+							<book-amazon asin="B008AWUHAI" image-id="61ObbPNR+uL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.42: 「魔法少女まどか☆マギカ オンライン」の紹介。</p>
+									<p>p.43: 「まどかたちと「東京」修学旅行を満喫した!」国会議事堂や東京タワーなど都内の名所で制服DXフィギュアを撮影。</p>
+									<p>p.44: 「NEXT STAGE」[前編]キービジュアル掲載。[前編]と[後編]が1週間違いで連続公開されることについて宣伝プロデューサーの神宮司学よりコメント。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>コンプティーク　2012年8月号</book-name>
+							<book-release>2012-07-10</book-release>
+							<book-amazon asin="B008BTYRII" image-id="61jKs1dJv9L" width="130" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.370: MAXわたなべ（MaxFactory代表）と平山まどか（アニメーター）の対談。第3話の時点で主要全キャラクターの figma 化が決定したことなど。平山まどかによるまどか、ほむら、キュゥべえのイラスト掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年8月号</book-name>
+							<book-release>2012-07-10</book-release>
+							<book-amazon asin="B008EWTLPQ" image-id="61L0ed2aNoL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.9-10: メガネほむら&amp;リボンほむら&amp;私服ほむらのピンナップ（牧孝雄）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.2　2012年9月号</book-name>
+							<book-release>2012-08-09</book-release>
+							<book-amazon asin="B008I45I5C" image-id="51IB9jVs92L" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「広がり続けるまどかワールド!!」（※背表紙は「ますます広がるまどかワールド!」）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2012年9月号</book-name>
+							<book-release>2012-08-10</book-release>
+							<book-amazon asin="B008NCDGVM" image-id="61saGqNeCyL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.62: 「LET'S THEATRE!」で前後編告知。後編キービジュアル掲載、悠木碧インタビュー。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメディア　2012年9月号</book-name>
+							<book-release>2012-08-10</book-release>
+							<book-amazon asin="B008NCDG94" image-id="612lU8fxUPL" width="119" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.116: 「華々しき銀幕世界へのいざない ANIME CITTAへようこそ」 前後編紹介。後編キービジュアル掲載（イラストについて宣伝プロデューサーの神宮司学のコメント）、特典付き前売り券第2弾の案内。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年9月号</book-name>
+							<book-release>2012-08-10</book-release>
+							<book-amazon asin="B008PUN1LM" image-id="510kwzaQXsL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.34-37: 「あの約束を、再び」まどかと後ろ向きの杏子&amp;さやか&amp;マミのイラスト（沼田誠也）、[前編]のアフレコレポート、「魔法少女まどか☆マギカオンライン」紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2012年10月号</book-name>
+							<book-release>2012-08-30</book-release>
+							<book-amazon asin="B008YJ1BXO" image-id="61djmTJhPRL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.112: 劇場版前後編情報。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2012年10月号</book-name>
+							<book-release>2012-09-10</book-release>
+							<book-amazon asin="B008YJ19BS" image-id="61EDwjgO-5L" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.107: 「再会の刻まで あと少し」前後編告知。画面ショット複数掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメディア　2012年10月号</book-name>
+							<book-release>2012-09-10</book-release>
+							<book-amazon asin="B00905J08Y" image-id="61rVQfoYNbL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.131: 「乗り遅れたらダメ! 劇場版アニメでアゲアゲお祭り気分◎」前後編紹介。悠木碧、斎藤千和コメント。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年10月号</book-name>
+							<book-release>2012-09-10</book-release>
+							<book-amazon asin="B00937KG0U" image-id="61-r9PNzrbL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: アルティメットまどか（原画: 谷口淳一郎）</p>
+									<p>pp.24-29: 「少女から伝説へ」宮本幸裕、寺尾洋之、山村洋貴、谷口淳一郎、劇団イヌカレー、新房昭之のコメント、主要キャストへの質問。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>KINEZO ANIME　Vol.1</book-name>
+							<book-release>2012-09-15</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.17-22: 前後編の記事。[前編]、[後編]キービジュアル掲載、TV版各話ストーリー紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>スクリーン+プラス　Vol.35（スクリーン特編版）</book-name>
+							<book-release>2012-09-18</book-release>
+							<book-isbn>978-4-7648-8315-4</book-isbn>
+							<book-amazon asin="4764883155" image-id="51RiOvrQnPL" width="114" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.32-37: <em>「今、観るべき劇場アニメ2012秋〜冬」</em>前後編キービジュアル、Introduction、キャラクター紹介など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメフリックス　Vol.1</book-name>
+							<book-release>2012-09-19</book-release>
+							<book-amazon asin="B0093F50XU" image-id="512X3rAGinL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.30-43: <em>「劇場版 魔法少女まどか☆マギカ [前編]始まりの物語／[後編]永遠の物語」</em>新房昭之、悠木碧、斎藤千和インタビュー。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>オトナファミ　2012年11月号</book-name>
+							<book-release>2012-09-20</book-release>
+							<book-amazon asin="B0096H5CHY" image-id="61TWqECJPtL" width="118" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.70-71: 「今旬エンタすぐわかり講座2012秋」で前後編の紹介。岩上敦宏インタビュー。新作（新編）の脚本は既に完成していて、制作もスタートしているとのこと。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>デジモノステーション　2012年11月号</book-name>
+							<book-release>2012-09-25</book-release>
+							<book-amazon asin="B0099AEVKM" image-id="51W-S0e7XWL" width="120" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>特別付録: 『魔法少女まどか☆マギカ』オリジナル☆ソーラー電卓。</p>
+									<p>pp.75-83: <em>「魔法少女まどか☆マギカ 完全導入マニュアル」</em> 中村正人（DREAMS COME TRUE）×岩上敦宏の対談、劇場版前後編の紹介など。</p>
+									<p>pp.84-85: 「しょこたん☆アニメは人類をつなぐ! （連載第28回）」悠木碧（鹿目まどか）☆対談。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン DELUXE　Vol.19</book-name>
+							<book-release>2012-09-27</book-release>
+							<book-amazon asin="B0099AEV9S" image-id="61jGCUbAhXL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.43: 「水着ガール特集」で版権絵1枚掲載（「メガミマガジン魂　Vol.1」表紙、中村直人）。</p>
+									<p>p.93: 本号掲載作品の紹介。前編キービジュアル、1話場面カット掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2012年11月号</book-name>
+							<book-release>2012-09-29</book-release>
+							<book-amazon asin="B009AXRIJO" image-id="61ICtTLJ1SL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.104-106: <em>「リリィな関係」劇場版 魔法少女まどか☆マギカ</em>、まどほむ、まどマミ、杏さや、ほむマミの組み合わせごとに場面カット掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>SWITCH　特別編集号　ソーシャルカルチャーネ申1oo The Bible</book-name>
+							<book-release>2012-10-06</book-release>
+							<book-isbn>978-4-88418-429-2</book-isbn>
+							<book-amazon asin="4884184297" image-id="51IHz6CYLyL" width="109" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: アルティメットまどか（イラスト: 谷口淳一郎）。</p>
+									<p>折り込み: 鹿目まどかイラスト（Vol.29 No.7の表紙）のピンナップ。</p>
+									<p>p.10: 新房昭之インタビュー。劇場版はファンが実際に集まるイベントという位置付け、個人的な願望として詢子の青春時代やワルプルギスの夜の正体の話をやりたいといった話。</p>
+									<p>p.11: 虚淵玄インタビュー。祈りの代償に関する価値観の話。</p>
+									<p>p.12: 悠木碧&amp;喜多村英梨インタビュー。「劇場盛り」の話。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>別冊ザテレビジョン　アニメザテレビジョン　Vol.1</book-name>
+							<book-release>2012-10-10</book-release>
+							<book-isbn>978-4-04-895460-0</book-isbn>
+							<book-amazon asin="4048954601" image-id="61Nqc+a+OgL" width="114" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙：前後編キービジュアル（蒼樹うめ）。</p>
+									<p>pp.4-20: <em>「総力特集　劇場版 魔法少女まどか☆マギカ　スペシャル考察&amp;プレビュー」</em>各キャラクター紹介とキャストの一言コメント。</p>
+									<p>折り込みピンナップ: 表紙と同じキービジュアルのA3イラスト（p.42 と p.43 の間）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.3　2012年11月号</book-name>
+							<book-release>2012-10-10</book-release>
+							<book-amazon asin="B009AXRJLG" image-id="61OE-gLrWfL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、ほむら 他（イラスト: 鳴子ハナハル）</p>
+									<p>キャッチコピー: 「まどかに逢える、奇跡。」（※背表紙は「劇場公開記念特製ミニ色紙つき!!」）</p>
+									<p>付録: 劇場公開記念ミニ色紙</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>オトナアニメ　Vol.26</book-name>
+							<book-release>2012-10-10</book-release>
+							<book-isbn>978-4-8003-0029-4</book-isbn>
+							<book-amazon asin="4800300290" image-id="51RCUxuTr+L" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.2-7: 「巻頭特別企画『劇場版 魔法少女まどか☆マギカ』」野中藍&amp;喜多村英梨インタビュー。前後編のアフレコの話。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2012年11月号</book-name>
+							<book-release>2012-10-10</book-release>
+							<book-amazon asin="B009DJGO5Y" image-id="61JakJ-4D4L" width="128" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.56-57: <em>「新房昭之[総監督]インタビュー」</em>前編と後編の区切り話数、10話部分にノイズを入れたこと、背景美術の話など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメディア　2012年11月号</book-name>
+							<book-release>2012-10-10</book-release>
+							<book-amazon asin="B009DJGME2" image-id="61zHaXLqAAL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.106-107: 「総チェック★ 劇場キャラまるハダカ診断」前後編紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年11月号</book-name>
+							<book-release>2012-10-10</book-release>
+							<book-amazon asin="B009H753BI" image-id="514eOER2UxL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>付録: <em>B2ポスター&amp;特集「劇場版 魔法少女まどか☆マギカ」</em>5人のイラスト（住本悦子）、新房昭之インタビュー。</p>
+									<p><a href="https://www.youtube.com/watch?v=SZ9X-4m_wPk" class="htmlbuild-host">発売CM</a></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>SPA!　2012年10月23日号</book-name>
+							<book-release>2012-10-16</book-release>
+							<book-amazon asin="B00UT754NW" image-id="61M8NXbBGQL" width="121" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: マミの魔法少女服を着た鹿目まどか（原画: 谷口淳一郎）。</p>
+									<p>pp.3-4: 舞妓まどかのポスター表裏（原画: 中村直人）。</p>
+									<p>pp.46-49: 「美女が解説！『まどか☆マギカ』の正体」年表、アイドルやモデルによるコメント（松井玲奈、山本美月、喜屋武ちあき、犬山紙子）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>Cut　2012年11月号</book-name>
+							<book-release>2012-10-19</book-release>
+							<book-amazon asin="B009K69NZS" image-id="51XCeLD-dwL" width="120" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>第2表紙: まどか、キュゥべえのイラスト（原画: 谷口淳一郎）。</p>
+									<p>pp.56-71: <em>「特集：秋アニメ最前線2012」</em>で前後編特集。</p>
+									<p>pp.58-61: 新房昭之インタビュー。TVシリーズからカットしたシーンの話、アフレコし直しの話など。</p>
+									<p>p.63: 悠木碧インタビュー。</p>
+									<p>p.64: 斎藤千和インタビュー。</p>
+									<p>p.67: 加藤英美里インタビュー。</p>
+									<p>pp.68-71: 梶浦由記インタビュー。全4ページのインタビューだが、『まどか』についての話は1ページ強。『Fate/Zero』の音楽を俯瞰的な視点で作ったのに対し、『まどか』は主観で作ったことなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>B.L.T.　2012年12月号</book-name>
+							<book-release>2012-10-24</book-release>
+							<book-amazon asin="B009P8B8P4" image-id="610rC2cO3+L" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.126: 悠木碧インタビュー。劇場版前後編のアフレコについて。劇場版第三弾（新編）の内容は何も知らないとのこと。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>リスアニ!　Vol.11</book-name>
+							<book-release>2012-10-26</book-release>
+							<book-isbn>978-4-7897-7180-1</book-isbn>
+							<book-amazon asin="4789771806" image-id="518lBeTXYUL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、ほむら、マミ（潮月一也）</p>
+									<p>pp.8-29: <em>「[特集1] 劇場版 魔法少女まどか☆マギカ "物語と音楽の融合"」</em>岩上敦宏コメント、ClariSインタビュー、Kalafinaインタビュー（新しい劇伴のうち2曲で「魔女の歌詞」をドイツ語訳した歌を入れたことなど）、梶浦由紀インタビュー、冨田明宏による劇伴考察（TV版OST曲タイトル日本語訳、for the next episode は曲に合わせて映像が作られたことなど）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2012年12月号増刊</book-name>
+							<book-release>2012-10-26</book-release>
+							<book-amazon asin="B009SP8014" image-id="61pXlfr-NbL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p><em>『劇場版 魔法少女まどか☆マギカ』特集号</em></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>KINEZO ANIME　Vol.2</book-name>
+							<book-release>2012-10-27</book-release>
+							<book-isbn>978-4-9906734-0-6</book-isbn>
+							<book-amazon asin="4990673409" image-id="51dYR6eyLgL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.15-27: <em>「『劇場版 魔法少女まどか☆マギカ　[前編]始まりの物語 [後編]永遠の物語』」</em>作品紹介、ポスターギャラリー、岩上敦宏インタビュー、[前編]初日舞台挨拶レポート（集合写真、各キャストの発言概要掲載）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2012年12月号</book-name>
+							<book-release>2012-10-30</book-release>
+							<book-amazon asin="B009R48ZOI" image-id="61JBMY77CoL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: アルティメットまどか&amp;リボンほむら（原画: 谷口淳一郎）。</p>
+									<p>別冊付録: <em>「PUELLA MAGI MADOKA MAGICA CINEMA ISSUES」</em>虚淵玄インタビュー（前後編の感想と新編制作の話）、新房昭之×悠木碧インタビュー、キャラクター紹介、蒼樹うめ色紙プレゼント、劇場版原案イラスト（まどか私服、変身さやか髪留め）、グッズ情報、ナムココラボ情報。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -2063,1546 +1986,950 @@
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年12月号</book-name>
-							<book-release>2012-10-30</book-release>
-							<book-amazon asin="B009R48ZOI" image-id="61JBMY77CoL" width="124" height="160"></book-amazon>
+							<book-name>アニメージュ　2012年12月号</book-name>
+							<book-release>2012-11-09</book-release>
+							<book-amazon asin="B009UXDBAY" image-id="61tiwVBousL" width="127" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: アルティメットまどか&amp;リボンほむら（原画: 谷口淳一郎）。</p>
-									<p>別冊付録: <em>「PUELLA MAGI MADOKA MAGICA CINEMA ISSUES」</em>虚淵玄インタビュー（前後編の感想と新編制作の話）、新房昭之×悠木碧インタビュー、キャラクター紹介、蒼樹うめ色紙プレゼント、劇場版原案イラスト（まどか私服、変身さやか髪留め）、グッズ情報、ナムココラボ情報。</p>
+									<p>pp.56-57: 「終わらぬ物語」アルティメットまどか、リボンほむらのイラスト（寺尾洋之）、岩上敦宏インタビュー。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>KINEZO ANIME　Vol.2</book-name>
-							<book-release>2012-10-27</book-release>
-							<book-isbn>978-4-9906734-0-6</book-isbn>
-							<book-amazon asin="4990673409" image-id="51dYR6eyLgL" width="112" height="160"></book-amazon>
+							<book-name>アニメディア　2012年12月号</book-name>
+							<book-release>2012-11-09</book-release>
+							<book-amazon asin="B009T90W2O" image-id="61n6cUZiUyL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.15-27: <em>「『劇場版 魔法少女まどか☆マギカ　[前編]始まりの物語 [後編]永遠の物語』」</em>作品紹介、ポスターギャラリー、岩上敦宏インタビュー、[前編]初日舞台挨拶レポート（集合写真、各キャストの発言概要掲載）。</p>
+									<p>pp.124-125: 「頑張れ美少女❤ EVERYGIRL GOING!」前後編の紹介、初日舞台挨拶（新宿バルト9）レポート。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年12月号増刊</book-name>
-							<book-release>2012-10-26</book-release>
-							<book-amazon asin="B009SP8014" image-id="61pXlfr-NbL" width="124" height="160"></book-amazon>
+							<book-name>ニュータイプ　2012年12月号</book-name>
+							<book-release>2012-11-09</book-release>
+							<book-amazon asin="B009XFIRLW" image-id="51j3oUpLHnL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p><em>『劇場版 魔法少女まどか☆マギカ』特集号</em></p>
+									<p>pp.36-37: 「MOVIN' ON 『劇場版 魔法少女まどか☆マギカ』」5人とキュゥべえのイラスト（寺尾洋之）、公開中の前後編の紹介。</p>
+									<p>p.145: EVENT 新宿バルト9でのメインキャスト6人による[前編]舞台挨拶の写真。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.11</book-name>
-							<book-release>2012-10-26</book-release>
-							<book-isbn>978-4-7897-7180-1</book-isbn>
-							<book-amazon asin="4789771806" image-id="518lBeTXYUL" width="112" height="160"></book-amazon>
+							<book-name>まんがタイムきららフォワード　2013年1月号</book-name>
+							<book-release>2012-11-24</book-release>
+							<book-amazon asin="B009YZYKWQ" image-id="61zy4u5H68L" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: まどか、ほむら、マミ（潮月一也）</p>
-									<p>pp.8-29: <em>「[特集1] 劇場版 魔法少女まどか☆マギカ "物語と音楽の融合"」</em>岩上敦宏コメント、ClariSインタビュー、Kalafinaインタビュー（新しい劇伴のうち2曲で「魔女の歌詞」をドイツ語訳した歌を入れたことなど）、梶浦由紀インタビュー、冨田明宏による劇伴考察（TV版OST曲タイトル日本語訳、for the next episode は曲に合わせて映像が作られたことなど）。</p>
+									<p>pp.3-4: 前後編オープニングカット掲載、『魔法少女まどか☆マギカ 〜The different story〜』、アンソロジーコミック、4コマアンソロジーコミック発売広告。</p>
+									<p>pp.57-82: 『かずみ☆マギカ』最終話</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>B.L.T.　2012年12月号</book-name>
-							<book-release>2012-10-24</book-release>
-							<book-amazon asin="B009P8B8P4" image-id="610rC2cO3+L" width="112" height="160"></book-amazon>
+							<book-name>娘TYPE　2013年1月号</book-name>
+							<book-release>2012-11-30</book-release>
+							<book-amazon asin="B00AAGOZQ4" image-id="61Yf6mxslkL" width="122" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.126: 悠木碧インタビュー。劇場版前後編のアフレコについて。劇場版第三弾（新編）の内容は何も知らないとのこと。</p>
+									<p>pp.19-20: サンタ姿のまどか、ほむら、キュゥべえのピンナップ（寺尾洋之）。</p>
+									<p>p.141: 「ピュアニーモキャラクターシリーズ No.064 佐倉杏子 私服Ver.」（アゾンインターナショナル）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>Cut　2012年11月号</book-name>
-							<book-release>2012-10-19</book-release>
-							<book-amazon asin="B009K69NZS" image-id="51XCeLD-dwL" width="120" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.4　2013年1月号</book-name>
+							<book-release>2012-12-10</book-release>
+							<book-amazon asin="B00A7ZCKQA" image-id="61g97CXFxuL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>第2表紙: まどか、キュゥべえのイラスト（原画: 谷口淳一郎）。</p>
-									<p>pp.56-71: <em>「特集：秋アニメ最前線2012」</em>で前後編特集。</p>
-									<p>pp.58-61: 新房昭之インタビュー。TVシリーズからカットしたシーンの話、アフレコし直しの話など。</p>
-									<p>p.63: 悠木碧インタビュー。</p>
-									<p>p.64: 斎藤千和インタビュー。</p>
-									<p>p.67: 加藤英美里インタビュー。</p>
-									<p>pp.68-71: 梶浦由記インタビュー。全4ページのインタビューだが、『まどか』についての話は1ページ強。『Fate/Zero』の音楽を俯瞰的な視点で作ったのに対し、『まどか』は主観で作ったことなど。</p>
+									<p>表紙: まどか、キュゥべえ（原画: 山村洋貴）</p>
+									<p>キャッチコピー: 「願いを叶えるとっておきの贈り物」（※背表紙は「まどかに叶うあなたの願い」）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>SPA!　2012年10月23日号</book-name>
-							<book-release>2012-10-16</book-release>
-							<book-amazon asin="B00UT754NW" image-id="61M8NXbBGQL" width="121" height="160"></book-amazon>
+							<book-name>Febri　Vol.14</book-name>
+							<book-release>2012-12-10</book-release>
+							<book-amazon asin="B00A7ZCK2Y" image-id="51f5dq5zpdL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: マミの魔法少女服を着た鹿目まどか（原画: 谷口淳一郎）。</p>
-									<p>pp.3-4: 舞妓まどかのポスター表裏（原画: 中村直人）。</p>
-									<p>pp.46-49: 「美女が解説！『まどか☆マギカ』の正体」年表、アイドルやモデルによるコメント（松井玲奈、山本美月、喜屋武ちあき、犬山紙子）。</p>
+									<p>表紙: 鹿目まどか、暁美ほむら（原画: 谷口淳一郎）</p>
+									<p>pp.4-13: <em>「特集 シャフト“なう”」</em> 前後編オープニングの画面ショット（上映版）と絵コンテ掲載、宮本幸裕×寺尾洋之インタビューで担当カット（寺尾）、新房総監督からの修正指示内容など。</p>
+									<p>pp.27-28: 「新房昭之、2012年を大いに語る」新房昭之インタビュー。[前編]冒頭のまどかの夢のシーンを削除した理由、寺尾洋之を副監督にした訳など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年11月号</book-name>
-							<book-release>2012-10-10</book-release>
-							<book-amazon asin="B009H753BI" image-id="514eOER2UxL" width="125" height="160"></book-amazon>
+							<book-name>ニュータイプ　2013年1月号</book-name>
+							<book-release>2012-12-10</book-release>
+							<book-amazon asin="B00AEAZKS8" image-id="51aM4TryOpL" width="122" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>付録: <em>B2ポスター&amp;特集「劇場版 魔法少女まどか☆マギカ」</em>5人のイラスト（住本悦子）、新房昭之インタビュー。</p>
-									<p><a href="https://www.youtube.com/watch?v=SZ9X-4m_wPk" class="htmlbuild-host">発売CM</a></p>
+									<p>pp.46-49: <em>「奇跡の軌跡」</em>まどか&amp;アルティメットまどかが抱き合うイラスト（寺尾洋之）、新房昭之×寺尾洋之のインタビュー。劇場版に関わるきっかけやマミの変身シーンの話など。</p>
+									<p>p.170: 「新房昭之の恐縮ですが……」で高橋祐馬（アニプレックス宣伝プロデューサー）との対談。芳文社本社ビルの『ひだまりスケッチ×ハニカム』と『劇場版魔法少女まどか☆マギカ』コラボ垂れ幕の話題。</p>
+									<p>付録: ILLUSTRATION CALENDAR 2013（5-6月「魔法少女まどか☆マギカ」） まどか&amp;アルティメットまどか（寺尾洋之）。</p>
+									<p><a href="https://www.youtube.com/watch?v=1t8bjJ_5sW0" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2012年11月号</book-name>
-							<book-release>2012-10-10</book-release>
-							<book-amazon asin="B009DJGME2" image-id="61zHaXLqAAL" width="125" height="160"></book-amazon>
+							<book-name>オトナアニメ年鑑2013</book-name>
+							<book-release>2012-12-14</book-release>
+							<book-isbn>978-4-8003-0071-3</book-isbn>
+							<book-amazon asin="4800300711" image-id="61GaarU7o6L" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.106-107: 「総チェック★ 劇場キャラまるハダカ診断」前後編紹介。</p>
+									<p>表紙: [後編]キービジュアル。</p>
+									<p>pp.10-15: <em>「特集　2012年劇場で観るアニメの最先端『劇場版 魔法少女まどか☆マギカ』」</em>前後編の紹介記事。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2012年11月号</book-name>
-							<book-release>2012-10-10</book-release>
-							<book-amazon asin="B009DJGO5Y" image-id="61JakJ-4D4L" width="128" height="160"></book-amazon>
+							<book-name>娘TYPE　2013年2月号</book-name>
+							<book-release>2012-12-27</book-release>
+							<book-amazon asin="B00AO7G7EM" image-id="61fXe4k599L" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.56-57: <em>「新房昭之[総監督]インタビュー」</em>前編と後編の区切り話数、10話部分にノイズを入れたこと、背景美術の話など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>オトナアニメ　Vol.26</book-name>
-							<book-release>2012-10-10</book-release>
-							<book-isbn>978-4-8003-0029-4</book-isbn>
-							<book-amazon asin="4800300290" image-id="51RCUxuTr+L" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.2-7: 「巻頭特別企画『劇場版 魔法少女まどか☆マギカ』」野中藍&amp;喜多村英梨インタビュー。前後編のアフレコの話。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.3　2012年11月号</book-name>
-							<book-release>2012-10-10</book-release>
-							<book-amazon asin="B009AXRJLG" image-id="61OE-gLrWfL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、ほむら 他（イラスト: 鳴子ハナハル）</p>
-									<p>キャッチコピー: 「まどかに逢える、奇跡。」（※背表紙は「劇場公開記念特製ミニ色紙つき!!」）</p>
-									<p>付録: 劇場公開記念ミニ色紙</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>別冊ザテレビジョン　アニメザテレビジョン　Vol.1</book-name>
-							<book-release>2012-10-10</book-release>
-							<book-isbn>978-4-04-895460-0</book-isbn>
-							<book-amazon asin="4048954601" image-id="61Nqc+a+OgL" width="114" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙：前後編キービジュアル（蒼樹うめ）。</p>
-									<p>pp.4-20: <em>「総力特集　劇場版 魔法少女まどか☆マギカ　スペシャル考察&amp;プレビュー」</em>各キャラクター紹介とキャストの一言コメント。</p>
-									<p>折り込みピンナップ: 表紙と同じキービジュアルのA3イラスト（p.42 と p.43 の間）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>SWITCH　特別編集号　ソーシャルカルチャーネ申1oo The Bible</book-name>
-							<book-release>2012-10-06</book-release>
-							<book-isbn>978-4-88418-429-2</book-isbn>
-							<book-amazon asin="4884184297" image-id="51IHz6CYLyL" width="109" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: アルティメットまどか（イラスト: 谷口淳一郎）。</p>
-									<p>折り込み: 鹿目まどかイラスト（Vol.29 No.7の表紙）のピンナップ。</p>
-									<p>p.10: 新房昭之インタビュー。劇場版はファンが実際に集まるイベントという位置付け、個人的な願望として詢子の青春時代やワルプルギスの夜の正体の話をやりたいといった話。</p>
-									<p>p.11: 虚淵玄インタビュー。祈りの代償に関する価値観の話。</p>
-									<p>p.12: 悠木碧&amp;喜多村英梨インタビュー。「劇場盛り」の話。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年11月号</book-name>
-							<book-release>2012-09-29</book-release>
-							<book-amazon asin="B009AXRIJO" image-id="61ICtTLJ1SL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.104-106: <em>「リリィな関係」劇場版 魔法少女まどか☆マギカ</em>、まどほむ、まどマミ、杏さや、ほむマミの組み合わせごとに場面カット掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン DELUXE　Vol.19</book-name>
-							<book-release>2012-09-27</book-release>
-							<book-amazon asin="B0099AEV9S" image-id="61jGCUbAhXL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.43: 「水着ガール特集」で版権絵1枚掲載（「メガミマガジン魂　Vol.1」表紙、中村直人）。</p>
-									<p>p.93: 本号掲載作品の紹介。前編キービジュアル、1話場面カット掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>デジモノステーション　2012年11月号</book-name>
-							<book-release>2012-09-25</book-release>
-							<book-amazon asin="B0099AEVKM" image-id="51W-S0e7XWL" width="120" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>特別付録: 『魔法少女まどか☆マギカ』オリジナル☆ソーラー電卓。</p>
-									<p>pp.75-83: <em>「魔法少女まどか☆マギカ 完全導入マニュアル」</em> 中村正人（DREAMS COME TRUE）×岩上敦宏の対談、劇場版前後編の紹介など。</p>
-									<p>pp.84-85: 「しょこたん☆アニメは人類をつなぐ! （連載第28回）」悠木碧（鹿目まどか）☆対談。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>オトナファミ　2012年11月号</book-name>
-							<book-release>2012-09-20</book-release>
-							<book-amazon asin="B0096H5CHY" image-id="61TWqECJPtL" width="118" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.70-71: 「今旬エンタすぐわかり講座2012秋」で前後編の紹介。岩上敦宏インタビュー。新作（新編）の脚本は既に完成していて、制作もスタートしているとのこと。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメフリックス　Vol.1</book-name>
-							<book-release>2012-09-19</book-release>
-							<book-amazon asin="B0093F50XU" image-id="512X3rAGinL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.30-43: <em>「劇場版 魔法少女まどか☆マギカ [前編]始まりの物語／[後編]永遠の物語」</em>新房昭之、悠木碧、斎藤千和インタビュー。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>スクリーン+プラス　Vol.35（スクリーン特編版）</book-name>
-							<book-release>2012-09-18</book-release>
-							<book-isbn>978-4-7648-8315-4</book-isbn>
-							<book-amazon asin="4764883155" image-id="51RiOvrQnPL" width="114" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.32-37: <em>「今、観るべき劇場アニメ2012秋〜冬」</em>前後編キービジュアル、Introduction、キャラクター紹介など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>KINEZO ANIME　Vol.1</book-name>
-							<book-release>2012-09-15</book-release>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.17-22: 前後編の記事。[前編]、[後編]キービジュアル掲載、TV版各話ストーリー紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年10月号</book-name>
-							<book-release>2012-09-10</book-release>
-							<book-amazon asin="B00937KG0U" image-id="61-r9PNzrbL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: アルティメットまどか（原画: 谷口淳一郎）</p>
-									<p>pp.24-29: 「少女から伝説へ」宮本幸裕、寺尾洋之、山村洋貴、谷口淳一郎、劇団イヌカレー、新房昭之のコメント、主要キャストへの質問。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2012年10月号</book-name>
-							<book-release>2012-09-10</book-release>
-							<book-amazon asin="B00905J08Y" image-id="61rVQfoYNbL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.131: 「乗り遅れたらダメ! 劇場版アニメでアゲアゲお祭り気分◎」前後編紹介。悠木碧、斎藤千和コメント。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2012年10月号</book-name>
-							<book-release>2012-09-10</book-release>
-							<book-amazon asin="B008YJ19BS" image-id="61EDwjgO-5L" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.107: 「再会の刻まで あと少し」前後編告知。画面ショット複数掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年10月号</book-name>
-							<book-release>2012-08-30</book-release>
-							<book-amazon asin="B008YJ1BXO" image-id="61djmTJhPRL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.112: 劇場版前後編情報。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年9月号</book-name>
-							<book-release>2012-08-10</book-release>
-							<book-amazon asin="B008PUN1LM" image-id="510kwzaQXsL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.34-37: 「あの約束を、再び」まどかと後ろ向きの杏子&amp;さやか&amp;マミのイラスト（沼田誠也）、[前編]のアフレコレポート、「魔法少女まどか☆マギカオンライン」紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2012年9月号</book-name>
-							<book-release>2012-08-10</book-release>
-							<book-amazon asin="B008NCDG94" image-id="612lU8fxUPL" width="119" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.116: 「華々しき銀幕世界へのいざない ANIME CITTAへようこそ」 前後編紹介。後編キービジュアル掲載（イラストについて宣伝プロデューサーの神宮司学のコメント）、特典付き前売り券第2弾の案内。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2012年9月号</book-name>
-							<book-release>2012-08-10</book-release>
-							<book-amazon asin="B008NCDGVM" image-id="61saGqNeCyL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.62: 「LET'S THEATRE!」で前後編告知。後編キービジュアル掲載、悠木碧インタビュー。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.2　2012年9月号</book-name>
-							<book-release>2012-08-09</book-release>
-							<book-amazon asin="B008I45I5C" image-id="51IB9jVs92L" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか（イラスト: ハノカゲ）</p>
-									<p>キャッチコピー: 「広がり続けるまどかワールド!!」（※背表紙は「ますます広がるまどかワールド!」）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年8月号</book-name>
-							<book-release>2012-07-10</book-release>
-							<book-amazon asin="B008EWTLPQ" image-id="61L0ed2aNoL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.9-10: メガネほむら&amp;リボンほむら&amp;私服ほむらのピンナップ（牧孝雄）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>コンプティーク　2012年8月号</book-name>
-							<book-release>2012-07-10</book-release>
-							<book-amazon asin="B008BTYRII" image-id="61jKs1dJv9L" width="130" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.370: MAXわたなべ（MaxFactory代表）と平山まどか（アニメーター）の対談。第3話の時点で主要全キャラクターの figma 化が決定したことなど。平山まどかによるまどか、ほむら、キュゥべえのイラスト掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年8月号</book-name>
-							<book-release>2012-06-30</book-release>
-							<book-amazon asin="B008AWUHAI" image-id="61ObbPNR+uL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.42: 「魔法少女まどか☆マギカ オンライン」の紹介。</p>
-									<p>p.43: 「まどかたちと「東京」修学旅行を満喫した!」国会議事堂や東京タワーなど都内の名所で制服DXフィギュアを撮影。</p>
-									<p>p.44: 「NEXT STAGE」[前編]キービジュアル掲載。[前編]と[後編]が1週間違いで連続公開されることについて宣伝プロデューサーの神宮司学よりコメント。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>大学漫画　Vol.20</book-name>
-							<book-release>2012-06-16</book-release>
-							<book-isbn>978-4-86225-833-5</book-isbn>
-							<book-amazon asin="4862258336" image-id="51vZpj6RdLL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.16-23: 「『魔法少女まどか☆マギカ』キャラクターをプロファイリングする」で魔法少女5人と魔女、キュゥべえについて、性格や特性からプロファイリング。まとめではほぼ3話ごとに主役キャラが変わる構成やキャラクターと世界観の関係について考察。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年7月号</book-name>
-							<book-release>2012-06-08</book-release>
-							<book-amazon asin="B00865NP8K" image-id="61s0kk0TSyL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.40-43: <em>「再生する少女たち」</em>5人のイラスト（宇佐麻友美）、久保田光俊、岩上敦宏のインタビュー。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2012年7月号</book-name>
-							<book-release>2012-06-08</book-release>
-							<book-amazon asin="B0085WZIZ2" image-id="61U273v3bNL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.108-109: 「魔法少女に大切なもの」劇場版紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2012年7月号</book-name>
-							<book-release>2012-06-08</book-release>
-							<book-amazon asin="B0085MLYRI" image-id="61+blMYNaML" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.73: 「前後編、連続公開決定！」前編キービジュアル掲載、虚淵玄インタビュー。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきらら☆マギカ　Vol.1　2012年7月号</book-name>
-							<book-release>2012-06-08</book-release>
-							<book-amazon asin="B0083IFSJY" image-id="61-eUkk6Q2L" width="110" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、マミ、さやか（原画: 谷口淳一郎）</p>
-									<p>キャッチコピー: 「もっと、ずっと一緒。」（※背表紙は「一冊まるごとまどか☆マギカ」）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年7月号</book-name>
-							<book-release>2012-05-30</book-release>
-							<book-amazon asin="B0082D3VCG" image-id="51Bw-i2k9CL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.125-126: <em>ピンナップポスター</em> 水着まどか・ほむら（「メガミマガジン魂」の表紙イラスト）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン魂　Vol.1</book-name>
-							<book-release>2012-05-30</book-release>
-							<book-amazon asin="B0083IFS4E" image-id="51+iu66tRFL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 水着のまどか&amp;ほむら（原画: 中村直人）。</p>
-									<p>pp.2-13: <em>「2大魔法少女、銀幕を舞う!」</em>新房昭之&amp;岩上敦宏 対談、コミック紹介、プライズフィギュア紹介（開発担当の細田恵インタビュー）、『魔法少女まどか☆マギカ ポータブル』紹介（開発プロデューサーの富澤祐介、土居由直インタビュー）。</p>
-									<p>pp.110-111: 「突撃❤お部屋拝見!!」第1回、まどかとさやかの部屋の配置や小物を紹介、風水診断を実施。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ウルトラジャンプ　2012年6月号</book-name>
-							<book-release>2012-05-19</book-release>
-							<book-amazon asin="B007ZFKA0I" image-id="51knzOxL0vL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.335-336: 巴マミとキュゥべえのカラーイラスト（西田亜沙子）。</p>
-									<p>p.338: アニメーターの西田亜沙子の紹介、『まどか☆マギカ』の作品紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>VOICE EYE　Vol.1</book-name>
-							<book-release>2012-05-18</book-release>
-							<book-isbn>978-4-8130-8160-9</book-isbn>
-							<book-amazon asin="4813081606" image-id="61xzRx5-LUL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.14-19: <em>「2011年度に飛躍した若手声優」</em>悠木碧インタビューで、マミが死ぬシーンはアフレコ時点では首をもがれた瞬間が映っていたが新房監督の判断で取りやめたことなど、新房昭之との対談では「おぎやはぎのメガネびいき」に出演した話、劇場版で10話パートの再アフレコの必要性に悩んでいること（新房）など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年6月号</book-name>
-							<book-release>2012-05-10</book-release>
-							<book-amazon asin="B007WTUTSA" image-id="61aqjBStksL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>付録: クリアファイル5枚セット（うち1枚が『魔法少女まどか☆マギカ』）。</p>
-									<p><a href="https://www.youtube.com/watch?v=6y2yshsEIwA" class="htmlbuild-host">発売CM</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>日経エンタテインメント!　2012年6月号</book-name>
-							<book-release>2012-05-02</book-release>
-							<book-amazon asin="B007UQ58MM" image-id="61rh1XiSc4L" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.93-94: 「これが女優の生きる道」で悠木碧インタビュー。前半は『まどか☆マギカ』の話。</p>
-									<p>p.97: 「ゲームの王国」で 3/12 〜 4/18 のゲームランキングの10位に『魔法少女まどか☆マギカ ポータブル』（本文での言及はなし）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年6月号</book-name>
-							<book-release>2012-04-28</book-release>
-							<book-amazon asin="B007T93QGU" image-id="611iIkb5XBL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.35: 前後編情報。ACE会場限定前売り券のイラスト掲載。</p>
-									<p>p.43: 「アニメ コンテンツ エキスポ 2012」のレポート。ステージでキャスト6人が初めて揃って登場したこと、等身大フィギュアが飾られたこと。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.09</book-name>
-							<book-release>2012-04-25</book-release>
-							<book-isbn>978-4-7897-7166-5</book-isbn>
-							<book-amazon asin="4789771660" image-id="51QqM+Tc+RL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.76-78: ClariSのアルバム「BIRTHDAY」発売のインタビューで「コネクト」の話題。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年5月号</book-name>
-							<book-release>2012-04-10</book-release>
-							<book-amazon asin="B007PSQAI6" image-id="61YxSxP8hFL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.7-10: 「いつかの、あの日に」前後編公開館、「アニメ コンテンツ エキスポ 2012」ステージ情報。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2012年5月号</book-name>
-							<book-release>2012-04-10</book-release>
-							<book-amazon asin="B007NLU59A" image-id="61teNKmBwkL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.52-53: 「まどか伝説、再臨」アルティメットまどかイラスト（潮月一也）、岩上敦宏のコメント掲載。公開時期は2012年秋、前編と後編のインターバルは「連続公開くらいのつもり」。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>痛G―痛車グラフィックス　Vol.13</book-name>
-							<book-release>2012-03-31</book-release>
-							<book-isbn>978-4-86396-185-2</book-isbn>
-							<book-amazon asin="4863961855" image-id="61qA-fNB+ZL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.41: 「グッドスマイル&amp;カラオケの鉄人カフェ」（秋葉原）の店内写真。等身大パネルやフィギュア。</p>
-									<p>pp.46-48: <em>「痛車のいる風景」</em>メルセデス・ベンツ コネクション（東京・六本木）で展示中の「まどマギ・魔法少女バージョン」のスマート痛車の紹介。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年5月号</book-name>
-							<book-release>2012-03-30</book-release>
-							<book-amazon asin="B007JWOBKC" image-id="61UP6fu6hSL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.53-54: 「ついに発売!! 『魔法少女まどか☆マギカ ポータブル』」虚淵玄インタビュー、劇団イヌカレーお祝いイラスト。</p>
-									<p>p.129: 『魔法少女まどか☆マガキ』×『俺妹』コラボレーションブロック崩し。（※"マガキ"との誤記）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>電撃G's magazine　2012年5月号</book-name>
-							<book-release>2012-03-30</book-release>
-							<book-amazon asin="B007IV4RLW" image-id="61+QTjeMi+L" width="132" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか&amp;ほむら（原画: 青木雄）。</p>
-									<p>pp.22-31: <em>巻頭特集「魔法少女まどか☆マギカ」</em>「魔法少女まどか☆マギカ ポータブル」情報、本誌専用カスタムテーマ、関係者インタビュー。</p>
-									<p>付録: フォトスタンドクロック（水着のまどか&amp;マミ）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>カイト　Vol.4</book-name>
-							<book-release>2012-03-30</book-release>
-							<book-isbn>978-4-86225-823-6</book-isbn>
-							<book-amazon asin="4862258239" image-id="51QvtFSIlcL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.6-12: <em>「小池一夫×虚淵玄 『魔法少女まどか☆マギカ』の世界とキャラクターを語る!」</em><a href="https://live.nicovideo.jp/watch/lv77366564" class="htmlbuild-host">ニコニコ生放送で2012年1月29日に行われた対談</a>の書き起こし。キャラクターの命名、1〜3話の構成の根拠、世界観をキャラクター化（キュゥべえ）したこと、執筆にあたり影響を受けた作品など。</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>2013年発行の<a href="https://www.amazon.co.jp/dp/4862258654/" class="htmlbuild-host htmlbuild-amazon-associate">「小池一夫対談集　キャラクター60年」</a>に再録。</li>
-								</ul>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>電撃PlayStation　Vol.515</book-name>
-							<book-release>2012-03-29</book-release>
-							<book-amazon asin="B007JWOCB0" image-id="61RJ1abCTKL" width="131" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.16-23: <em>『魔法少女まどか☆マギカ ポータブル』攻略特集第1弾。</em>アニメ準拠ルートとマミルートの攻略記事、富澤祐介×虚淵玄×土居由直インタビュー（前号の続き）。魔女同士が戦う案があった（ボツになった）、魔女のイメージ自体はアニメ制作段階から（劇団イヌカレーの中では）あったらしい、など。</p>
-									<p>付録: 『魔法少女まどか☆マギカ ポータブル』特大B2ポスター（前号の表紙イラスト）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.8.2 （アニソン クリエイターズⅡ）</book-name>
-							<book-release>2012-03-24</book-release>
-							<book-isbn>978-4-7897-7161-0</book-isbn>
-							<book-amazon asin="478977161X" image-id="51I1p7pbM-L" width="110" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 鹿目まどかの原画（10話で芸術家の魔女に矢を放つカット）。</p>
-									<p>表2: 「劇場企画進行中」広告。「アニメ コンテンツ エキスポ 2012」情報。</p>
-									<p>p.12: 「[特集1] 梶浦由記」で表紙と同じまどかのイラストが掲載。</p>
-									<p>p.24: 「梶浦由記の音楽が聴けるアニメ23本!」で『まどか☆マギカ』あり（BD6巻のジャケットイラスト）。</p>
-									<p>p.69: 渡辺翔のインタビュー「新進気鋭の意外な音楽遍歴」で「コネクト」の歌詞の話題。</p>
-									<p>p.150: 編集後記の背景にオープニングの走る鹿目まどかの原画（本文での言及はなし）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン DELUXE　Vol.18</book-name>
-							<book-release>2012-03-22</book-release>
-							<book-isbn>978-4-05-606596-1</book-isbn>
-							<book-amazon asin="4056065969" image-id="61No04eVpPL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.24-30: <em>「2大アニメ特集 IS&lt;インフィニット・ストラトス&gt;&amp;魔法少女まどか☆マギカ特集」</em>で版権絵7枚掲載。</p>
-									<p>p.94: 本号掲載作品の紹介。BD&amp;DVD6巻ジャケット、1話と12話の場面カット掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年4月号</book-name>
-							<book-release>2012-03-10</book-release>
-							<book-amazon asin="B007EWCJ42" image-id="51Y1W7ZI24L" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.127-134: 「第6回声優アワード　受賞者大発表!」（主演女優賞: 悠木碧、助演女優賞: 加藤英美里）両名ともコメント掲載。</p>
-									<p>付録: NEWTYPE SCHOOL CALENDAR 2012-2013（10-11月「魔法少女まどか☆マギカ」マミ、まどか、さやか イラスト: 松本元気）。</p>
-									<p>とじこみ付録: NEWTYPE SCHOOL CALENDAR 2012-2013 スペシャルシール（キュゥべえ、まどか、ほむら、マミ、さやか、杏子）。</p>
-									<p><a href="https://www.youtube.com/watch?v=oybwMQcSgyI" class="htmlbuild-host">発売CM</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>コンプティーク　2012年4月号</book-name>
-							<book-release>2012-03-10</book-release>
-							<book-amazon asin="B007C7QR2Y" image-id="61FbbpscGwL" width="129" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.112-115: <em>『魔法少女まどか☆マギカ ポータブル』紹介記事。</em>富澤祐介（バンダイナムコゲームズ）×土居由直（ニトロプラス）の対談。虚淵玄メッセージではゲームのエピソードは映画との関連性はないこと、アニメとの整合性は要求されていないこと、監修のポイントはキャラクターの性格や口調にまつわる部分だったことなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>電撃PlayStation　Vol.514</book-name>
-							<book-release>2012-03-08</book-release>
-							<book-amazon asin="B007D2OO5A" image-id="6123sEjSCaL" width="132" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: まどか、ほむら、キュゥべえ（イラスト: 守岡英行）</p>
-									<p>pp.16-25: <em>『魔法少女まどか☆マギカ ポータブル』特集。</em>ほむらルート、ボーナスルートの詳細、富澤祐介×虚淵玄×土居由直インタビュー。2011年1月のマチ★アソビで富澤が土居に話をして2月中旬くらいに企画書を渡した、新規に登場する魔女もすべて劇団イヌカレーによるデザイン、必殺技や魔法の名前は虚淵が考えた、など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>電撃G's magazine　2012年4月号</book-name>
-							<book-release>2012-02-29</book-release>
-							<book-amazon asin="B007AHRGB2" image-id="61Bk9VlReyL" width="131" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.58-89: 「俺の妹がこんなに可愛いわけがない×魔法少女まどか☆マギカ　着せ替えブロック崩し」のコラボ衣装掲載。</p>
-									<p>pp.60-65: 「魔法少女まどか☆マギカポータブル」の特集記事。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2012年4月号</book-name>
-							<book-release>2012-02-29</book-release>
-							<book-amazon asin="B00792TZLW" image-id="61VkD4huXHL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.21-22: ピンナップ: 水着さやか、杏子（潮月一也）。</p>
-									<p>p.111: 『魔法少女まどか☆マギカ ポータブル』発売情報。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年3月号</book-name>
-							<book-release>2012-02-10</book-release>
-							<book-amazon asin="B0072IBYTO" image-id="61hl-r5TsGL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.197: 「新房昭之の恐縮ですが……」で2011年の振り返りとして、3話連続放送や芸能人が言及した例の紹介など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年3月号</book-name>
-							<book-release>2012-01-30</book-release>
-							<book-amazon asin="B006YXYMGU" image-id="61IjBYretsL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.95-96: 「魔法少女まどか☆マギカ ポータブル」さやかルートの情報など。</p>
-									<p>別冊付録: 眼鏡ほむら&amp;キュゥべえのバレンタインイラストB2ポスター（原画: 中村直人）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>電撃PlayStation　Vol.511</book-name>
-							<book-release>2012-01-26</book-release>
-							<book-amazon asin="B006WP6ETS" image-id="515l9vx6pCL" width="130" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.84-85: 『魔法少女まどか☆マギカ ポータブル』情報。さやかルートの詳細、斎藤千和、加藤英美里のコメント。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.08</book-name>
-							<book-release>2012-01-25</book-release>
-							<book-isbn>978-4-7897-7157-3</book-isbn>
-							<book-amazon asin="4789771571" image-id="51Yx588dFML" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.120: 「リスアニ! が振り返る2011年アニメ・アニソンシーン」で『まどか☆マギカ』も掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.10</book-name>
-							<book-release>2012-01-25</book-release>
-							<book-amazon asin="B006QAQ0UC" image-id="516TJyLsLuL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.88: 「新房語」大澤信博がゲスト。途中『まどか☆マギカ』の話題になり、『まどか☆マギカ』のヒットは時代が生んだ偶然の産物であること、大澤は千葉県柏市のコラボカフェに行ったこと、キュゥべえのファンであること、などを話す。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>かつくら　Vol.1　2012冬</book-name>
-							<book-release>2012-01-24</book-release>
-							<book-amazon asin="4775309854" image-id="61c+WGERDXL" width="117" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.53-54: <em>「虚淵玄インタビュー」</em>で『Fate/Zero』と共に『まどか☆マギカ』の話も。脚本家の領分が他のアニメとは違い、放任されていて、変更されるときは現場の判断で変えず自分に戻ってきたこと（最終イメージを脚本家に委ねる）、続編（新編）の制作時はTVシリーズとは異なり監督やプロデューサーもストーリーの確固たる希望があったこと、結末の受け止め方が自分と新房監督でずれていたから、そのずれを埋める発想で続きを生み出せたことなど。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>SWITCH　Vol.30　No.2</book-name>
-							<book-release>2012-01-20</book-release>
-							<book-isbn>978-4-88418-329-5</book-isbn>
-							<book-amazon asin="4884183290" image-id="511jhxCmNrL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.38-39: 仁井将人（DeNAプロデューサー）のインタビュー。「Mobage」でのソーシャルゲーム化について。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2012年2月号</book-name>
-							<book-release>2012-01-10</book-release>
-							<book-amazon asin="B006OAKE2E" image-id="61pLXFK7VJL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.7-8: 制服まどか、ほむら、メガネほむらのピンナップ（イラスト: 牧孝雄）。</p>
-									<p>付録: クリアファイル2枚セット。</p>
-									<p><a href="https://www.youtube.com/watch?v=hBodT8Gsdl0" class="htmlbuild-host">発売CM</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2012年2月号</book-name>
-							<book-release>2012-01-10</book-release>
-							<book-amazon asin="B006OAKCHG" image-id="61QI+eiV6NL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>別冊付録: まどか、ほむら、マミ、さやか、杏子の版権イラスト（2012年1月号記事）のクリアファイル。</p>
+									<p>付録: 「ドキッ! 丸ごと水着! 描き下ろしだらけのB1カレンダー2013」に水着まどか、ほむら（山村洋貴）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 					</section>
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
-							<h2>2011年</h2>
+							<h2>2013年</h2>
 						</div>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>電撃PlayStation　Vol.509</book-name>
-							<book-release>2011-12-22</book-release>
-							<book-amazon asin="B006K1TZZ4" image-id="51gPdFI77XL" width="129" height="160"></book-amazon>
+							<book-name>ニュータイプ　2013年2月号</book-name>
+							<book-release>2013-01-10</book-release>
+							<book-amazon asin="B00ARJ2ESK" image-id="51IfYsvmWUL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.62-65: 『魔法少女まどか☆マギカ ポータブル』情報。マミルートの詳細、限定契約BOXのクリアカードイラスト公開、12月に収録された「お菓子が食べられたら嬉しいなって」の収録レポート。クリアプレートコレクション、「魔法少女まどか☆マギカ iP」配信情報。</p>
+									<p>付録: アルティメットまどか&amp;まどか&amp;ほむら&amp;マミ&amp;さやか&amp;杏子のB3ポスター（寺尾洋之）。</p>
+									<p><a href="https://www.youtube.com/watch?v=PyJhZLibcQE" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>Cut　2012年1月号</book-name>
-							<book-release>2011-12-19</book-release>
-							<book-amazon asin="B006GCXLQ6" image-id="51MVtWOc59L" width="124" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.5　2013年3月号</book-name>
+							<book-release>2013-02-08</book-release>
+							<book-amazon asin="B00AYRDECK" image-id="615KX+knBjL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.46:「2011年、TVアニメは何を革命したのか？」（TVシリーズからのカット数点）</p>
-									<p>pp.60-63: <em>「なぜアニメはいま、『まどか☆マギカ』を必要としたのか?」（新房昭之インタビュー）</em> ストーリー主義的なものとして作ったつもりがキャラクターも受け入れられたこと、キュゥべえは『スタートレック』（アメリカのSFテレビドラマ）のスポットのイメージだったこと、劇場版は最初はTVシリーズの『2』をやる話だったことなど。</p>
+									<p>表紙: まどか、ほむら（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「となりには、いつもまどか。」（※背表紙は「となりにはいつもまどか」）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>B.L.T.　2012年2月号</book-name>
-							<book-release>2011-12-16</book-release>
-							<book-amazon asin="B006IAZA4W" image-id="61Dlcm49EfL" width="112" height="160"></book-amazon>
+							<book-name>アニメージュ　2013年3月号</book-name>
+							<book-release>2013-02-09</book-release>
+							<book-amazon asin="B00B2OLV9W" image-id="61mMknc3iYL" width="127" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.156: 「祝!!成人式 悠木碧」劇場版制作決定を受けてのコメント。続編の話はちょうど作品が終わった頃に聞いた。</p>
+									<p>pp.146-149: 「この人に話を聞きたい 第百五十二回」谷口淳一郎顔出しインタビュー。『まどか☆マギカ』についての話（p.148）では、キャラクターデザイン（岸田隆宏）と作画の違い、シャフトの作業の特異性、劇場版での作画の変化などが語られる。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>季刊エス　2012年冬号（第37号）</book-name>
-							<book-release>2011-12-15</book-release>
-							<book-amazon asin="B006E515M2" image-id="61MichkwUjL" width="122" height="160"></book-amazon>
+							<book-name>メガミマガジン　2013年4月号</book-name>
+							<book-release>2013-02-28</book-release>
+							<book-amazon asin="B00BEZ37FK" image-id="61hAMIP6WbL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.72-77: <em>『魔法少女まどか☆マギカ』新房昭之インタビュー</em>　9話、10話の絵コンテ、10話まどほむ抱きつきシーンの原画掲載。</p>
+									<p>p.133: 「フィギュア★マイスター」でSQフィギュア〜美樹さやか〜の紹介。開発担当者コメント。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>日経エンタテインメント!　2013年4月号</book-name>
+							<book-release>2013-03-04</book-release>
+							<book-amazon asin="B00BI2YQHM" image-id="51TK2MOWwaL" width="120" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.111: 「第4回 ヒットメーカー・オブ・ザ・イヤー 2012〜2013」で「ブレイクスルー章」を受賞した岩上敦宏の紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>Cut　2013年4月号</book-name>
+							<book-release>2013-03-19</book-release>
+							<book-amazon asin="B00BNCAP04" image-id="51jL6nUOWlL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.66: [新編]紹介。「編集部も新しい何かを知っているわけではない」としつつ、これまでの関係者のコメントから「3本目の映画で物語は終わりません」（虚淵）、「本当は『インキュベーターの逆襲』というタイトルにしたかった」（新房）を紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン DELUXE　Vol.20</book-name>
+							<book-release>2013-03-28</book-release>
+							<book-amazon asin="B00BUSV1CW" image-id="51K6D9XxlcL" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.90: 手を繋いだアルティメットまどか、リボンほむらのイラスト（原画: 谷口淳一郎）。</p>
+									<p>p.93: イラスト掲載作品の紹介（前後編）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>うぶモード　2013年5月号</book-name>
+							<book-release>2013-04-09</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>p.66: 「宮台式幸福学対話篇 TALK#01 vs.虚淵玄」宮台真司と虚淵玄の対談。魔法少女ものの基本である「主人公である魔法少女が世界から愛されている」という前提をひっくり返してストーリーを作ったことなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.6　2013年5月号</book-name>
+							<book-release>2013-04-10</book-release>
+							<book-amazon asin="B00BJMAWXI" image-id="61HAAUlpADL" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、キュゥべえ（原画: 蒼樹うめ）</p>
+									<p>キャッチコピー: 「劇場版 魔法少女まどか☆マギカ [新編]叛逆の物語 2013年秋公開!!」（※背表紙は「[新編]叛逆の物語 2013年秋公開!!」）</p>
+									<p>付録: 表紙イラストホログラム下敷き</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2013年5月号</book-name>
+							<book-release>2013-04-10</book-release>
+							<book-amazon asin="B00C2BSDPO" image-id="51-LR4A039L" width="123" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.40-41: 「私たちの物語」まどか&amp;リボンほむらのイラスト（寺尾洋之）、[新編]の紹介記事。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>娘TYPE　2013年6月号</book-name>
+							<book-release>2013-04-30</book-release>
+							<book-amazon asin="B00CF0UKBW" image-id="61JAtAUsY3L" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.5: 『[新編]叛逆の物語』公開情報。暁美ほむらビジュアル掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2013年6月号</book-name>
+							<book-release>2013-04-30</book-release>
+							<book-amazon asin="B00CAZDFKU" image-id="61BG13IN7NL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.46: [新編]情報。</p>
+									<p>p.94: ACEでの「『劇場版 魔法少女まどか☆マギカ』ステージ」レポート。</p>
+									<p>pp.116-117: 「『魔法少女まどか☆マギカ』プライズグッズのお部屋」、加藤英美里によるSQフィギュア（杏子）や各種キュゥべえグッズの紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>うぶモード　2013年6月号</book-name>
+							<book-release>2013-05-09</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>p.42: 「宮台式幸福学対話篇 TALK#02 vs.虚淵玄」宮台真司と虚淵玄の対談。最終話のまどかの選択は一神教よりも多神教的な解釈であること、『幼少期の終わり』（アーサー・C・クラーク）との関連、『エヴァンゲリオン』との対比など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>うぶモード　2013年7月号</book-name>
+							<book-release>2013-06-07</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>p.42: 「宮台式幸福学対話篇 TALK#03 vs.虚淵玄」宮台真司と虚淵玄の対談。不登校新聞社発行の「Fonte」に寄稿した生死感に関する話題など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.7　2013年7月号</book-name>
+							<book-release>2013-06-10</book-release>
+							<book-amazon asin="B00CPRCP0Y" image-id="61BxuO87CoL" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、さやか、杏子 他（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「まどかといれば、笑顔。」（※背表紙は「[前編]&amp;[後編]BD&amp;DVD 2013年7月24日発売!!」）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2013年8月号</book-name>
+							<book-release>2013-07-10</book-release>
+							<book-amazon asin="B00DMCSAXW" image-id="518RhMjWgQL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.42-43: 「あなたの希む世界に……」鉄塔にたたずむほむら&amp;まどか&amp;キュゥべえのイラスト（坂本一也）、[新編]の紹介記事。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>smart　2013年9月号</book-name>
+							<book-release>2013-07-24</book-release>
+							<book-amazon asin="B00DP3I8UI" image-id="61MML2jUOSL" width="115" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.67-72: 生駒里奈（乃木坂46）と松井玲奈（SKE48）がそれぞれまどか、ほむらのコスプレをしてのインタビュー、新編公開情報、前後編DVD&amp;BD情報、ムック本「魔法少女まどか☆マギカ LOVE!」発売情報。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>娘TYPE　2013年9月号</book-name>
+							<book-release>2013-07-30</book-release>
+							<book-amazon asin="B00DUZABPQ" image-id="51TXGUBhWjL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.74: 次号予告。新編第1弾キービジュアル（ほむら）。</p>
+									<p>p.88: 新編情報。第1弾前売り鑑賞券。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2013年9月号</book-name>
+							<book-release>2013-07-30</book-release>
+							<book-amazon asin="B00DVMU93M" image-id="61V2Dd35Y5L" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.99: <em>「進撃の美人たち」</em> [新編] の紹介記事。</p>
+									<p>p.113: 「劇場版まどか☆マギカ【番外編】宝物語」<a href="http://1kuji.bpnavi.jp/item/558" class="htmlbuild-host">一番くじ 劇場版 魔法少女まどか☆マギカ</a>のきゅんキャラびねっと紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>うぶモード　2013年8月号</book-name>
+							<book-release>2013-08-01</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>p.42: 「宮台式幸福学対話篇 TALK#04 vs.虚淵玄」宮台真司と虚淵玄の対談。まどかとほむらの対比、"幸福"の価値観に関する話題など。虚淵曰く、ほむら的な生き方よりまどか的な生き方の方が断然幸せ。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>日経エンタテインメント!　2013年9月号</book-name>
+							<book-release>2013-08-03</book-release>
+							<book-amazon asin="B00DYWNVMU" image-id="51cUh6THkUL" width="117" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.26-27: 「アニメ・アニソン・声優の新常識30」記事内で『まどか☆マギカ』の名も挙がる。新編第1弾キービジュアル掲載。</p>
+									<p>pp.124-125: Japan Expo 2013 の記事で UltraBook のコラボPCが紹介。展示ブースでの記念写真掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>MdN　2013年9月号</book-name>
+							<book-release>2013-08-06</book-release>
+							<book-amazon asin="B00GD3NX70" image-id="61iIdX61OGL" width="121" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.50: TV版、劇場版、[新編]の3タイプのロゴについて、染谷洋平によるコメント。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.8　2013年9月号</book-name>
+							<book-release>2013-08-09</book-release>
+							<book-amazon asin="B00DWAANC0" image-id="61oJgZSeCjL" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、ほむら、さやか、キュゥべえ（イラスト: 浜弓場双）</p>
+									<p>キャッチコピー: 「準備はいい――？」（※背表紙は「[新編]叛逆の物語 10月26日(土)公開!!」）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2013年9月号</book-name>
+							<book-release>2013-08-10</book-release>
+							<book-amazon asin="B00E3W4KXY" image-id="61WbgRMqQhL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.148: 「新房昭之の恐縮ですが……」で草川啓造との対談。TVシリーズで脚本が仕上がってから、実際に制作が始まるまで時間が空いたことが紹介。</p>
+									<p>pp.168-171: <em>「あなたに会いたい。」</em>新房昭之×虚淵玄のインタビュー。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>娘TYPE　2013年10月号</book-name>
+							<book-release>2013-08-30</book-release>
+							<book-amazon asin="B00ED1QZ0Q" image-id="51-qBOKGJyL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 水着のまどか&amp;ほむら（原画: 篠原健二）</p>
+									<p>pp.28-31: <em>「PRELUDE...」</em>[新編]紹介記事。新房昭之×虚淵玄のインタビュー、ClariS、Kalafinaのメッセージ。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2013年10月号</book-name>
+							<book-release>2013-08-30</book-release>
+							<book-amazon asin="B00EDR7TBY" image-id="61mcyeC2DGL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.25-26: アルティメットまどか&amp;さやかのピンナップポスター（石原恵治）</p>
+									<p>p.44: 新編情報、「Loppi限定描き下ろし前売り券」イラスト掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2013年10月号</book-name>
+							<book-release>2013-09-10</book-release>
+							<book-amazon asin="B00ENMGQWW" image-id="510WEUEc79L" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.69: [新編] の紹介「待つのは希望か、それとも――。」（第2弾キービジュアル）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2013年10月号</book-name>
+							<book-release>2013-09-10</book-release>
+							<book-amazon asin="B00ET8MVJC" image-id="6199qxdSc3L" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>別冊付録: 「マジカル☆ニュータイプ」[新編]情報、新房昭之×草川啓造×大沼心の座談会。</p>
+									<p><a href="https://www.youtube.com/watch?v=4HbAjF77XmM" class="htmlbuild-host">発売CM</a></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>KERA　2013年11月号</book-name>
+							<book-release>2013-09-14</book-release>
+							<book-amazon asin="B00EZ6M9TK" image-id="515HAqAeg-L" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.146: 「劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語を先どり」斎藤千和インタビュー。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>シアターカルチャーマガジンT. [ティー.]　2013 AUTUMN　No.23</book-name>
+							<book-release>2013-09-20</book-release>
+							<book-amazon asin="B00G4V9BNQ" image-id="514eoi7pj-L" width="109" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>裏表紙: [新編]のほむら原画。</p>
+									<p>pp.113-102: <em>「アニメ界に波紋を呼ぶ、新たな伝説「劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語」」</em>悠木碧と斎藤千和のインタビュー、シャフト社内風景、後編の絵コンテ掲載（9話パート杏子「独りぼっちは」、10話パートほむら「くり返す私は何度でも」、キュゥべえ「僕と契約して」）。</p>
+									<p>pp.103-102: 新房昭之インタビュー。最初の脚本からまどかの出番を増やしたこと、TVシリーズ12話のまどほむ空間は『2001年宇宙の旅』の白い部屋のイメージがあったこと、作品に反映されなかった設定の話など。</p>
 								</div>
 
 								<ul class="p-notes">
-									<li>2019年発行の「新房昭之×シャフト　クロニクル」に再掲（原画、絵コンテは増減している）。</li>
+									<li>ページ番号が逆になっているのは、本記事のみ裏表紙から続く形で逆向きに読ませる作りになっているため。</li>
 								</ul>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>オトナアニメ年鑑2012</book-name>
-							<book-release>2011-12-14</book-release>
-							<book-isbn>978-4-86248-858-9</book-isbn>
-							<book-amazon asin="4862488587" image-id="51Qwlf600fL" width="113" height="160"></book-amazon>
+							<book-name>smart　2013年11月号</book-name>
+							<book-release>2013-09-24</book-release>
+							<book-amazon asin="B00EUGDIJ0" image-id="51UBhasoCSL" width="109" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: TVシリーズBlu-ray&amp;DVD第6巻パッケージイラスト。</p>
-									<p>pp.2-14: 「2011年のアニメシーンを振り返る」で2011年アニメの筆頭として紹介。</p>
-									<p>pp.26-29: <em>「オリジナルアニメはチャレンジであり賭けである」</em>岩上敦宏と神宮司学（アニプレックス宣伝プロデューサー）のインタビュー。オリジナルアニメについてや、読売新聞一面広告をはじめとする広報展開の話。</p>
-									<p>pp.30-33: 「新房昭之・幾原邦彦の“作家性”に耽溺する」で『まどか☆マギカ』と『輪るピングドラム』を例に両監督の画作りを検証した記事（文：廣田恵介）。</p>
+									<p>pp.172-175: 「BEAMS Tを着た魔法少女まどか☆マギカ」コラボTシャツを着たまどか、ほむらの描き下ろしイラスト（山村洋貴）と男女モデルの写真。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2012年1月号</book-name>
-							<book-release>2011-12-10</book-release>
-							<book-amazon asin="B0069SYU7G" image-id="61UNZzjKhSL" width="125" height="160"></book-amazon>
+							<book-name>SPA!　2013年10月1日号</book-name>
+							<book-release>2013-09-24</book-release>
+							<book-amazon asin="B00HWLIDTA" image-id="61XnwemisfL" width="122" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.10-11: 「劇場版 魔法少女まどか☆マギカ(仮)」と題して劇場プロジェクト情報。餅を食べる5人*キュゥべえのイラスト（原画: 伊東良明）、虚淵玄のコメント。</p>
+									<p>表紙: リボンほむら（原画: 中村直人）。</p>
+									<p>折込ポスター: 表紙イラスト、[新編]第1弾キービジュアル。</p>
+									<p>p.9: 「今週の顔」で虚淵玄の[新編]に関して「TV版終了の前から続編の話は出ていた」「（TV版の時に）新房さんにこのままではハッピーエンドにならないと言われたが、自分はハッピーエンドのつもりだった」などのコメント。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>クイック・ジャパン　Vol.99</book-name>
-							<book-release>2011-12-10</book-release>
-							<book-amazon asin="4778312929" image-id="51GilCO5B4L" width="112" height="160"></book-amazon>
+							<book-name>娘TYPE　2013年11月号</book-name>
+							<book-release>2013-09-30</book-release>
+							<book-amazon asin="B00F496IG2" image-id="611jKaUtG+L" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.114-117: 徹底特集「アニメこそリアルだ!」でTVシリーズのキービジュアルやキュゥべえのイラストが掲載。</p>
-									<p>pp.118-121: <em>「アニメはメジャーな娯楽になったのか?」</em>新房昭之インタビュー。3話でマミが喰われるシーンは、もし深夜放送でなければ子供にインパクトを与えられるように、もっと残酷な描写にしたかもしれないという話など。</p>
-									<p>pp.134-137: 「アニメの将来、テレビの未来」で岩上敦宏×山本幸治（「ノイタミナ」編集長）の対談。ストーリー性が濃い作品にもかかわらず、キャラクターが二次創作で一人歩きした話題など。</p>
+									<p>p.92: 新編情報。主題歌情報、百江なぎさキャラクター紹介。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>日経エンタテインメント!　2012年1月号</book-name>
-							<book-release>2011-12-03</book-release>
-							<book-amazon asin="B00684UTBM" image-id="61-mzEmnvzL" width="119" height="160"></book-amazon>
+							<book-name>メガミマガジン　2013年11月号</book-name>
+							<book-release>2013-09-30</book-release>
+							<book-amazon asin="B00F496J52" image-id="61t7QPiH1HL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.30: 「2011年ヒット番付 TOP50」の39位に『まどか☆マギカ』。</p>
-									<p>pp.126-127: 「年間データバンク -2011 Hit Ranking-」で『まどか☆マギカ』の大ヒットに言及。「吉田尚記のアニメWiki」の号外という扱いで吉田尚記のコメントあり。</p>
+									<p>pp.4-5: <em>「NEW MEGA HEROINES SCOOP」</em>で [新編] の情報。百江なぎさの設定絵掲載。「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2012年1月号</book-name>
-							<book-release>2011-11-30</book-release>
-							<book-amazon asin="B0065LRMJ0" image-id="61o2dY3iO-L" width="123" height="160"></book-amazon>
+							<book-name>日経エンタテインメント!　2013年11月号</book-name>
+							<book-release>2013-10-04</book-release>
+							<book-amazon asin="B00F9CO5XW" image-id="61WcyXc-YSL" width="120" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.3-4: スケートをする5人とキュゥべえのイラストのピンナップポスター（原画: 潮月一也）。</p>
-									<p>p.27: 「萌えぴあ」劇場プロジェクト始動の記事。岩上敦宏のインタビュー（3本目の新作の脚本作業は終わっているとの発言）、虚淵玄とメインキャスト6人のコメント掲載。</p>
+									<p>p.53: 「1980's 90's 00's 名作遺産200」で『まどか☆マギカ』紹介（半ページほど）。新編第2弾キービジュアル、新編のナイトメア戦の場面カット（23m03s）、岩上敦宏の写真掲載。</p>
+									<p>p.117: 「声優核心バイオグラフィー!」（第4回）で悠木碧がゲスト。新編に関するコメント。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2012年1月号</book-name>
-							<book-release>2011-11-30</book-release>
-							<book-amazon asin="B0069SYUZI" image-id="61uv-lvsIKL" width="123" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.9　2013年11月号</book-name>
+							<book-release>2013-10-10</book-release>
+							<book-amazon asin="B00EV9RMO8" image-id="61theKeMvuL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.53: 「2012年MOVIE WAVE」劇場版プロジェクト制作決定。TVシリーズの場面ショット複数掲載。</p>
-									<p>p.162: 鹿目まどかスケールフィギュア（グッドスマイルカンパニー）。</p>
-									<p>pp.193-194: ピンナップ: 水着まどか、ほむら（中村直人）。</p>
+									<p>表紙: まどか、ほむら（イラスト: 蒼樹うめ）</p>
+									<p>キャッチコピー: 「3カ月連続刊行スタート!!」（※背表紙は「[新編]公開直前―― 3カ月連続刊行開始!!」）</p>
+									<p>付録: 表紙イラストホログラム下敷き</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきららフォワード　2012年1月号</book-name>
-							<book-release>2011-11-24</book-release>
-							<book-amazon asin="B00629O220" image-id="61AIGmsLbYL" width="113" height="160"></book-amazon>
+							<book-name>Febri　Vol.19</book-name>
+							<book-release>2013-10-10</book-release>
+							<book-amazon asin="B00F08HEKQ" image-id="51oFwG3sMLL" width="109" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.3: 劇場化プロジェクト始動、ニュータイプ2011年12月号のイラスト掲載（アルまど、リボほむ、キュゥべえ）、蒼樹うめのコメント掲載。</p>
-									<p>pp.115-140: 『かずみ☆マギカ』第11話</p>
+									<p>p.114: 「新房語」大嶋実句（シャフト）がゲスト。[新編]の実写弁当はシャフト社内で制作し、ソウルジェムはうずらの卵で作ったことなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年12月号</book-name>
-							<book-release>2011-11-10</book-release>
-							<book-amazon asin="B006071CUY" image-id="51-3EJ4SDTL" width="126" height="160"></book-amazon>
+							<book-name>アニメディア　2013年11月号</book-name>
+							<book-release>2013-10-10</book-release>
+							<book-amazon asin="B00FA4Q4TW" image-id="612wht0mr4L" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p><em>劇場プロジェクト発表</em></p>
-									<p>表紙: アルティメットまどか、リボンほむら、キュゥべえのイラスト（蒼樹うめ）。</p>
-									<p>pp.16-23: <em>「魔法少女達の伝説」</em>ほむら&amp;さやか&amp;杏子&amp;マミのイラスト（潮月一也）、新房昭之×蒼樹うめ×虚淵玄×岩上敦宏のインタビュー、庵野秀明、佐孝仁司、松井玲奈のコメント。</p>
-									<p>pp.202-205: <a href="https://webnewtype.com/special/animeaward/2011/" class="htmlbuild-host">ニュータイプアニメアワード2011</a>（12冠達成）。</p>
-									<p><a href="https://www.youtube.com/watch?v=6HgSGpiCjHc" class="htmlbuild-host">発売CM</a></p>
+									<p>pp.120-121: 「運命への叛逆が導くのは希望か絶望か」 [新編] 特集記事。第3弾キービジュアル。斎藤千和、阿澄佳奈のコメント。スマートフォンアプリ「嫁コレ」紹介。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>日経エンタテインメント!　2011年12月号</book-name>
-							<book-release>2011-11-04</book-release>
-							<book-amazon asin="B005WK92K2" image-id="61eOE1ENMyL" width="120" height="160"></book-amazon>
+							<book-name>ニュータイプ　2013年11月号</book-name>
+							<book-release>2013-10-10</book-release>
+							<book-amazon asin="B00FAS9062" image-id="51ooYdimYeL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.32: 「マチ★アソビ」で展示された5人の等身大パネルの写真。</p>
-									<p>p.47: 「吉田尚記のアニメWiki」でクリエイターの話。虚淵玄を「オタクオブオタク」と評す。</p>
-									<p>pp.50-51: 松井玲奈（SKE48）のインタビューで『まどか』のヒロインのイメージカラーを表現するときに使われる光の描写が『さよなら絶望先生』で桜が出てくるシーンとそっくりという話。</p>
+									<p>表紙: リボンほむら（原画: 谷口淳一郎）。</p>
+									<p>pp.14-23: <em>「The Only Neat Thing To Do」</em>リボンほむらのイラスト（谷口淳一郎、表紙とは別物）、新房昭之×虚淵玄、阿澄佳奈、加藤英美里、西尾維新×虚淵玄のインタビュー。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン リリィ（2011年12月号別冊）</book-name>
-							<book-release>2011-10-31</book-release>
-							<book-amazon asin="B005WWJPD4" image-id="61JHxfrb6GL" width="114" height="160"></book-amazon>
+							<book-name>Cut　2013年11月号</book-name>
+							<book-release>2013-10-19</book-release>
+							<book-amazon asin="B00FK9ZX1W" image-id="51aArRaipcL" width="123" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.70-77: 「少女たちの輝かしき友情[非日常編]」寝間着姿のまどか＆ほむら描き下ろしイラスト（作画: 本八幡忠三）、TVシリーズのストーリーダイジェスト。</p>
+									<p>pp.74-81: <em>「『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』2号連続徹底特集、第1弾!」</em>悠木碧インタビュー、斎藤、加藤、喜多村、野中へのアンケート。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年12月号</book-name>
-							<book-release>2011-10-29</book-release>
-							<book-amazon asin="B005V0RFB6" image-id="61CDvMtCN1L" width="124" height="160"></book-amazon>
+							<book-name>SWITCH　2013年11月号　Vol.31　No.11</book-name>
+							<book-release>2013-10-20</book-release>
+							<book-isbn>978-4-88418-350-9</book-isbn>
+							<book-amazon asin="4884183509" image-id="51+HP1pbLgL" width="117" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.29: 「新作アニメカットに新ビジュアル PSP版『まどマギ』最新情報大公開!」描き下ろしキービジュアル公開、ほむらルート発表など。</p>
-									<p>pp.49-50: さやか、杏子、キュゥべえのピンナップポスター（原画: 潮月一也）。</p>
+									<p>pp.98-103: <em>「新房昭之 [オーバーランも辞さない覚悟]」</em> 公開間近の新編に関するインタビュー。時系列として前後編の続きであること、絵コンテの段階でシナリオからかなり膨らんだこと、劇団イヌカレーにオファーを出した経緯など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>DENGEKI PSP　Vol.3</book-name>
-							<book-release>2011-10-21</book-release>
-							<book-amazon asin="B005UHZ2LA" image-id="61ZgaN5beCL" width="131" height="160"></book-amazon>
+							<book-name>週刊スピリッツ　2013年11月4日号　No.47</book-name>
+							<book-release>2013-10-21</book-release>
+							<book-amazon asin="B00FOVYSH6" image-id="51rjSFGD4NL" width="108" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 鹿目まどか（『魔法少女まどか☆マギカ ポータブル』の立ち絵）。</p>
-									<p>pp.3-11: <em>「巻頭特集 魔法少女のススメ」</em>魔法少女まどか☆マギカ ポータブル情報。</p>
-									<p>綴込付録: 『魔法少女まどか☆マギカ ポータブル』のデコレーションステッカー（鹿目まどか、マミのドキドキ ティロ・フィナーレ）。</p>
-									<p>p.81: 読者プレゼントにカラコレ（ムービック）。</p>
+									<p>表紙: まどかとほむらのコスプレ写真。</p>
+									<p>pp.3-7: 上間美緒（女優）、秋本帆華（チームしゃちほこ）による、版権イラストを元にしたコスプレ写真3枚。</p>
+									<p>p.10: 上間、秋本インタビュー。コスプレ撮影や作品の感想など。</p>
+									<p>折り込み: ポストカード（水着姿の魔法少女5人）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ユリイカ　2011年11月臨時増刊号（総特集: 魔法少女まどか☆マギカ―魔法少女に花束を）</book-name>
-							<book-release>2011-10-20</book-release>
-							<book-isbn>978-4-7917-0229-9</book-isbn>
-							<book-amazon asin="4791702298" image-id="518g5f7ujQL" width="103" height="160"></book-amazon>
+							<book-name>smart　2013年12月増刊号　No.288</book-name>
+							<book-release>2013-10-24</book-release>
+							<book-amazon asin="B00FOVYR36" image-id="619sF7mr0JL" width="110" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.24-38: 「この世でひとつだけの、かけがえのない絆」悠木碧×斎藤千和の対談。まどかとほむらの関係性やそれぞれの行動分析、オーディション時の話など。</p>
-									<p>pp.52-73: 「『まどか☆マギカ』へ至る道」虚淵玄×田中ロミオの対談。</p>
-									<p>その他、ライターなどによる考察記事、漫画家やイラストレーターによるイラスト寄稿などで構成。</p>
+									<p>表紙: 暁美ほむら&amp;キュゥべえ（作画: 中村直人）。</p>
+									<p>pp.174-179: 「著名人&amp;ファッション業界人ファンが語りつくす! [新編]ストーリーも大予想! 『魔法少女まどか☆マギカ』」（松井玲奈、サンキュータツオ、ほか）、悠木碧への一問一答など。</p>
+									<p>付録1: 描き下ろしクリアファイル（表紙イラスト、中村直人）。</p>
+									<p>付録2: 魔法少女大集合ステッカー（p.90とp.91の間に挟み込み）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年11月号</book-name>
-							<book-release>2011-09-30</book-release>
-							<book-amazon asin="B005MZI22G" image-id="61BCyP2TgWL" width="125" height="160"></book-amazon>
+							<book-name>デジモノステーション　2013年12月号</book-name>
+							<book-release>2013-10-25</book-release>
+							<book-amazon asin="B00FL2T4YA" image-id="61tDfcB6HcL" width="119" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.17-18: 弓道をするまどか、ほむらのイラスト（原画: 中村直人）。</p>
-									<p>p.128: 『魔法少女まどか☆マギカ ポータブル』情報。まどか、さやか、杏子、マミのキャラクター画像など。</p>
+									<p>pp.174-177: 「ビジョメガネSP まどか&amp;ほむら」眼鏡を掛けたまどか、ほむらの描き下ろしイラスト（原画: 中村直人）、「”まどか☆マギカ”を知る15のアレコレ」。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン DELUXE　Vol.17</book-name>
-							<book-release>2011-09-30</book-release>
-							<book-amazon asin="B005POI8ZA" image-id="61aVdVwkDeL" width="112" height="160"></book-amazon>
+							<book-name>リスアニ!　Vol.15</book-name>
+							<book-release>2013-10-30</book-release>
+							<book-isbn>978-4-7897-7201-3</book-isbn>
+							<book-amazon asin="4789772012" image-id="51yh6r1HwHL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>とじ込み付録: まどか&amp;ほむらのイラスト（原画: 滝山真哲）。</p>
-									<p>pp.17-29: 版権絵12枚収録（アニメディアとメガミマガジンからの再録）。</p>
+									<p>表紙: まどか、ほむら（潮月一也）</p>
+									<p>pp.6-29: <em>「[特集1] 劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語 "物語は奏で音楽は語る"」</em>ClariSインタビュー、渡辺翔インタビュー（[新編]のシナリオを知らずに歌詞を書いたこと、リテイク箇所など）、Kalafinaインタビュー（“銀の庭”の意味など）、梶浦由記×鶴岡陽太インタビュー。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>電撃PlayStation　Vol.503</book-name>
-							<book-release>2011-09-29</book-release>
-							<book-amazon asin="B005MRM0ZE" image-id="61pmnoiQgmL" width="130" height="160"></book-amazon>
+							<book-name>娘TYPE　2013年12月号</book-name>
+							<book-release>2013-10-30</book-release>
+							<book-amazon asin="B00FQPJPLO" image-id="61swYkUbu0L" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.54-55: 『魔法少女まどか☆マギカ ポータブル』紹介。</p>
-									<p>pp.56-57: 「figma 鹿目まどか 制服バージョン」に関する対談。富沢祐介（バンダイナムコゲームス）×金子雅文（マックスファクトリー）×秋山拓郎（グッドスマイルカンパニー）。</p>
+									<p>表紙: 制服の眼鏡ほむら&amp;杏子（原画: 中村直人）</p>
+									<p>pp.32-37: <em>「魔法少女は魔女の夢を見るか？」</em>[新編]の紹介記事、斎藤千和×野中藍のインタビュー、宮本幸祐、悠木碧、喜多村英梨、水橋かおりのコメント、「劇場版 魔法少女まどかマギカ The Battle Pentagram」の紹介。</p>
+									<p>付録: 水着のまどか&amp;ほむらのB2ポスター（2013年10月号表紙イラスト）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.8</book-name>
-							<book-release>2011-09-24</book-release>
-							<book-amazon asin="B005GTJJZW" image-id="51a9YxOXbCL" width="113" height="160"></book-amazon>
+							<book-name>電撃G's magazine　2013年12月号</book-name>
+							<book-release>2013-10-30</book-release>
+							<book-amazon asin="B00FSQ9WDW" image-id="61BrjH19YkL" width="129" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.84-89: <em>「新房語」（第8回）</em>鈴木博文（EDアニメーション担当）がゲスト。EDで紙を一枚も使わずタブレットで描いた（鈴木）、魔女空間は劇団イヌカレーにお願いしたが発想の原点は『コゼット』だった（新房）、最初はEDに魔女を12〜13体出そうと思っていた（鈴木）、最後に出てくる「もやもやした光」は一瞬キュゥべえになるつもりで描いた（鈴木）、DVDではマミが食べられる音をリアルな音にするアイデアも音響サイドからあった（新房）など。</p>
+									<p>表紙: 鹿目まどか（原画: 住本悦子）。</p>
+									<p>pp.28-39: <em>「劇場版魔法少女まどか☆マギカ」</em>[新編]情報、悠木碧インタビュー、「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。</p>
+									<p>付録: にいてんご 暁美ほむら 水着Ver. フィギュア</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ゲームラボ　2011年10月号</book-name>
-							<book-release>2011-09-16</book-release>
-							<book-amazon asin="B005K9UDX0" image-id="61XsQcw4jtL" width="113" height="160"></book-amazon>
+							<book-name>メガミマガジン　2013年12月号</book-name>
+							<book-release>2013-10-30</book-release>
+							<book-amazon asin="B00FRMSZTY" image-id="61aDu+kndPL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.138: 夏コミでの「ティロ・フィナーレ本」（まどか屋さん）頒布が紹介。</p>
+									<p>表紙: マミ&amp;なぎさ（原画: 谷口淳一郎）。</p>
+									<p>pp.4-11: <em>「RESTART MAGICA」</em>水橋かおり×阿澄佳奈インタビュー、劇場グッズやコラボキャンペーンの紹介、「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」の紹介と富澤祐介プロデューサーのインタビューなど。</p>
+									<p>p.15: 表紙イラストの挟み込みポスター。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>コンプティーク　2011年10月号</book-name>
-							<book-release>2011-09-10</book-release>
-							<book-amazon asin="B005J5LR9E" image-id="61sFJIzME8L" width="130" height="160"></book-amazon>
+							<book-name>VOICE GIRLS　Vol.16</book-name>
+							<book-release>2013-10-31</book-release>
+							<book-isbn>978-4-86336-351-9</book-isbn>
+							<book-amazon asin="4863363516" image-id="51zocRTcuPL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.50-53: 『魔法少女まどか☆マギカ ポータブル』紹介記事。杏子以外の立ち絵、悠木碧と加藤英美里のコメントなど。</p>
+									<p>pp.16-17: 悠木碧インタビューで[新編]の話題（インタビューは公開前、本の発売は公開直後）。前半の収録から後半の収録まで間があったことなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>PLANETS SPECIAL 2011 夏休みの終わりに</book-name>
-							<book-release>2011-08-31</book-release>
-							<book-amazon asin="4905325021" image-id="41DPAb9gh3L" width="112" height="160"></book-amazon>
+							<book-name>MdN　2013年12月号</book-name>
+							<book-release>2013-11-06</book-release>
+							<book-amazon asin="B00GD3NX8Y" image-id="61pVWryIAUL" width="121" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.40-51: 「「父殺し（の不可能性）」から「父赦し」へ―3.11後の世界とその意味」（宮台真司）のインタビューの中で散発的に言及される。</p>
-									<p>pp.94-105: 「誌上ニコ生 PLANETS」で『まどか☆マギカ』特集（石岡良治×黒瀬陽平×坂上秋成+司会: 宇野常寛）。2011年5月4日に<a href="http://live.nicovideo.jp/watch/lv47398722" class="htmlbuild-host">ニコ生で放送された番組</a>の誌面版。冒頭に ramco によるイラスト掲載。</p>
+									<p>pp.40-41: 「終わりのあとの始まり 印刷の魔法をもう一度信じてみる?」で「劇場版 魔法少女まどか☆マギカ 総集編 Keyanimation ClearFile」の紹介（談: 浅見啓介）。</p>
+									<p><a href="https://books.mdn.co.jp/magazine/3213101012/" class="htmlbuild-host">公式ページ</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年10月号</book-name>
-							<book-release>2011-08-30</book-release>
-							<book-amazon asin="B005GW4SFU" image-id="61tTVwjICIL" width="125" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.10　2013年12月号</book-name>
+							<book-release>2013-11-08</book-release>
+							<book-amazon asin="B00FBKF5X6" image-id="61JmzqfCKML" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.30-32: <em>「『魔法少女まどか☆マギカ』PSPゲーム化、それはとってもうれしいなって」</em>ポータブル情報。土居由直×富澤祐介のインタビュー、キャラクター画像、変身シーンの紹介など。</p>
-									<p>折込B2ポスター: 浴衣姿の5人+キュゥべえのイラスト（原画: 中村直人）</p>
-									<p>別冊付録: <em>『魔法少女まどか☆マギカ』グッズコンプリートカタログ2011夏</em></p>
+									<p>表紙: さやか、杏子（イラスト: 蒼樹うめ）</p>
+									<p>キャッチコピー: 「3カ月連続刊行第2弾!!」（※背表紙は「[新編]叛逆の物語 絶賛公開中―!!」）</p>
+									<p>付録: 表紙イラストホログラム下敷き</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきららフォワード　2011年10月号</book-name>
-							<book-release>2011-08-24</book-release>
-							<book-amazon asin="B005EMLFFS" image-id="61OBGubBIhL" width="111" height="160"></book-amazon>
+							<book-name>アニメディア　2013年12月号</book-name>
+							<book-release>2013-11-09</book-release>
+							<book-amazon asin="B00G2FBWI6" image-id="61KXrLuOeYL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.3-4: 公式ガイドブック、アンソロジーコミック発売予告（表紙イラスト掲載）。『魔法少女まどか☆マギカ ポータブル』ゲーム化決定（悠木碧、加藤英美里コメント掲載）。Blu-ray&amp;DVD 6巻発売予告。</p>
-									<p>pp.109-134: 『かずみ☆マギカ』第8話</p>
+									<p>pp.40-41: 「映画館で味わおう　最高のお・も・て・な・し」宮本幸裕、谷口淳一郎、山村洋貴のコメント掲載。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>電撃PlayStation　Vol.500</book-name>
-							<book-release>2011-08-11</book-release>
-							<book-amazon asin="B005EYQ0SI" image-id="512ApLzflVL" width="130" height="160"></book-amazon>
+							<book-name>ニュータイプ　2013年12月号</book-name>
+							<book-release>2013-11-09</book-release>
+							<book-amazon asin="B00G4T7ULI" image-id="51QQoC2YAgL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.6-15: <em>「まどか☆マギカポータブル」</em>キャラクター紹介、アドベンチャーパート、ダンジョンパート紹介。土居由直（ニトロプラス）、富澤祐介（バンダイナムコゲームズ）のインタビュー。悠木碧、加藤英美里コメント。</p>
+									<p>pp.36-39: <em>「それは、わたしの願った世界」</em>加藤英美里、谷口淳一郎インタビュー。キャラデザの際、なぎさはまどか達と同世代バージョンと、幼い現バージョンがあったことなど。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年9月号</book-name>
-							<book-release>2011-08-10</book-release>
-							<book-amazon asin="B005ESIXNY" image-id="61NM7XRh7PL" width="125" height="160"></book-amazon>
+							<book-name>WHAT's IN?　2013年12月号</book-name>
+							<book-release>2013-11-14</book-release>
+							<book-amazon asin="B00GBB3S92" image-id="51R3efwEGpL" width="114" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.151: 「新房昭之の恐縮ですが……」で「ギャグ + 魔法少女作品」の話。久米田康治先生による魔法少女モノの提案や、「ひだまり☆マギカ」ネタなど。</p>
+									<p>p.110: 「君の銀の庭」リリースに関してのKalafinaインタビュー。梶浦由記の「この曲はある少女の空想の世界」という発言が Hikaru の口から語られる。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>idea 348（2011年9月号）</book-name>
-							<book-release>2011-08-10</book-release>
-							<book-amazon asin="B0057Y03XS" image-id="61g0Lh-V89L" width="121" height="160"></book-amazon>
+							<book-name>Cut　2013年12月号</book-name>
+							<book-release>2013-11-19</book-release>
+							<book-amazon asin="B00GDIKBPM" image-id="51klYF9MbeL" width="123" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.2-3: 染谷洋平の紹介。TV版ロゴ、BD/DVDパッケージ、コミック3作品表紙に関するコメント。</p>
+									<p>pp.38-43: <em>「『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』2号連続徹底特集、後編!」</em>新房昭之インタビュー。「（脚本の虚淵玄に対し）5人の魔法少女が一緒に行動するシーンを作るというのが一番のオーダー」「銃撃戦とかが派手になったのはコンテを描いてくれた笹木さんのお陰」など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年9月号</book-name>
-							<book-release>2011-07-30</book-release>
-							<book-amazon asin="B005C4HTOO" image-id="61ufrgQBNDL" width="125" height="160"></book-amazon>
+							<book-name>オトナアニメ　Vol.32</book-name>
+							<book-release>2013-11-27</book-release>
+							<book-isbn>978-4-8003-0284-7</book-isbn>
+							<book-amazon asin="4800302846" image-id="51lp2mu1XfL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>折込ロングポスター: 水着さやか（原画: 中村直人）、水着杏子（原画: 潮月一也）。</p>
+									<p>表紙: [新編]第1弾キービジュアル</p>
+									<p>pp.2-27: <em>「特集　劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語」</em>初日舞台挨拶レポート（新宿バルト9）、キャラクター紹介、絵づくりにおけるセル・背景・コラージュの3要素の解説。</p>
+									<p>pp.14-17: 宮本幸裕インタビュー（上映10日後）。新房監督の強い思いでさやかは生き返ることになったこと、マミとほむらの戦闘シーンは絵コンテの笹木信作に映画『リベリオン』のイメージを伝えたこと、「ガン=カタ」や「マジカルバナナ」のシーンのCGについてなど。</p>
+									<p>pp.22-27: 新房昭之インタビュー。企画の成り立ち、公開前の情報の出し方（これまでの続編であることを告知したこと）、[新編]は（TVシリーズではなく）[前・後編]の続きであるという考え方、「叛逆の物語」の副題の決定経緯など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>SPA!　2011年7月19日号</book-name>
-							<book-release>2011-07-12</book-release>
-							<book-amazon asin="B007NCZEOA" image-id="61+4VMhWryL" width="121" height="160"></book-amazon>
+							<book-name>娘TYPE　2014年1月号</book-name>
+							<book-release>2013-11-30</book-release>
+							<book-amazon asin="B00GR6GXPM" image-id="61WzcZnZk-L" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.54-57 : 「大人気アニメ『まどか☆マギカ』の正体」宮台真司（社会学者）、宮崎哲弥（評論家）、八代嘉美（幹細胞生物学者）、森川嘉一郎（明治大学国際日本学部准教授）、磯崎哲也（公認会計士）の5名によるコメント。</p>
-									<p>p.101: 「アニメ定量分析　Vol.29」（山本幸治・ノイタミナプロデューサー）で『まどか☆マギカ』について語られる。2年前に企画書を見せてもらったことなど。</p>
+									<p>p.136: 新編情報。場面カット複数掲載。</p>
+									<p>p.143: Blu-ray BOX情報。</p>
+									<p>p.144: 「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。</p>
+									<p>p.147: 新編コミカライズ1巻情報。</p>
+									<p>付録: 制服の眼鏡ほむら&amp;杏子のB2ポスター（2013年12月号表紙イラスト）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年8月号</book-name>
-							<book-release>2011-07-08</book-release>
-							<book-amazon asin="B0057Y03GU" image-id="61lXtr7WuIL" width="125" height="160"></book-amazon>
+							<book-name>メガミマガジン　2014年1月号</book-name>
+							<book-release>2013-11-30</book-release>
+							<book-amazon asin="B00GNG8052" image-id="61MydVQLeiL" width="126" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.183: 「新房昭之のお恐縮ですが……」で吉野弘幸（脚本家）との対談。放送前の情報の出し方などの話。</p>
+									<p>p.42-44: <em>「[新編]叛逆の物語 SWEET &amp; BITTER BATTLES」</em> メインスタッフからのメッセージ、公開初日舞台挨拶レポート、「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。鋼屋ジンによる [新編] のレビュー。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>オトナアニメ　Vol.21</book-name>
-							<book-release>2011-07-08</book-release>
-							<book-isbn>978-4-86248-772-8</book-isbn>
-							<book-amazon asin="4862487726" image-id="51jHPgfmBoL" width="112" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.11　2014年1月号</book-name>
+							<book-release>2013-12-10</book-release>
+							<book-amazon asin="B00GCFRR4Y" image-id="61IluNPpzYL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: アルティメットまどか（原画: 中村直人）</p>
-									<p>pp.10-41: <em>「特集　徹底解明！魔法少女まどか☆マギカ」</em>ヒロイン解説、各話解説（11話〜12話）、演出の考察（7話、11話、12話の絵コンテ掲載）、外伝コミックレビュー。</p>
-									<p>pp.24-27: 悠木碧インタビュー。オーディション時の話、まどかのノートのイラストについてなど。</p>
-									<p>pp.32-35: 虚淵玄インタビュー。12話でマミの口から出た「円環の理」の伝承設定、各魔法少女の心情など。</p>
+									<p>表紙: マミ、なぎさ（イラスト: 蒼樹うめ）</p>
+									<p>キャッチコピー: 「3カ月連続刊行 いよいよ第3弾!!」（※背表紙は「[新編]叛逆の物語 絶賛公開中――!!」）</p>
+									<p>付録: 表紙イラストホログラム下敷き</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年8月号</book-name>
-							<book-release>2011-06-30</book-release>
-							<book-amazon asin="B0055OKZ9M" image-id="619ldq5b52L" width="124" height="160"></book-amazon>
+							<book-name>Febri　Vol.20</book-name>
+							<book-release>2013-12-10</book-release>
+							<book-amazon asin="B00FPBRX36" image-id="51ludySS96L" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>別冊付録: <em>「魔法少女まどか☆マギカ SPECIAL FAN BOOK」</em>作家やイラストレーターによる論評&amp;イラスト集。</p>
+									<p>pp.113-120: <em>「新房語」</em>宮本幸裕、谷口淳一郎がゲストで[新編]の話。"べべ"は本当の名前ではないという話、各シーンの担当スタッフ、総カット数など。</p>
+									<p>p.157: 「今月の女神」に巴マミ。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>SWITCH　2011年7月号　Vol.29　No.7</book-name>
-							<book-release>2011-06-20</book-release>
-							<book-isbn>978-4-88418-322-6</book-isbn>
-							<book-amazon asin="4884183223" image-id="51DEl-kh8pL" width="119" height="160"></book-amazon>
+							<book-name>ニュータイプ　2014年1月号</book-name>
+							<book-release>2013-12-10</book-release>
+							<book-amazon asin="B00GUP6QU2" image-id="61AN-e9TRQL" width="123" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 鹿目まどか（イラスト: 岸田隆宏）。</p>
-									<p>p.18: <em>「【特集】ソーシャルカルチャー ネ申100」</em>新房昭之インタビュー。震災の話、（震災とは無関係に）放送時期を延期していたこと、キュゥべえが口を動かさない理由など。</p>
-									<p>p.19: 同上、虚淵玄インタビュー。Twitterで気を遣ったこと、10話のループ設定など。</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>SWITCH 編集部から通販で雑誌を買うと、表紙のイラストの A2 ポスターが付いてきた。</li>
-								</ul>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年7月号</book-name>
-							<book-release>2011-06-10</book-release>
-							<book-amazon asin="B0052YKEFK" image-id="61v2FN6qNPL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>別冊付録: 「for promise」（加藤英美里×新房昭之、劇団イヌカレー×宮本幸裕、虚淵玄のインタビュー）</p>
-									<p><a href="https://www.youtube.com/watch?v=gWoOr_LtRYU" class="htmlbuild-host">発売CM</a></p>
+									<p>別冊付録: <em>「……in dream」</em>谷口淳一郎、寺尾洋之×谷口淳一郎×山村洋貴、宮本幸裕×泥犬のインタビュー。</p>
+									<p><a href="https://www.youtube.com/watch?v=Ktz6Y9oGIM8" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2011年7月号</book-name>
-							<book-release>2011-06-10</book-release>
-							<book-amazon asin="B0052ETRLC" image-id="61oA-CdcfWL" width="126" height="160"></book-amazon>
+							<book-name>メガミマガジン　2014年2月号</book-name>
+							<book-release>2013-12-27</book-release>
+							<book-amazon asin="B00H8X84KA" image-id="61Vm0qmyLyL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.8: 「無敵のツインテール❤」で鹿目まどかが取り上げられる。蒼樹うめによるコメント掲載（まどかのビジュアルで悩んだ点など）。</p>
+									<p>p.84: <em>「MADOKA'S HIGH」</em> 新編の情報、「暁美ほむら 晴れ着ver.」フィギュア、「劇場版 魔法少女まどか☆マギカ The Battle Pentagram」情報。</p>
+									<p>p.85: 日日日（あきら・小説家）による [新編] のレビュー。作品の話よりは、虚淵玄やニトロプラス社の話がメイン。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>プレイボーイ　2011年6月13日号</book-name>
-							<book-release>2011-05-30</book-release>
-							<book-amazon asin="B007EIAIIU" image-id="51SR8NfuyUL" width="120" height="160"></book-amazon>
+							<book-name>ストレンジャーソレント　2014年2月号</book-name>
+							<book-release>2013-12-28</book-release>
+							<book-amazon asin="B00HFMMIFQ" image-id="61vgU+hqnML" width="109" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.46-47: <em>「虚淵玄が明かす『魔法少女まどか☆マギカ』の真実」</em>武器がたくさん出てくるのは、当時蒼樹うめ共々『モンスターハンター』にハマっていたからお互いの共通言語として脚本に入れたということ、（キャラクターとして）ほむらだけは蒼樹うめの作品から取ったわけではないこと、続編は「やってくれ」とは言われているがどう展開させるか悩んでいることなど。</p>
+									<p>p.272: 大阪芸術大学のコラボイベント「まどか☆マギカ's Magica」のレポート。トークショー、展示の情報、ラッピングスクールバスの写真掲載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2014年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2014年2月号</book-name>
+							<book-release>2014-01-10</book-release>
+							<book-amazon asin="B00HFD3P0M" image-id="61t0wA+LD3L" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.150: 「新房昭之の恐縮ですが……」で『まどか☆マギカ』のシナリオが放送よりずいぶん前にできあがっていた話。</p>
+									<p>pp.168-171: <em>「永遠の絶望を」</em>悪魔ほむら&amp;ほむらのイラスト（菊田幸一）、斎藤千和インタビュー。ラストシーンの録り直しの話など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年7月号</book-name>
-							<book-release>2011-05-30</book-release>
-							<book-amazon asin="B0050IQPF6" image-id="61OjEJ597hL" width="123" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.12　2014年3月号</book-name>
+							<book-release>2014-02-10</book-release>
+							<book-amazon asin="B00HWCJF0A" image-id="51MyWq10s1L" width="114" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>折込ロングポスター: 水着ほむら（原画: 中村直人）、水着マミ（原画: 潮月一也）。</p>
-									<p>別冊付録: <em>「魔法少女まどか☆マギカ COMPLETE BOOK」</em>虚淵玄インタビュー、11〜12話概要、新房昭之インタビュー、キャストによる座談会。</p>
+									<p>表紙: まどか、悪魔ほむら（原画: 山村洋貴）</p>
+									<p>キャッチコピー: 「『[新編]叛逆の物語』 BD&amp;DVD 4/2発売決定!!」（※背表紙は「[新編]叛逆の物語 BD&amp;DVD 4/2発売決定!!」）</p>
+									<p>付録: 表紙イラストB3ポスター</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.6</book-name>
-							<book-release>2011-05-25</book-release>
-							<book-amazon asin="B004WY9RNQ" image-id="51XcxgTHZ6L" width="114" height="160"></book-amazon>
+							<book-name>ニュータイプ　2014年3月号</book-name>
+							<book-release>2014-02-10</book-release>
+							<book-amazon asin="B00I11AZZU" image-id="51seO+Q8HEL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.86-93: <em>「新房語」</em>虚淵玄がゲスト。放送延期決定後も4月の放送直前まで11話、12話の制作を続けていた（新房）、11話の戦闘シーンは脚本ではほむらがタンクローリーをぶつけたところで終わっていた（虚淵）、ワルプルギスの夜の周りにいる魔女の手下は絵コンテ段階では他の魔法少女になっていた（新房）、マミの必殺技「アルティマ・シュート」をアフレコ現場で変えた、などの話題。</p>
+									<p>p.147: 「新房昭之の恐縮ですが……」で『まどか☆マギカ』発表時のニュータイプ誌面での掲載記事の話。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>Cut　2011年6月号</book-name>
-							<book-release>2011-05-19</book-release>
-							<book-amazon asin="B004Y0AIJ0" image-id="61lgSXZ5Q+L" width="123" height="160"></book-amazon>
+							<book-name>ストレンジャーソレント　2014年4月号</book-name>
+							<book-release>2014-03-01</book-release>
+							<book-amazon asin="B00IPCVMN4" image-id="61zhBjEBUEL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.11: 特集「マクロス、そしていま出会うべきアニメたち」で『まどか☆マギカ』のカット2点掲載。</p>
-									<p>pp.54-59: <em>「問題作こそ大ヒット作!? 驚異のヒットメーカー、新房昭之の脳内に迫る」</em>個々の作品の話よりは、アニメ制作全般に関する話が多い。</p>
+									<p>pp.265-269: <em>「ストレンジャーソレント特別対談！ 虚淵玄×小池一夫 『魔法少女まどか☆マギカ　叛逆の物語』を語る」</em><a href="https://live.nicovideo.jp/watch/lv162841750" class="htmlbuild-host">ニコニコ生放送で2013年12月22日に行われた対談</a>の書き起こし。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年6月号</book-name>
-							<book-release>2011-05-10</book-release>
-							<book-amazon asin="B004XIWD2I" image-id="61aJzOaTWvL" width="123" height="160"></book-amazon>
+							<book-name>MdN　2014年4月号</book-name>
+							<book-release>2014-03-06</book-release>
+							<book-amazon asin="B00IRX1SEY" image-id="51eWlOGnr3L" width="121" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.182-185: <em>「それは、とっても嬉しいなって……」</em>肩にキュゥべえを乗せたほむらのイラスト（高橋美香）、第11話〜12話オンエアを終了しての虚淵玄、新房昭之インタビュー（5月号の続き）。</p>
+									<p>pp.24-25: 「PRODUCTION NOTE 新装版-TV series」の装丁について、作者のミルキィ・イソベによる解説。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2011年6月号</book-name>
-							<book-release>2011-05-10</book-release>
-							<book-amazon asin="B004XCWW02" image-id="61LNNxriFYL" width="126" height="160"></book-amazon>
+							<book-name>季刊エス　2014年春号（第46号）</book-name>
+							<book-release>2014-03-15</book-release>
+							<book-amazon asin="B00I9H1X16" image-id="61LTQnPbgHL" width="119" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.3-6（折込）: アルティメットまどかイラスト（高橋美香）、虚淵玄インタビュー。</p>
-									<p>pp.72-73: 最終回アフレコレポート漫画（出口由美子）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2011年6月号</book-name>
-							<book-release>2011-05-10</book-release>
-							<book-amazon asin="B004WDQ6UY" image-id="612rEVYWRNL" width="126" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.58-61: <em>「彼女の決意を忘れない――」</em>11話〜12話の画面ショット多数掲載（震災対応で差し替えられた体育館のカットも掲載）、悠木碧、斎藤千和インタビュー、新房昭之×虚淵玄コメント。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年6月号</book-name>
-							<book-release>2011-04-30</book-release>
-							<book-amazon asin="B004WDQ7CG" image-id="61iy04LPrmL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.17-18: TV版キービジュアルの折り込みピンナップ（原画: 岸田隆宏）。</p>
-									<p>pp.44-46: <em>「魔法少女が選んだ世界」</em>岩上敦宏インタビュー。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2011年6月号</book-name>
-							<book-release>2011-04-30</book-release>
-							<book-amazon asin="B004WOTBP0" image-id="61O-EUL9JZL" width="122" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.32: AT-X広告。放送中作品に『まどか☆マギカ』（画像付き）。</p>
-									<p>pp.142-143: <em>「出没！ギャル街っく天国！」</em> 10〜11話などの場面ショット多数。</p>
-									<p>p.169: 『かずみ☆マギカ』1巻の情報。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>月刊メガストア　2011年6月号</book-name>
-							<book-release>2011-04-30</book-release>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.10-11: 「虚淵玄 緊急インタビュー」で『まどか☆マギカ』についても語られる。放送前に「虚淵玄」の名前が出たことは予定外だったこと、新房さんは『ジョジョの奇妙な冒険』のような能力者バトルを期待していたらしいこと、結末は自分なりにハッピーエンドであることなど。</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>発売日は正確でない可能性。</li>
-								</ul>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.05</book-name>
-							<book-release>2011-04-25</book-release>
-							<book-isbn>978-4-7897-7126-9</book-isbn>
-							<book-amazon asin="4789771261" image-id="51a05+jM7ML" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 鹿目まどか、暁美ほむら（中村直人）</p>
-									<p>pp.7-19: <em>「[特集1]『魔法少女まどか☆マギカ』」</em> 最速! 全12話駆け足ストーリーレビュー、梶浦由記インタビュー（9話冒頭の魔女が変身するシーンで飛んでいる譜線は9話最後に流れる曲の譜面）、ClariSインタビュー（ClariSの2人がテレビを見ている蒼樹うめイラスト掲載）。</p>
-									<p>pp.20-22: 「Kalafina LIVE Spring TOUR 2011 “Magia”」ライブレポート。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>B.L.T.　2011年6月号</book-name>
-							<book-release>2011-04-23</book-release>
-							<book-amazon asin="B004W8DUNU" image-id="51fLLpUtXpL" width="111" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 鹿目まどか（ゲーマーズ版のみ）、暁美ほむら（アニメイト版のみ）、美樹さやか（とらのあな版のみ）。</p>
-									<p>p130-133: <em>「魔法少女まどか☆マギカ」大特集</em>まどか&amp;ほむら&amp;さやかのイラスト（谷口淳一郎）、悠木碧コメント（11話の演技について）、虚淵玄インタビュー。</p>
-									<p>特典: 表紙イラストブロマイド（ゲーマーズ版、アニメイト版、とらのあな版のみ）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年5月号</book-name>
-							<book-release>2011-04-09</book-release>
-							<book-amazon asin="B004U5MOZK" image-id="61Blr2Rn9GL" width="123" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>p.124: 「新房昭之とおシゴトな仲間達」（最終回）で虚淵玄との対談。「奇跡」の取り扱い、<a href="https://www.amazon.co.jp/dp/B00E1C77IQ/" class="htmlbuild-host htmlbuild-amazon-associate">サンデルの政治哲学</a>との関係性などについて。</p>
-									<p>特別付録: <em>描き下ろしB2ポスター&amp;特集記事「魔法少女まどか☆マギカ」</em>まどか&amp;眼鏡ほむらのイラスト（住本悦子）、虚淵玄、新房昭之による第10話までの振り返り。</p>
-									<p><a href="https://www.youtube.com/watch?v=8PPpUkaAehc" class="htmlbuild-host">発売CM</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2011年5月号</book-name>
-							<book-release>2011-04-09</book-release>
-							<book-amazon asin="B004TGPZH4" image-id="61FjzoqMCrL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.120-121: 「Dear Magical Girls」10話のまどか、ほむらの場面ショットが大きく掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2011年5月号</book-name>
-							<book-release>2011-04-09</book-release>
-							<book-amazon asin="B004TB6T6A" image-id="61tzh0piqvL" width="127" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.32-37: <em>「少女たちの決意」</em>まどか&amp;ほむら&amp;キュゥべえのイラスト（潮月一也）、新房昭之×虚淵玄インタビュー（8〜10話に関する内容）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>オトナアニメ　Vol.20</book-name>
-							<book-release>2011-04-09</book-release>
-							<book-isbn>978-4-86248-711-7</book-isbn>
-							<book-amazon asin="4862487114" image-id="51X7yWzHwwL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>表紙: 鹿目まどか（TVシリーズ第2弾キービジュアルの一部）</p>
-									<p>pp.6-39: <em>「特集　魔法少女まどか☆マギカ」</em>キャラクター紹介、各話解説（10話まで）、演出の考察、劇団イヌカレー&amp;宮本幸裕へのQ&amp;A形式の質問、劇団イヌカレーのコラージュ紹介、梶浦由記の作品史。</p>
-									<p>pp.18-20: 新房昭之インタビュー。虚淵玄との出会い、絵コンテの描き方など。</p>
-									<p>pp.34-36: 虚淵玄インタビュー。ほむらの盾の構造解説、フィクションに含まれる毒の要素に関する持論など。</p>
-									<p>p.39: 岩上敦宏インタビュー。主要スタッフの採用経緯など。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.4.1 （アニソンクリエイターズⅠ）</book-name>
-							<book-release>2011-03-31</book-release>
-							<book-isbn>978-4-7897-7125-2</book-isbn>
-							<book-amazon asin="4789771253" image-id="51kS+GX+QdL" width="113" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.20-25: <em>『魔法少女まどか☆マギカ』特集ページ。</em>ClariS、Kalafinaの紹介（文はそれぞれ冨田明宏、有村悠）。</p>
-									<p>p.141: 「コネクト」の広告。</p>
-									<p>p.151: 「Magia」の広告。</p>
-									<p>裏表紙: Blu-ray&amp;DVD1巻の広告。パッケージイラスト掲載。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年5月号</book-name>
-							<book-release>2011-03-30</book-release>
-							<book-amazon asin="B004SBIH5C" image-id="61-C1Ai59WL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.173-174: まどか&amp;ほむら&amp;さやか&amp;杏子&amp;キュゥべえの折り込みピンナップ（イラスト: ゆーぽん）。</p>
-									<p>別冊付録: <em>「魔法少女まどか☆マギカ スペシャルブック」</em>1話〜10話の虚淵玄コメント付きストーリー解説、次回予告イラスト集、設定イラスト（まどかのパジャマ姿や杏子の家族、モブキャラなどの蔵出し）、イラストギャラリー（Blu-ray店舗特典）、スタッフコメント集。</p>
-									<p>別冊付録: 水着イラストのB2ポスター（原画: 谷口淳一郎）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　2011年5月号</book-name>
-							<book-release>2011-03-30</book-release>
-							<book-amazon asin="B004TB6SKM" image-id="61rxCoHXa8L" width="121" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.29-30: ピンナップ: パジャマ姿のまどか、ほむら、マミ、さやか、杏子（潮月一也）。</p>
-									<p>p.35: 独立創刊のお祝いコメントでVol.17表紙のまどかとほむらからメッセージ。</p>
-									<p>p.38: Blu-ray&amp;DVD1巻広告。</p>
-									<p>p.92: 「いっしょにお花見したい娘」の1位: 鹿目まどか、7位: 巴マミ。「いっしょに卒業旅行したい娘」の4位: 暁美ほむら、6位: 美樹さやか、9位: 巴マミ。</p>
-									<p>p.112:　Vol.17の表紙ギャラリー。</p>
-									<p>pp.158-161: <em>「魔のトライアングルにご用心♥」</em> 8〜10話などの場面ショット複数掲載、岩上敦宏の一言コメント、キャストコメント。</p>
-									<p>p.212: 「いまときのムスメ力」明貴美加（メカデザイナー）による時間制御ウィングを装備した暁美ほむらイラスト。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>Febri　Vol.5</book-name>
-							<book-release>2011-03-28</book-release>
-							<book-amazon asin="B004QGYZHI" image-id="51KCW4Sk6KL" width="112" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.4-29: <em>「虚淵玄大特集!!」</em>で虚淵玄×高橋龍也（シナリオライター・脚本家）×高山箕犀（イラストレーター）の座談会（2011年2月8日）。序盤（1〜3話）の構成が“黒田メソッド”であること、脚本ではアクションシーンは一切書かなかったことなど。</p>
-									<p>pp.100-105: 「新房語」（第5回）あおきえいがゲスト。劇団イヌカレーの作業内容や、虚淵玄の脚本についての話。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>季刊エス　2011年春号（第34号）</book-name>
-							<book-release>2011-03-15</book-release>
-							<book-amazon asin="B004OSXHD6" image-id="61n6fx9MhxL" width="122" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.48-53: <em>『魔法少女まどか☆マギカ』新房昭之インタビュー</em>　3話、5話の絵コンテ、オープニングのまどか変身シーン原画掲載。</p>
+									<p>pp.74-79: <em>『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』新房昭之インタビュー</em>　ほむら変身シーンの原画が掲載。</p>
 								</div>
 
 								<ul class="p-notes">
@@ -3612,371 +2939,1044 @@
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年4月号</book-name>
-							<book-release>2011-03-10</book-release>
-							<book-amazon asin="B004PIZX6O" image-id="61MSS3P63+L" width="125" height="160"></book-amazon>
+							<book-name>MdN　2014年5月号</book-name>
+							<book-release>2014-04-05</book-release>
+							<book-amazon asin="B00J496WUA" image-id="51sgs+ia4RL" width="118" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.130: 10〜12話の番組情報（サブタイトル、あらすじが非公開のため欄外に掲載）。</p>
-									<p>pp.180-183: 「最後の願い」制服&amp;魔法少女姿の2人のまどかイラスト（高橋美香）、キュゥべえに関して、新房昭之、虚淵玄、蒼樹うめによるコメント、加藤英美里インタビュー。</p>
+									<p>pp.48-55: 「デザイナーのもとに眠っていたラフや別案と出会う」で [新編] Blu-rayパッケージの紹介。染谷洋平インタビュー。</p>
+									<p><a href="https://books.mdn.co.jp/magazine/3214101005/" class="htmlbuild-host">公式ページ</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2011年4月号</book-name>
-							<book-release>2011-03-10</book-release>
-							<book-amazon asin="B004OSXGZK" image-id="61stIzEf8xL" width="125" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.13　2014年5月号</book-name>
+							<book-release>2014-04-10</book-release>
+							<book-amazon asin="B00ITYI5KG" image-id="61vTonESm9L" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.97: 10〜12話の番組情報（あらすじ、サブタイトルは非公開）。</p>
-									<p>pp.132-135: <em>「『まどか』特集 ふたつの願い」</em> 9話までの振り返り、斎藤千和インタビュー、岩上敦宏コメント。</p>
+									<p>表紙: まどか、マミ、なぎさ（イラスト: Koi）</p>
+									<p>キャッチコピー: 「劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語 Blu-ray&amp;DVD絶賛発売中!!」（※背表紙は「[新編]叛逆の物語 BD&amp;DVD 大好評発売中!!」）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2011年4月号</book-name>
-							<book-release>2011-03-10</book-release>
-							<book-amazon asin="B004NVB4IE" image-id="61PiiDR0iOL" width="127" height="160"></book-amazon>
+							<book-name>ニュータイプ　2014年5月号</book-name>
+							<book-release>2014-04-10</book-release>
+							<book-amazon asin="B00J4T7KII" image-id="61YjouHyNyL" width="123" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.70-71: <em>「魔法少女の想いは哀しく、儚く」</em> 9話までの紹介、悠木碧インタビュー。</p>
-									<p>p.72: インターネットラジオ「あにめじ湯」（Vol.81）のゲストに悠木碧。ペットの猫「エイミー」の写真掲載。</p>
-									<p>pp.84-86: 「設定資料FILE」各キャラクターの設定イラスト掲載。</p>
+									<p>pp.9-10: アルティメットまどか&amp;悪魔ほむらのピンナップ（菊田幸一）。</p>
+									<p><a href="https://www.youtube.com/watch?v=A4jIvFs1idk" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年4月号</book-name>
-							<book-release>2011-02-28</book-release>
-							<book-amazon asin="B004N77PB8" image-id="61jzNGztROL" width="124" height="160"></book-amazon>
+							<book-name>オトナアニメ　Vol.34</book-name>
+							<book-release>2014-05-30</book-release>
+							<book-amazon asin="4800304156" image-id="51gHlkmxdwL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: ほむらと黒猫（原画: 谷口淳一郎）。</p>
-									<p>pp.19-20: 表紙イラストのピンナップポスター。</p>
-									<p>pp.30-39: <em>「魔法少女たちの光と闇」</em>7話までの概要、宮本幸裕インタビュー、劇団イヌカレーQ&amp;A、蒼樹うめ描き下ろし4コマ漫画、虚淵玄&amp;ハノカゲインタビュー、一肇によるオフィシャルノベル。</p>
-									<p>付録: 白いスクール水着を着たまどかのロングポスター。</p>
+									<p>pp.34-37: 「シャフト演出作品、ここを観る!」特集で [新編] のキャプチャーが2枚掲載。また『メカクシティアクターズ』のコラムでは、アニメーターの阿部厳一郎について、TV版オープニングのまどか走りや、 [後編] でほむらと杏子の変身シーンを手掛けたことを紹介。</p>
+									<p>pp.50-52: <em>『劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語』のおさらい。</em>ガン=カタシーンの撮影方法（手描き/CG）への言及や阿澄佳奈のコメント。50ページ下部の「魔女の井戸」のキャプチャー画像は、ほむらに光が当たった上映版を使用。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　Vol.17</book-name>
-							<book-release>2011-02-28</book-release>
-							<book-amazon asin="B004OSXHNG" image-id="61RKdFIXAEL" width="124" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.14　2014年7月号</book-name>
+							<book-release>2014-06-10</book-release>
+							<book-amazon asin="B00KCUXXGQ" image-id="61hSbgEhhUL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: ドレスを着たまどか&amp;ほむら（原画: 谷口淳一郎）</p>
-									<p>p.7: パジャマ姿のまどか折り込みポスター（原画: 今村亮）</p>
-									<p>pp.34-40: <em>「とまどうまどかに愛の手を!!」</em>各魔法少女の戦い方分析、新房昭之×虚淵玄×蒼樹うめの座談会など。</p>
+									<p>表紙: 魔法少女6人、キュゥべえ（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「ここにくれば逢える――」（※背表紙は「ここにくればまどかに逢える」）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年3月号</book-name>
-							<book-release>2011-02-10</book-release>
-							<book-amazon asin="B004L5NE44" image-id="61F8HZY+1iL" width="125" height="160"></book-amazon>
+							<book-name>メガミマガジン　2014年9月号</book-name>
+							<book-release>2014-07-30</book-release>
+							<book-amazon asin="B009FRJKV4" image-id="61R2SgCcdzL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.30-35: <em>「魔女か、魔法少女」</em>5人とキュゥべえのイラスト（高橋美香）、悠木碧×斎藤千和、宮本幸裕のインタビュー、「劇団イヌカレーさんに17の質問」。</p>
-									<p>p.128: 6〜9話の番組情報（サブタイトル、あらすじが非公開のため欄外に掲載）。</p>
-									<p>p.142: Blu-ray&amp;DVD 1巻広告、2月14日アニメイトバレンタインチョコプレゼント情報。</p>
+									<p>p.8: 「メガミマガジン15周年記念企画 人気ヒロイン変遷史」で鹿目まどか掲載（蒼樹うめ設定イラスト掲載）。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2011年3月号</book-name>
-							<book-release>2011-02-10</book-release>
-							<book-amazon asin="B004K8VTGM" image-id="6186iS3uj-L" width="124" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.15　2014年9月号</book-name>
+							<book-release>2014-08-08</book-release>
+							<book-amazon asin="B00LFW7BKY" image-id="61mt7bgv+4L" width="110" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.28-29: 「あの娘のハートをキャッチ! バレンタイン❤大作戦」虚淵玄インタビュー。原子力のリスクに言及（※雑誌発売は東日本大震災前）。</p>
-									<p>p.103: 6〜9話の番組情報（あらすじ、サブタイトルは非公開）。</p>
-									<p>裏表紙: Blu-ray&amp;DVD第1巻の広告。</p>
+									<p>表紙: アラサーマミ（イラスト: あらたまい）</p>
+									<p>キャッチコピー: 「巴マミの平凡な日常 最新コミックス②8月11日発売!!」（※背表紙は「巴マミの平凡な日常 ドアプレート付き!!」）</p>
+									<p>付録: 「巴マミの平凡な日常」ドアプレート（現物写真 <a href="https://twitpic.com/e9pmx9" class="htmlbuild-host">その1</a>、<a href="https://twitpic.com/e9pn4b" class="htmlbuild-host">その2</a>）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2011年3月号</book-name>
-							<book-release>2011-02-10</book-release>
-							<book-amazon asin="B004J0A5DE" image-id="61MJXjM-BnL" width="126" height="160"></book-amazon>
+							<book-name>MdN EXTRA　Vol.1</book-name>
+							<book-release>2014-08-30</book-release>
+							<book-amazon asin="4844364391" image-id="61wS0NthGFL" width="121" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.3-5: 「F（不機嫌な）K（彼女から）C（チョコをもらおう）大作戦」チョコを抱えたまどかとほむらのイラスト（潮月一也）、斎藤千和コメント（ほむらがバレンタインチョコをあげるとしたら）。</p>
+									<p>p.94: 「BALCOLONY.に学ぶ美少女とデザイン。」でTV版、劇場版、[新編]の3タイプのロゴについて、染谷洋平によるコメント。（2013年9月号の再録）</p>
+									<p>p.106-115: 「デザイナーの思考や制作プロセスがわかるデザインのラフ案&amp;別案」で「叛逆の物語」BDパッケージの紹介。染谷洋平インタビュー。（2014年5月号の再録）</p>
+									<p>pp.140-141: 「終わりのあとの始まり 印刷の魔法をもう一度信じてみる?」で「劇場版 魔法少女まどか☆マギカ 総集編 Keyanimation ClearFile」の紹介（談: 浅見啓介）。（2013年12月号の再録）</p>
+									<p><a href="https://books.mdn.co.jp/books/3214102001/" class="htmlbuild-host">公式ページ</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年3月号</book-name>
-							<book-release>2011-01-29</book-release>
-							<book-amazon asin="B004IOZAEU" image-id="61Esmmri3UL" width="124" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.16　2014年11月号</book-name>
+							<book-release>2014-10-10</book-release>
+							<book-amazon asin="B00MX42KGS" image-id="614xzoC4JNL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.3-5: 水着のまどか、ほむら、さやか、マミのピンナップポスター（原画: 高橋美香）。</p>
-									<p>p.60: ClariSインタビュー、「コネクト」についてなど。</p>
-									<p>pp.75-79: <em>「鬼才・虚淵玄の魅力に迫る!!輝き・衝撃・感銘 ディープインパクト」</em>3話までの紹介、「第4話のラストで登場した新たな魔法少女」として杏子の私服、魔法少女服のイラスト掲載、虚淵玄インタビュー。</p>
+									<p>表紙: 悪魔ほむら（イラスト: 蒼樹うめ）</p>
+									<p>キャッチコピー: 「"まどか"があれば何もいらない。」</p>
+									<p>付録: 表紙イラストクリアファイル</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　Vol.16</book-name>
-							<book-release>2011-01-29</book-release>
-							<book-amazon asin="B004K8VTJY" image-id="612VFous5TL" width="124" height="160"></book-amazon>
+							<book-name>ニュータイプ　2014年12月号</book-name>
+							<book-release>2014-11-10</book-release>
+							<book-amazon asin="B00FC0Z3J6" image-id="61q8W8SxISL" width="124" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.42-45: <em>「まどか☆マジか!?」</em>3話までの場面カット、杏子のキャラクター紹介、虚淵玄インタビュー（オーディションで斎藤千和は別キャラクターで参加していたが、土壇場でほむらのセリフを演じ、結果的にそれが功を奏した話など）。</p>
-									<p>p.139: 5〜7話の放送スケジュール（MBS、TBS、CBC）。サブタイトルは非公開。1話の場面カット掲載。</p>
-									<p>p.155: 「コネクト」発売情報。ジャケットイラスト掲載。</p>
-									<p>pp.187-188: ピンナップ: 水着まどか、マミ（潮月一也）。</p>
+									<p>p.32: 「hello world」虚淵玄インタビュー内で『魔法少女まどか☆マギカ』をやる経緯などの話。</p>
+									<p>p.118: 「新房昭之のあの人とヒミツの話」で大澤信博（アニメプロデュース会社・ジェンコ）との対談。『ヴァンパイアバンド』で悠木碧と斎藤千和がシャフト作品で初共演し、『魔法少女まどか☆マギカ』でのコンビネーションに繋がったであろう話。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>リスアニ!　Vol.04</book-name>
-							<book-release>2011-01-25</book-release>
-							<book-isbn>978-4-7897-7119-1</book-isbn>
-							<book-amazon asin="4789771199" image-id="51yjxIz-0SL" width="113" height="160"></book-amazon>
+							<book-name>まんがタイムきららフォワード　2015年1月号</book-name>
+							<book-release>2014-11-22</book-release>
+							<book-amazon asin="B00OYUMWL2" image-id="61I8onBN-dL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表2: 「コネクト」の広告。まどか、ほむらのアニメ盤ジャケットイラスト掲載。</p>
-									<p>pp.24-32: <em>「[特集2] 魔法少女まどか☆マギカ」</em>第1話速報レビュー（前田久）、CllariS、Kalafinaインタビュー。「コネクト」の収録はハロウィンの時期だったことなど。</p>
-									<p>p.70: 「2011冬クール放送アニメOP×EDレビュー」で冨田明宏（音楽評論家）による「コネクト」「Magia」の解説。</p>
+									<p>pp.199-224: 『すずね☆マギカ』最終話</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきららフォワード　2011年3月号</book-name>
-							<book-release>2011-01-24</book-release>
-							<book-amazon asin="B004GEFQCS" image-id="615GjarKv0L" width="112" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.17　2015年1月号</book-name>
+							<book-release>2014-12-10</book-release>
+							<book-amazon asin="B00PM7313E" image-id="61OUJNQVQdL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.6-7: Blu-ray&amp;DVD 1巻発売予告（キービジュアル掲載）。コミカライズ1巻発売予告（表紙イラスト掲載）、『かずみ☆マギカ』連載開始情報（キャラクターイラスト掲載）。</p>
-									<p>pp.8-52: 『かずみ☆マギカ』第1話（巻頭カラー）</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年2月号</book-name>
-							<book-release>2011-01-08</book-release>
-							<book-amazon asin="B004GUXVQA" image-id="61uYFfbAwqL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.118-123: 「Creation Archive 魔法少女まどか☆マギカ」まどか&amp;ほむら&amp;マミ&amp;キュゥべえのイラスト（高橋美香）、杏子を除く4人とキュゥべえのキャラクター紹介、岸田隆宏の一言コメント、蒼樹うめキャラクター原案集。</p>
-									<p>p.136: 2〜5話の番組情報（サブタイトル、あらすじが非公開のため欄外に掲載）。</p>
-									<p>p.151: 「新房昭之とおシゴトな仲間達」冒頭で『魔法少女まどか☆マギカ』に関する話題。</p>
-									<p><a href="https://www.youtube.com/watch?v=4EJF1o-Ah5E" class="htmlbuild-host">発売CM</a></p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2011年2月号</book-name>
-							<book-release>2011-01-08</book-release>
-							<book-amazon asin="B004FV7QWU" image-id="6196BfJ1dBL" width="124" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.24-25: <em>「魔女っ娘まる見え　マジカルスコープ!」</em>まどか&amp;ほむら&amp;さやか&amp;マミ&amp;キュゥべえのイラスト（岸田隆宏）、作品紹介、キャラクター紹介、岩上敦宏コメント。</p>
-									<p>p.102: 2〜5話の番組情報（あらすじ、サブタイトルは非公開）。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2011年2月号</book-name>
-							<book-release>2011-01-08</book-release>
-							<book-amazon asin="B004FO4S7S" image-id="61FqNwVOrdL" width="125" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.42-43: <em>「切り札は友情物語!!」</em>まどか&amp;ほむら&amp;マミ&amp;さやか&amp;キュゥべえのイラスト（高橋美香）、1話に関する虚淵玄インタビュー（雑誌の発売日はMBS、TBSでの1話放送直後）。1話ラストのマミが銃を撃つシーンは絵コンテでは大砲的なものを1発撃つだけだったが、映像では100丁くらいの銃が出てきて一斉砲火になったことなど。</p>
-									<p>p.130: 第6話までの放送データ。サブタイトルはいずれも非公開、メインキャストに杏子なし。</p>
-								</div>
-							</book-contents>
-						</htmlbuild-book>
-
-						<htmlbuild-book heading-level="3">
-							<book-name>オトナアニメ　Vol.19</book-name>
-							<book-release>2011-01-08</book-release>
-							<book-isbn>978-4-86248-679-0</book-isbn>
-							<book-amazon asin="4862486797" image-id="61nmwSf8AWL" width="115" height="160"></book-amazon>
-							<book-contents>
-								<div class="p-text">
-									<p>pp.110-114: <em>「シャフト☆ワークス 2010-2011」</em>の記事内で蒼樹うめ、虚淵玄のインタビュー。企画立ち上げ時の話、キャラクターについてなど。</p>
+									<p>表紙: まどか、眼鏡ほむら（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「"まどか"と、ぽかぽか。」（※背表紙は「まどかと一緒なら心も体もぽかぽか。」）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 					</section>
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
-							<h2>2010年</h2>
+							<h2>2015年</h2>
 						</div>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年2月号</book-name>
-							<book-release>2010-12-27</book-release>
-							<book-amazon asin="B004F0LMOO" image-id="61aBtNoYToL" width="124" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.18　2015年3月号</book-name>
+							<book-release>2015-02-10</book-release>
+							<book-amazon asin="B00S9X6I88" image-id="61FGoVstVoL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 鹿目まどか（原画: 谷口淳一郎）。</p>
-									<p>pp.13-14: 「運命の4人」まど&amp;さやか&amp;キュゥべえ他のピンナップポスター（原画: 高橋美香）。</p>
-									<p>pp.15-16: 表紙イラストのピンナップポスター。</p>
-									<p>pp.24-29: <em>「魔法少女まどか☆マギカ Magical Girl Start of Legend」</em>作品紹介、新房昭之インタビュー、キャラクター設定イラスト、関係者39人のメッセージ、蒼樹うめイラストメッセージ。</p>
+									<p>表紙: リボンほむら（悪魔）（イラスト: 得能正太郎）</p>
+									<p>キャッチコピー: 「2015年も、"まどか"だけ――」</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>電撃G's magazine　2011年2月号</book-name>
-							<book-release>2010-12-27</book-release>
-							<book-amazon asin="B004FO4RAQ" image-id="61t-rbyPyOL" width="132" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.19　2015年5月号</book-name>
+							<book-release>2015-04-10</book-release>
+							<book-amazon asin="B00UXLY444" image-id="617yOEp1HSL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.66-67: 「ドキドキの魔法少女タイム♥」まどか、ほむら、キュゥべえの版権イラスト（谷口淳一郎）。</p>
+									<p>表紙: まどか、なぎさ 他（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「2015年も、"まどか"だけ――」</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　Vol.15</book-name>
-							<book-release>2010-12-27</book-release>
-							<book-amazon asin="B004GI13E4" image-id="61bJTVjwXYL" width="124" height="160"></book-amazon>
+							<book-name>ニュータイプ　2015年5月号</book-name>
+							<book-release>2015-04-10</book-release>
+							<book-amazon asin="B00URAYHSO" image-id="51G7y+oRCfL" width="126" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.54: 新番紹介。まどか、さやか、マミ、ほむらのキャラクター紹介（蒼樹うめによるキャラ設定イラスト）。1話場面カット。</p>
-									<p>p.123: 4話までの放送スケジュール（MBS、TBS、CBC）。サブタイトルは非公開。</p>
+									<p>pp.7-8: アルティメットまどか、新魔法少女服(?)まどかのピンナップ（蒼樹うめ）。</p>
+									<p><a href="https://www.youtube.com/watch?v=3E6ewo6BaVQ" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきららフォワード　2011年2月号</book-name>
-							<book-release>2010-12-24</book-release>
-							<book-amazon asin="B004EKI7PC" image-id="61c0rtkFS8L" width="111" height="160"></book-amazon>
+							<book-name>MdN　2015年6月号</book-name>
+							<book-release>2015-05-07</book-release>
+							<book-amazon asin="B00TYLC14E" image-id="51kGnuqlEML" width="121" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.6-7: 『まどか☆マギカ』放送予告（キービジュアル掲載）。美樹さやか、キュゥべえのイラスト公開（蒼樹うめ）。コミックス発売、『おりこ☆マギカ』発売、『かずみ☆マギカ』連載予告。</p>
+									<p>pp.64-67: 「少女の表現史」で鹿目まどか紹介（談: 篠田利隆）。</p>
+									<p><a href="https://books.mdn.co.jp/magazine/3215101006/" class="htmlbuild-host">公式ページ</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2011年1月号</book-name>
-							<book-release>2010-12-10</book-release>
-							<book-amazon asin="B004EBH7MK" image-id="616ijp-wvLL" width="124" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.20　2015年7月号</book-name>
+							<book-release>2015-06-10</book-release>
+							<book-amazon asin="B00WN3XVQC" image-id="61nG7cmPBsL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.36-37: 「想像の最前線2011」制服で抱きつくまどかとほむらのイラスト（高橋美香）、新房昭之、虚淵玄、岩上敦宏、宮本幸裕のコメント。</p>
+									<p>表紙: アルティメットまどか（イラスト: 蒼樹うめ）</p>
+									<p>キャッチコピー: 「The Third Anniversary 祝☆3周年!!」</p>
+									<p>付録: 表紙イラストクリアファイル</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>「魔獣編」連載開始。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2015年7月号</book-name>
+							<book-release>2015-06-10</book-release>
+							<book-amazon asin="B00Y27U13I" image-id="61QLgqAwPIL" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.107: 「新房昭之のあの人とヒミツの話」で金庭こず恵（ムービック）と対談、『まどか☆マギカ』を含む新房作品のグッズ展開の話。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2011年1月号</book-name>
-							<book-release>2010-12-10</book-release>
-							<book-amazon asin="B004DPEH0W" image-id="61l5ajbPWML" width="124" height="160"></book-amazon>
+							<book-name>Febri　Vol.29</book-name>
+							<book-release>2015-06-17</book-release>
+							<book-amazon asin="B00YAC8OP2" image-id="61V++H3OJHL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.38-39: 「新房昭之×蒼樹うめ×虚淵玄×シャフトで新感覚魔法少女！」 ほむら、まどか、さやか、マミ、キュゥべえのイラスト（原画: 谷口淳一郎）、キャラクター紹介、岩上敦宏のコメント。</p>
-									<p>p.74: 1話の番組情報（あらすじ、サブタイトルは非公開）。</p>
+									<p>pp.119-120: 「新房語（最終回）」大沼心がゲスト。オリジナル作品の話題で『まどか☆マギカ』の名前が挙がり、虚淵玄へ「『ジョジョの奇妙な冒険』のような異能力バトルものにしたい」というお願いをした話など。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2011年1月号</book-name>
-							<book-release>2010-12-10</book-release>
-							<book-amazon asin="B004AX9QVW" image-id="61Yrd+SCsaL" width="125" height="160"></book-amazon>
+							<book-name>メガミマガジン　2015年9月号</book-name>
+							<book-release>2015-07-30</book-release>
+							<book-amazon asin="B00ZD9F4U4" image-id="61FK57sEokL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.38-39: <em>「魔法少女になってみる?」</em>まどか&amp;ほむら&amp;さやか&amp;マミ&amp;キュゥべえのイラスト（高橋美香）、新房昭之監督Q&amp;A。</p>
-									<p>p.134: 第1話の放送データ。放送局の記載はMBS、TBSのみ（CBCなし）。脚本、演出、絵コンテ等のスタッフのみ掲載（p.39にはキャストも掲載されている）。</p>
+									<p>p.45: 「業界著名人はアニメをかく語りき」新房昭之インタビュー。「美少女」の話題で『宇宙戦艦ヤマト』から始まり、『まどか☆マギカ』も（「美少女モノ」ではないという意味で）例に挙げられる。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2011年1月号</book-name>
-							<book-release>2010-11-30</book-release>
-							<book-amazon asin="B004CFGQM0" image-id="61xg7Qh2XgL" width="122" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.21　2015年9月号</book-name>
+							<book-release>2015-08-10</book-release>
+							<book-amazon asin="B010TKKMWQ" image-id="61YCd6du51L" width="110" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.17-18: 魔法少女服のまどか、ほむら、さやか、マミのピンナップポスター（原画: 谷口淳一郎）。</p>
-									<p>pp.32-33: <em>「魔法少女まどか☆マギカ　魔法少女名鑑」</em>蒼樹うめインタビュー、まどか、ほむら、マミ、さやかのキャラクター原案、設定絵が掲載。</p>
+									<p>表紙: まどか、ほむら（原画: 中村直人）</p>
+									<p>キャッチコピー: 「まどかのまぶしい――夏!!」</p>
+									<p>付録: 表紙イラストクリアファイル</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>娘TYPE　Vol.14</book-name>
-							<book-release>2010-11-30</book-release>
-							<book-amazon asin="B004CS4C96" image-id="6121drAzClL" width="124" height="160"></book-amazon>
+							<book-name>ニュータイプ　2015年10月号</book-name>
+							<book-release>2015-09-07</book-release>
+							<book-amazon asin="B0148CNZ9I" image-id="51KG65G+RKL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.58: 新番紹介。まどか、ほむら、マミ、さやかのキャラクター紹介（蒼樹うめによるキャラ設定イラスト）。虚淵玄コメント。キャストはまどかとほむらのみ掲載。</p>
+									<p>p.143: 「新房昭之のあの人とヒミツの話」で岩上敦宏（アニプレックス）と対談。後編のまどかとほむらの宇宙空間のシーンで服を着せる変更を行ったことに言及。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>まんがタイムきららフォワード　2011年1月号</book-name>
-							<book-release>2010-11-24</book-release>
-							<book-amazon asin="B0049B6F6Y" image-id="61ETPBiiWvL" width="110" height="160"></book-amazon>
+							<book-name>MdN　2015年11月号</book-name>
+							<book-release>2015-10-06</book-release>
+							<book-amazon asin="B015Z53XYO" image-id="61y837PwCgL" width="121" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.3-4: 『魔法少女まどか☆マギカ』2011年1月より放送予定。鹿目まどか、暁美ほむら、巴マミのキャラクターイラストとキャスト情報掲載。</p>
+									<p>p.7: 「蒼樹うめ展」開催情報とキービジュアル掲載。</p>
+									<p>p.102: 「フォントのショーケース」で「蒼樹うめ展」キービジュアルのタイトルロゴやキャッチコピーのフォント解説。</p>
+									<p><a href="https://books.mdn.co.jp/magazine/3215101011/" class="htmlbuild-host">公式ページ</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>ニュータイプ　2010年12月号</book-name>
-							<book-release>2010-11-10</book-release>
-							<book-amazon asin="B0049HV5K4" image-id="61del3RH6UL" width="124" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.22　2015年11月号</book-name>
+							<book-release>2015-10-09</book-release>
+							<book-amazon asin="B0158X17CS" image-id="61j1ROldSPL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>pp.48-49: 「SUPERNOVA 新星現わる 魔法少女まどか☆マギカ」新房昭之、虚淵玄のインタビュー。蒼樹うめによるまどか、ほむらのイラスト掲載。</p>
+									<p>表紙: まどか、杏子（イラスト: 川井マコト）</p>
+									<p>キャッチコピー: 「秋の夜長はまどかと一緒に！」</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメディア　2010年12月号</book-name>
-							<book-release>2010-11-10</book-release>
-							<book-amazon asin="B00494QTV2" image-id="61EKYWR6dqL" width="124" height="160"></book-amazon>
+							<book-name>まんがタイムきらら☆マギカ　Vol.23　2016年1月号</book-name>
+							<book-release>2015-12-10</book-release>
+							<book-amazon asin="B017XY63VU" image-id="61bJi1Y4hUL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.164: 新作紹介で『魔法少女まどか☆マギカ』。鹿目まどか制服、魔法少女服の原案イラスト（蒼樹うめ）掲載。「声／花澤香菜」と誤記（翌号で訂正）。</p>
+									<p>表紙: まどか、さやか、マミ、ベベ、キュゥべえ（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「まどか達からのとっておきのプレゼント♪」</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>アニメージュ　2010年12月号</book-name>
-							<book-release>2010-11-10</book-release>
-							<book-amazon asin="B0048G6Q50" image-id="61wmVHTjAwL" width="126" height="160"></book-amazon>
+							<book-name>ニュータイプ　2016年1月号</book-name>
+							<book-release>2015-12-10</book-release>
+							<book-amazon asin="B0188TZKVI" image-id="61+ImMYI+SL" width="126" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.147: 新作紹介。鹿目まどか原案イラスト（蒼樹うめ）掲載。</p>
+									<p>p.176: <em>「"魔法少女"の可能性」</em>新房昭之、久保田光俊による「コンセプトムービー」に関するインタビュー。</p>
+									<p>付録: バレエまどか&amp;マミ&amp;制服ほむらのB2ポスター（潮月一也）。</p>
+									<p><a href="https://www.youtube.com/watch?v=d0Ct1MXx2JE" class="htmlbuild-host">発売CM</a></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
-							<book-name>メガミマガジン　2010年12月号</book-name>
-							<book-release>2010-10-30</book-release>
-							<book-amazon asin="B00474KL90" image-id="61XR55tA6hL" width="124" height="160"></book-amazon>
+							<book-name>娘TYPE　2016年2月号</book-name>
+							<book-release>2015-12-26</book-release>
+							<book-amazon asin="B018XBUPHU" image-id="610ZyO9NdxL" width="125" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>p.115: <em>「1大プロジェクト始動! 魔法少女まどか★マギカ」</em>岩上敦宏プロデューサーインタビュー、蒼樹うめ原案の魔法少女（鹿目まどか）のシルエット掲載。</p>
+									<p>p.111: 「MADOGATARI展」広告。展示内容概略と札幌会場の予告。コンセプトムービーの場面カット。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2016年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ゲームラボ　2016年2月号</book-name>
+							<book-release>2016-01-16</book-release>
+							<book-amazon asin="B000DZID9C" image-id="616KMBlvFNL" width="114" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.99: 「発売&amp;放送禁止アニメ大全」で、災害を連想させる作品としてTV版11話で体育館に避難している鹿目家のキャプチャーが掲載（本放送では放送されず、パッケージ版に収録されたカット）。</p>
+									<p>p.104: 東日本大震災で『まどか☆マギカ』が4月に一挙放送という形になったことに言及。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.24　2016年3月号</book-name>
+							<book-release>2016-02-10</book-release>
+							<book-amazon asin="B01AM8KWVG" image-id="51ZG2dzsM4L" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、さやか（イラスト: 原悠衣）</p>
+									<p>キャッチコピー: 「2016年もまどかで決まり!!」</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2016年3月号</book-name>
+							<book-release>2016-02-10</book-release>
+							<book-amazon asin="B01AXOUUFC" image-id="61IlkLZ6K5L" width="125" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.157: 「新房昭之のあの人とヒミツの話」で、淀明子（アニプレックスプロデューサー）と対談、初めて新房監督に関わったのが『まどか☆マギカ』。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2016年4月号</book-name>
+							<book-release>2016-03-10</book-release>
+							<book-amazon asin="B01BY5LRFG" image-id="61j8rMpPPyL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>付録: B2ポスター: マミ、アルティメットまどか、悪魔ほむら（谷口淳一郎）。</p>
+									<p><a href="https://www.youtube.com/watch?v=c4YPtbsolOY" class="htmlbuild-host">発売CM</a></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>Cut　2016年4月号</book-name>
+							<book-release>2016-03-19</book-release>
+							<book-amazon asin="B01BCF8XZK" image-id="51C64EiF6nL" width="121" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.97: 梶浦由記の『僕だけがいない街』でのインタビュー内で『まどか☆マギカ』を『Fate/Zero』と比較したコメント。『まどか』は主人公が中学生で視野が狭いので、（視聴者寄りではなく）主人公目線を意識した話。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.25　2016年5月号</book-name>
+							<book-release>2016-04-09</book-release>
+							<book-amazon asin="B01C908MA8" image-id="51VGaI+g-CL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: バレエまどか（イラスト: 蒼樹うめ）</p>
+									<p>キャッチコピー: 「まどかと踊る?」</p>
+									<p>付録: 表紙イラストクリアファイル</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>MdN　2016年6月号</book-name>
+							<book-release>2016-05-06</book-release>
+							<book-amazon asin="B01E50ROE0" image-id="61WbBcCzXQL" width="121" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.73: 「惚れる悪の造形」でキュゥべえ紹介。</p>
+									<p><a href="https://books.mdn.co.jp/magazine/3216101006/" class="htmlbuild-host">公式ページ</a></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.26　2016年7月号</book-name>
+							<book-release>2016-06-10</book-release>
+							<book-amazon asin="B01FWHCSP0" image-id="61+fz4mAUuL" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: リボンほむら（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「全ては、まどかのために――」（※背表紙は「ハノカゲ[魔獣編]大好評連載中！」）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメディア　2016年7月号</book-name>
+							<book-release>2016-06-10</book-release>
+							<book-amazon asin="B01EVM3U3G" image-id="61a3RGJg-HL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.175-176: 水着の鹿目まどか、暁美ほむらA3ポスター（原画: 谷口淳一郎）。</p>
+									<p>付録: 同イラストのポストカード。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.27　2016年9月号</book-name>
+							<book-release>2016-08-09</book-release>
+							<book-amazon asin="B01IFI3HMQ" image-id="51SvRihhcfL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、ほむら、マミ、キュゥべえ（イラスト: 琴慈）</p>
+									<p>キャッチコピー: 「暑さを吹き飛ばすまどかの笑顔」</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.28　2016年11月号</book-name>
+							<book-release>2016-10-08</book-release>
+							<book-amazon asin="B01LWIA1R6" image-id="51WyIT-ku1L" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: アルティメットまどか、リボンほむら（イラスト: ハノカゲ）</p>
+									<p>キャッチコピー: 「まどかとなら、何処へでも――」</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.29　2017年1月号</book-name>
+							<book-release>2016-12-10</book-release>
+							<book-amazon asin="B01N64P4VK" image-id="51gCe94T5dL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、さやか、杏子（イラスト: はりかも）</p>
+									<p>キャッチコピー: 「まどかとすごす魔法の時間♪」</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2017年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきらら☆マギカ　Vol.30　2017年3月号</book-name>
+							<book-release>2017-02-09</book-release>
+							<book-amazon asin="B01N382U5A" image-id="51ouabljNLL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、ほむら（イラスト: 蒼樹うめ）</p>
+									<p>キャッチコピー: 「まどかがささやく魔法の呪文」</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>リスアニ!　Vol.28</book-name>
+							<book-release>2017-02-09</book-release>
+							<book-isbn>978-4-7897-7262-4</book-isbn>
+							<book-amazon asin="4789772624" image-id="51-IpMGl81L" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.81: ClariSのアルバム「Faily Castle」に関するインタビューで、『まどか☆マギカ』の時にスタッフが物語について何も教えてくれない状態で収録したこと、カレンは3曲の新録にあたり前のClariSのマネにならないようにしたこと、など。</p>
+									<p>表3: ClariS「Faily Castle」の広告。限定版に『まどか☆マギカ』主題歌3作の 2017ver. が収録されることが記載。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>MdN　2017年5月号</book-name>
+							<book-release>2017-04-06</book-release>
+							<book-amazon asin="B01MSTEHIW" image-id="51n+oixrMkL" width="121" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.102: 「PORTFOLIO NO.46 BALCOLONY.」で制作実績としてMADOGATARI展キービジュアルやウェブサイトデザイン紹介。</p>
+									<p>p.107: 同じくBALCOLONY.社でMADOGATARI展のデザインを担当した野条友史のコメント。</p>
+									<p><a href="https://books.mdn.co.jp/magazine/3217101005/" class="htmlbuild-host">公式ページ</a></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2017年7月号</book-name>
+							<book-release>2017-05-30</book-release>
+							<book-amazon asin="B06XZS277C" image-id="51GJ6MCNXPL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.68-69: 「それはボクたちの希望」マギアレコードの紹介記事。まどか、いろは、ほむら、さな、やちよ、フェリシア、鶴乃のキャラクタービジュアルとキャスト掲載、「コネクト」「ドッペル」などのシステム説明。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2017年8月号</book-name>
+							<book-release>2017-07-10</book-release>
+							<book-amazon asin="B072KPNKV4" image-id="61GH8caDhaL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.144-145: 「音楽と映像が、融合した日」 <a href="https://smemusictheater.jp/" class="htmlbuild-host">MUSIC THEATER 2017</a>のレポート記事。バックにアニメ作品の映像が流れるライブで、まどか☆マギカ関連では「コネクト」「Magia」の2曲が流れた。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>SWITCH　2017年8月号　Vol.35　No.8</book-name>
+							<book-release>2017-07-20</book-release>
+							<book-isbn>978-4-88418-495-7</book-isbn>
+							<book-amazon asin="4884184955" image-id="51FA+pyPnBL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.64-68: <em>「HISTORY OF HEROINE BY SHAFT シャフトが描いたヒロイン」</em>で蒼樹うめ×新房昭之の対談。キャラクターデザインの話など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2017年9月号</book-name>
+							<book-release>2017-08-09</book-release>
+							<book-amazon asin="B073ZYRKNM" image-id="612XxYBmtjL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.38-39: マギアレコード紹介。いろは、やちよ、フェリシア、レナ、かえで、ももこ、鶴乃、さなのキャラクター紹介、いろはの変身シーン。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>芸術新潮　2017年9月号</book-name>
+							<book-release>2017-08-25</book-release>
+							<book-amazon asin="B074JRWX4N" image-id="51v6K3nDqHL" width="118" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.62: 「私が愛したアニメ クリエイターズ・インタビュー」で新房昭之インタビュー。『まどか☆マギカ』と『コゼットの肖像』にY字路を出した話など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>Febri　Vol.44</book-name>
+							<book-release>2017-10-13</book-release>
+							<book-amazon asin="B076F739V9" image-id="51xGSaBC+aL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 環いろは、暁美ほむら（原画: 谷口淳一郎）</p>
+									<p>pp.4-33: <em>「巻頭特集　マギアレコード　魔法少女まどか☆マギカ外伝」</em>ゲームシステム紹介、メモリアリスト、魔法少女名鑑。</p>
+									<p>pp.27-29: 沼田誠也、谷口淳一郎によるゲームオープニング解説（絵コンテ、修正原画掲載）。</p>
+									<p>pp.30-31: 劇団イヌカレー・泥犬による魔法少女変身シーン&amp;ドッペル解説（杏子の絵コンテ掲載）。</p>
+									<p>pp.32-33: 佐藤允紀インタビュー。メインキャラクターは最初に武器とイメージカラーを決めてから蒼樹うめに描き下ろしてもらったこと、やちよなど一部のメインキャラクターがレアリティをあえて低く設定されている理由など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ダ・ヴィンチ　2017年12月号</book-name>
+							<book-release>2017-11-06</book-release>
+							<book-amazon asin="B076BS2CNX" image-id="511moTWbwRL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.179: 新房昭之、蒼樹うめのコメント。TVシリーズの脚本を書いていたときの話（新房）、虚淵玄と初めて会ったときの第一印象（蒼樹）など。蒼樹うめによる鹿目まどか、セイバー（Fate/Zero）、常守朱（PSYCHO-PASS）の描き下ろしイラストも掲載。</p>
+									<p>pp.185-186: 虚淵玄のロングインタビュー。TVシリーズ脚本打ち合わせ時のこと、キャラクターが露悪的にならないよう配慮したこと、新編の話作りのことなど。</p>
+									<p>pp.200-201: マギアレコードの紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>Febri　Vol.45</book-name>
+							<book-release>2017-11-25</book-release>
+							<book-amazon asin="B077YZFTHL" image-id="51POxH9m0uL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.62: マギレコ紹介（文: 本澤徹）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>コンプティーク　2018年1月号</book-name>
+							<book-release>2017-12-09</book-release>
+							<book-amazon asin="B077HP64CX" image-id="61XEXNIH0zL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.52-55: マギアレコードの紹介記事。まどか、いろは、ほむら、マミ、杏子、レナ、かえで、ももこ、やちよ、フェリシア、鶴乃のキャラクター紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2018年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>コンプティーク　2018年2月号</book-name>
+							<book-release>2018-01-10</book-release>
+							<book-amazon asin="B0788XQ6WR" image-id="61AhnR30wkL" width="112" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.114-117: マギアレコードの紹介記事。鶴乃★5解放「魔法少女の新たな力が解放される!」、<a href="http://www.bpnavi.jp/kuji/item/2281" class="htmlbuild-host">一番くじマギレコ第2弾</a>の情報、メモリア紹介。</p>
+									<p>p.177: スマートフォン用ゲーム<a href="http://lastperiod.happyelements.co.jp/" class="htmlbuild-host">『ラストピリオド』</a>とのコラボイベント紹介。アルティメットまどか、マミ（キュゥべえ衣装Ver）イラスト。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>コンプティーク　2018年3月号</book-name>
+							<book-release>2018-02-10</book-release>
+							<book-amazon asin="B0794Y8FKT" image-id="610M0X8mqKL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.118-119: マギアレコードの紹介記事。やちよ★5解放「背負った想いが新たな力を導く」。</p>
+									<p>pp.160-161: スマートフォン用ゲーム<a href="http://www.projecttokyodolls.jp/" class="htmlbuild-host">『プロジェクト東京ドールズ』</a>とのコラボイベント紹介。まどか、ほむら、マミの衣装を着たキャラクターのコラボカード。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>コンプティーク　2018年4月号</book-name>
+							<book-release>2018-03-10</book-release>
+							<book-amazon asin="B07B12HM4W" image-id="61fYCVIGFVL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.176-177: マギアレコードの紹介記事。美樹さやか登場「思い出を胸に青き剣士は戦う――」。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>コンプティーク　2018年5月号</book-name>
+							<book-release>2018-04-10</book-release>
+							<book-amazon asin="B07C8ZPQ9S" image-id="61GGgu6ba1L" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.120-121: マギアレコードの紹介記事。アリナ・グレイ実装「生と死を描く魔法少女登場――」。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>まんがタイムきららフォワード　2018年10月号</book-name>
+							<book-release>2018-08-24</book-release>
+							<book-amazon asin="B07F7RSQNG" image-id="61MFCVOgYlL" width="111" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.6: マギアレコードの広告。アルティメットまどか降臨、「Magia Day 2018」など。</p>
+									<p>pp.7-44: 『マギアレコード 魔法少女まどか☆マギカ外伝』（巻頭カラー）</p>
+									<p>pp.261-280: 『巴マミの平凡な日常』</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2018年10月号</book-name>
+							<book-release>2018-09-10</book-release>
+							<book-amazon asin="B07G1XXX1M" image-id="61UkYYcxSdL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.127: 「新房昭之のあの人とヒミツの話」で草川啓造との対談。『コゼットの肖像』の話の中で、新房昭之が[前編]（※[後編]の間違いと思われる）で1分くらいの長回しカットを入れた（鈴木博文が担当）ことに言及。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>MARQUEE　Vol.129</book-name>
+							<book-release>2018-10-10</book-release>
+							<book-isbn>978-4-434-25266-2</book-isbn>
+							<book-amazon asin="4434252666" image-id="51iX8HIlLOL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.52-53: けやき坂46の柿崎芽実と丹生明里による『舞台 マギアレコード』のインタビュー。柿崎は小学生の時に『まどか☆マギカ』を見ていたてマミがいちばん好き、フェリシアのハンマーは張りぼてではなく2kgくらいあった、など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2018年11月号</book-name>
+							<book-release>2018-10-10</book-release>
+							<book-amazon asin="B07H5VTZXQ" image-id="61mAb3Zv2iL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.151: マギアレコードアニメ化の情報（スタッフ、キャストは「未定」）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>デザインノート　No.82</book-name>
+							<book-release>2018-11-26</book-release>
+							<book-amazon asin="4416518609" image-id="61su1hODxQL" width="124" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.40: 草野剛が手掛けたデザイン例として「ニッポンのマンガ＊アニメ＊ゲーム」展（国立新美術館、2015年）の展示エリア写真。</p>
+									<p>p.47: 「BALCPLONY.」が手掛けたデザイン例として『マギアレコード』公式サイト。</p>
+									<p>pp.48-49: 染谷洋平インタビューで『まどか☆マギカ』に関わるきっかけなどが掲載。</p>
+									<p>p.58: 「BALCPLONY.」が手掛けたデザイン例として『SHAFT TEN』『MADOGATARI展』公式サイトなど。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2019年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2019年4月号</book-name>
+							<book-release>2019-03-09</book-release>
+							<book-amazon asin="B07NRF18Y5" image-id="510BJziYb7L" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.123: 「新房昭之のあの人とヒミツの話」で岩上敦宏との対談。新作に向けての打ち合わせは続いていること、TVシリーズ制作時の回想話。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2019年5月号</book-name>
+							<book-release>2019-04-10</book-release>
+							<book-amazon asin="B07P8B9LW5" image-id="51DbxIQwE3L" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.121: 「新房昭之のあの人とヒミツの話」で蒼樹うめとの対談。『マギアレコード』でキャラクター数が増えてきたことによる苦悩（蒼樹）、TVアニメのシナリオ会議に顔を出している（新房）など。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2019年10月号</book-name>
+							<book-release>2019-09-10</book-release>
+							<book-amazon asin="B07WYC2XF1" image-id="51eGW0Ez5vL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.60-61: 「約束を探して…」いろは&amp;やちよ&amp;ももこ&amp;レナ&amp;かえでのイラスト（篠原健二）、石川達也プロデューサーのコメント。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2019年11月号</book-name>
+							<book-release>2019-10-10</book-release>
+							<book-amazon asin="B07XV719XK" image-id="510g5Ii9WHL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.115: 「新房昭之のあの人とヒミツの話」で金沢利幸（アニプレックス）との対談。マギレコではゲームの手伝いを少しだけしている、[新編]公開時の新房昭之監督の取材は店で食事をしながら行うことが多かった、ほかにも[新編]の話。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2019年12月号</book-name>
+							<book-release>2019-11-09</book-release>
+							<book-amazon asin="B07Z761RN8" image-id="51P0+yId6xL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>p.107: 「新房昭之のあの人とヒミツの話」で冒頭に『マギアレコード』のTVアニメのアフレコがすでに終わっていることが一言だけ語られた。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2020年1月号</book-name>
+							<book-release>2019-12-10</book-release>
+							<book-amazon asin="B081KQ4M5D" image-id="61YGvlChxeL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.66-67: <em>「ウワサの街で…」</em>TVアニメ・マギアレコードの紹介記事。いろは&amp;黒江のイラスト（<a href="https://twitter.com/shaft_official/status/1204709708239474688" class="htmlbuild-host">原画: 山村洋貴</a>）、宮本幸裕インタビュー（黒江について、ウワサ空間のデザインにJ.A.シーザーが参加していること、章ごとに監督が異なることなど）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2020年1月号</book-name>
+							<book-release>2019-12-10</book-release>
+							<book-amazon asin="B081KQLJGT" image-id="51AL5oOS67L" width="128" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.82-83: <em>「表情豊かな少女たちの姿」</em>TVアニメ・マギアレコードの紹介記事。いろは&amp;やちよのイラスト（<a href="https://twitter.com/shaft_official/status/1204709708239474688" class="htmlbuild-host">原画: 杉山延寛</a>）、久保田光俊インタビュー（ゲームの企画段階から関わっていた、『まどか』の続きではなく新作のTVアニメとして作っているなど）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年2月号</book-name>
+							<book-release>2019-12-27</book-release>
+							<book-amazon asin="B0833S9ZFQ" image-id="517K-MZeW2L" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.9-10: いろは&amp;小さいキュゥべえのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1210492551179862016" class="htmlbuild-host">原画: 秋葉徹</a>）。</p>
+									<p>p.79: 「2020年冬のチュウ目作品23選」でTVアニメ・マギアレコードの紹介。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2020年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2020年2月号</book-name>
+							<book-release>2020-01-10</book-release>
+							<book-amazon asin="B082PPJCM6" image-id="51Ginn8ofbL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.44-45: 「秘々解明」TVアニメ・マギアレコードの紹介記事。いろは&amp;うい&amp;みたま&amp;小さいキュゥべえのイラスト（<a href="https://twitter.com/shaft_official/status/1215575061479821312" class="htmlbuild-host">原画: 高野晃久</a>）、麻倉もものコメント。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年3月号</book-name>
+							<book-release>2020-01-30</book-release>
+							<book-amazon asin="B0848KP7QM" image-id="51Q1wCDVYjL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: やちよのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1222824376799678465" class="htmlbuild-host">原画: 秋葉徹</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2020年3月号</book-name>
+							<book-release>2020-02-10</book-release>
+							<book-amazon asin="B083XTGVLJ" image-id="61vXBjQjc1L" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.62-63: 「やさしい孤高」TVアニメ・マギアレコードの紹介記事。やちよイラスト（<a href="https://twitter.com/shaft_official/status/1226852281993154561" class="htmlbuild-host">原画: 宮嶋仁志</a>）、雨宮天のインタビュー（第6話までの振り返りなど）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2020年3月号</book-name>
+							<book-release>2020-02-10</book-release>
+							<book-amazon asin="B083XVFP4M" image-id="51uwAsPac-L" width="121" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.34-37: 「Source of Rumor」TVアニメ・マギアレコードの紹介記事。いろは&amp;フェリシアのイラスト（<a href="https://twitter.com/shaft_official/status/1226852281993154561" class="htmlbuild-host">原画: 宮嶋仁志</a>）、佐倉綾音インタビュー（『まどか』1話に出演していたことなど）。</p>
+									<p>折り込みポスター: いろは&amp;フェリシア（原画: 宮嶋仁志）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年4月号</book-name>
+							<book-release>2020-02-29</book-release>
+							<book-amazon asin="B084WMGWYP" image-id="61ATxCfuoYL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: 鶴乃のピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1233700879460515841" class="htmlbuild-host">原画: 渥美智也</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>声優アニメディア　2020年4月号</book-name>
+							<book-release>2020-03-10</book-release>
+							<book-amazon asin="B084QCYBFC" image-id="51wto0ffzqL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>裏表紙: ドレス姿のいろは&amp;やちよ&amp;鶴乃。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>本の中身は未確認。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>アニメージュ　2020年4月号</book-name>
+							<book-release>2020-03-10</book-release>
+							<book-amazon asin="B084Z4K3BG" image-id="61iorSBt9sL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: いろは&amp;さなのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1237355188203077632" class="htmlbuild-host">原画未確認</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2020年4月号</book-name>
+							<book-release>2020-03-10</book-release>
+							<book-amazon asin="B084Z4K32C" image-id="61l7I7Gbr7L" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.34-37: 「Their branch point」やちよ&amp;みふゆ&amp;マミのイラスト（<a href="https://twitter.com/shaft_official/status/1237355188203077632" class="htmlbuild-host">原画: Izumi Takuya（漢字表記不明）</a>）、雨宮天インタビュー。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年5月号</book-name>
+							<book-release>2020-03-30</book-release>
+							<book-amazon asin="B086D88XL9" image-id="51R-5b5xHkL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: ホーリーマミのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1244588014136745984" class="htmlbuild-host">原画未確認</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ニュータイプ　2020年5月号</book-name>
+							<book-release>2020-04-10</book-release>
+							<book-amazon asin="B085RQN3L1" image-id="617eD50dDqL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.92-95: <em>「魔法少女のそのウワサ」</em>水橋かおりインタビュー、ディレクター座談会（宮本幸裕×岡田堅二郎×吉澤翠）。</p>
+									<p>いろは&amp;やちよイラストのB2ポスター（原画未確認）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年6月号</book-name>
+							<book-release>2020-04-30</book-release>
+							<book-amazon asin="B087Q2W7MX" image-id="61AJ9JBbGzL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: フェリシアのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1255839038914744320" class="htmlbuild-host">原画未確認</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年7月号</book-name>
+							<book-release>2020-05-29</book-release>
+							<book-amazon asin="B0897F5LC6" image-id="61KX1ncCAiL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: さなのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1266695964200275968" class="htmlbuild-host">原画未確認</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年8月号</book-name>
+							<book-release>2020-06-30</book-release>
+							<book-amazon asin="B08BWT8BQ1" image-id="61O0lul+4TL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: みふゆのピンナップイラスト（<a href="https://twitter.com/shaft_official/status/1278987717406154753" class="htmlbuild-host">原画未確認</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年9月号</book-name>
+							<book-release>2020-07-30</book-release>
+							<book-amazon asin="B08CWJ4WFY" image-id="61Z8Nhz5QAL" width="126" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: 里見灯花のピンナップイラスト（<a href="https://twitter.com/MegamiMAGAZINE/status/1288011537613901830" class="htmlbuild-host">原画未確認</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>メガミマガジン　2020年10月号</book-name>
+							<book-release>2020-08-28</book-release>
+							<book-amazon asin="B08FTLNM7L" image-id="61ScgQI3DpL" width="127" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>掲載ページ未確認: さやかのピンナップイラスト（<a href="https://twitter.com/MegamiMAGAZINE/status/1298545722594226176" class="htmlbuild-host">原画未確認</a>）。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>ダ・ヴィンチ　2020年10月号</book-name>
+							<book-release>2020-09-04</book-release>
+							<book-amazon asin="B08F6TF7MK" image-id="51sDX7GUblL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: まどか、いろは（原画: 谷口淳一郎）</p>
+									<p>pp.168-177: <em>「特別企画　マギアレコード魔法少女まどか☆マギカ外伝」</em>スタッフインタビュー、キャスト座談会。このうち、「ダ・ヴィンチニュース」のサイトで<a href="https://ddnavi.com/interview/668574/a/" class="htmlbuild-host">劇団イヌカレーが語るクリエイティブの原点</a>、<a href="https://ddnavi.com/interview/668197/a/" class="htmlbuild-host">みかづき荘座談会</a>、<a href="https://ddnavi.com/interview/668561/a/" class="htmlbuild-host">見滝原魔法少女座談会</a>が公開されている。</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2021年</h2>
+						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>リスアニ!　Vol.43.1「ClariS音楽大全“クラリスアニ！”」</book-name>
+							<book-release>2021-02-17</book-release>
+							<book-isbn>978-4-7897-7320-1</book-isbn>
+							<book-amazon asin="4789773205" image-id="515eM01TpCL" width="113" height="160"></book-amazon>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.116-119: 湯浅篤インタビュー。あえて『まどマギ』を観ていない、「カラフル」制作時も予告編しか観ていない。</p>
+									<p>pp.120-123: 渡辺翔インタビュー。「コネクト」制作時のバイト先でのエピソード、ClariSメンバーと初めて会った時の話、「コネクト」のみならず「カラフル」もストーリーは知らされていなかった（ただしストーリーとリンクはさせて欲しいというオーダーだった）こと。</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>

--- a/html/madoka/library/newspaper.html
+++ b/html/madoka/library/newspaper.html
@@ -43,1019 +43,149 @@
 				<main class="l-content__main">
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
-							<h2>2019年</h2>
+							<h2>2011年</h2>
 						</div>
 
 						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>日刊スポーツ</newspaper-name>
-							<newspaper-release>2019-01-19</newspaper-release>
+							<newspaper-name>毎日新聞</newspaper-name>
+							<newspaper-release>2011-01-21</newspaper-release>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>8面: 「メドベ&amp;ザギトワ日本CMでコラボ」21日から放送されるマギレコCM出演について。本文は<a href="https://www.nikkansports.com/sports/news/201901180000877.html" class="htmlbuild-host">ウェブ記事</a>より多少削減されている。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2018年</h2>
-						</div>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞</newspaper-name>
-							<newspaper-release>2018-10-29</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>20面（広告）: <em>「明かされる百江なぎさの過去――」</em>マギアレコード、なぎさ全面広告（カラー）</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>北海道版は17面、大阪版は28面、西部版は22面、名古屋版は未確認。</li>
-								</ul>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2018-10-29</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>27面（広告）: <em>「――明かされる百江なぎさの過去」</em>マギアレコード、なぎさ全面広告（カラー）</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>中部版は25面、大阪版は29面、北海道版、北陸版、西部版は未確認。</li>
-								</ul>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2017年</h2>
-						</div>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>東奥日報</newspaper-name>
-							<newspaper-release>2017-12-17</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>18面（第4社会）: 「蒼樹うめの世界 丸ごと」蒼樹うめ展in青森の紹介。館内『ひだまりスケッチ』コーナーの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞</newspaper-name>
-							<newspaper-release>2017-12-17</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>24面: 「愛らしいキャラ 一堂に」蒼樹うめ展in青森の紹介。館内『ひだまりスケッチ』コーナーの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>陸奥新報</newspaper-name>
-							<newspaper-release>2017-12-17</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>2面: 「愛らしいキャラ 多彩に」蒼樹うめ展in青森の紹介。館内『ひだまりスケッチ』コーナーの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>デーリー東北</newspaper-name>
-							<newspaper-release>2017-11-11</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>22面（第2社会）: 「来月からイラストレーター蒼樹うめ氏作品展 青森放送 ラッピングでPR」蒼樹うめ展in青森の紹介。青森放送本社のキュゥべえラッピングの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>東奥日報</newspaper-name>
-							<newspaper-release>2017-11-11</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>22面（第4社会）: 『壁にキュゥべえの顔「蒼樹うめ展を」PR』蒼樹うめ展in青森の紹介。青森放送本社のキュゥべえラッピングの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>陸奥新報</newspaper-name>
-							<newspaper-release>2017-11-11</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>2面: 「外壁に「キュゥべえ」」蒼樹うめ展in青森の紹介。青森放送本社のキュゥべえラッピングの写真掲載。</p>
+									<p>2面（特集ワイド）: 「まんたんプレス」で1月期の深夜アニメ紹介。『まどか☆マギカ』については「事前情報がほとんどないのも話題になっている」と紹介。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
 							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2017-05-15</newspaper-release>
+							<newspaper-release>2011-03-02</newspaper-release>
 							<newspaper-class>夕刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>9面: 5月3日にNHK BSプレミアムで放送された<a href="https://web.archive.org/web/20170517133312/http://www.nhk.or.jp/anime/anime100/program/" class="htmlbuild-host">ニッポンアニメ100 発表！あなたが選ぶアニメ ベスト100</a>で『まどか☆マギカ』（TVシリーズ）が3位になったこと。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞（新潟）</newspaper-name>
-							<newspaper-release>2017-02-20</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>23面（新潟）: 「蒼樹うめさんの世界 スケッチやセットに」蒼樹うめ展in新潟の紹介。キービジュアルのパネル展示写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（新潟）</newspaper-name>
-							<newspaper-release>2017-02-18</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>23面（新潟）: 「蒼樹うめ展 きょう新潟で開幕」。ひだまりスケッチエリアの写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>fumufumu J（新潟日報社のこども新聞）</newspaper-name>
-							<newspaper-release>2017-02-12</newspaper-release>
-							<newspaper-class>vol.43</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>5面: 『ひだまりスケッチ』の紹介と共に「蒼樹うめ展 in 新潟」の告知。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2016年</h2>
-						</div>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2016-12-29</newspaper-release>
-							<newspaper-class>コミケ特別号外（C91）</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>2面: C91で販売されるMADOGATARI展グッズ紹介。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2016-12-23</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>28面: 「「MADOGATARI展」金沢21世紀美術館で開幕」。物販エリアの撮影コーナーの写真。（※読売新聞中部支社版は24面）</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>北國新聞</newspaper-name>
-							<newspaper-release>2016-12-23</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>32面: 「アニメ原画 目凝らす 21美「マドガタリ」開幕」</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2016-09-27</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>20面: 「SLOT魔法少女まどか☆マギカ2」の紹介。筐体写真やゲーム内映像が多数掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2016-09-23</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>22面: 「「MADOGATARI展」開幕」東京アンコール展の紹介。スポーツ報知ブース写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2016-08-12</newspaper-release>
-							<newspaper-class>コミケ特別号外（C90）</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>2面: C90で販売されるMADOGATARI展グッズ紹介。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>The Japan News</newspaper-name>
-							<newspaper-release>2016-07-30</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>9面: C90のスポーツ報知によるMADOGATARI展グッズ販売紹介。（※英語）</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2016-05-05</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>25面: 「「MADOGATARI展」名古屋で開幕」3面シアターでコンセプトムービーを上映中の写真。</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>レイアウトは大阪と中部が同じ、東京は異なる。読売新聞中部支社版は21面。</li>
-								</ul>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>中日新聞</newspaper-name>
-							<newspaper-release>2016-05-05</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>10面（市民）: 「まどか☆マギカ アニメ原画展示」MADOGATARI展（名古屋）の紹介。まどかコーナーの写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>中日新聞</newspaper-name>
-							<newspaper-release>2016-04-30</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>32面（テレビ欄）: MADOGATARI展名古屋会場の広告。キービジュアル（ほむら、忍）カラー掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2016-03-19</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>27面: 「イラスト原画や作業机公開」蒼樹うめ展大阪会場の開催案内。劇場版色紙コーナーの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2016-03-17</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>21面（文化）: 「19日から「蒼樹うめ展 in 大阪」」</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞（東京）</newspaper-name>
-							<newspaper-release>2016-03-11</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>4面（文化）: スペイン映画<a href="http://www.bitters.co.jp/magicalgirl/" class="htmlbuild-host">『マジカル・ガール』</a>の紹介で、ベルムト監督が影響を受けた作品として『まどか☆マギカ』の名が挙がる。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2016-03-07</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>11面（特集）: 「蒼樹うめ展 in 大阪」の広告（カラー）。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2016-03-06</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>8面（読書）: 「蒼樹うめ展 in 大阪」の紹介。『ひだまりスケッチ』のイラスト掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2016-02-16</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>6面（特集）: 「蒼樹うめ展 in 大阪」の広告（カラー）。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>北海道新聞</newspaper-name>
-							<newspaper-release>2016-02-12</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>7面: 「札幌で「MADOGATARI展」」物販コーナー脇に掲出された大型タペストリーの写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2016-02-10</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>22面（芸能）: 「「MADOGATARI展」札幌で開幕」まどかコーナーの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2016-02-09</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>10面（社会）: 「蒼樹うめ展 in 大阪」の広告（カラー）。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2016-02-07</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>21面: 「個性的キャラの”素顔”を見よう」蒼樹うめ展 in 大阪の紹介。前後編イメージビジュアル、『ひだまりスケッチ×ハニカム』キービジュアル掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2016-02-06</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>21面: 「「MADOGATARI展」像登場」さっぽろ雪まつりの雪像とMADOGATARI展（札幌）の紹介。まどか、忍、キュゥべえの雪像写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>Frankfurter Allgemeine</newspaper-name>
-							<newspaper-release>2016-01-15</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>Feuilleton 11面: 「Eine Mädchentragödie」ドイツでのDVD発売に伴う『まどか☆マギカ』作品紹介。新編の場面ショット掲載（カラー）。</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>17日付けで Web サイトでも記事が公開、<a href="http://www.faz.net/aktuell/feuilleton/kino/anime-madoka-magica-eine-maedchentragoedie-14014295.html" class="htmlbuild-host">Animé „Madoka Magica“: Eine Mädchentragödie - Kino - FAZ</a>。</li>
-								</ul>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2015年</h2>
-						</div>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>スポーツ報知</newspaper-name>
-							<newspaper-release>2015-12-23</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>23面（芸能）: 「MADOGATARI展 27日まで開催」大阪会場ウェルカムトンネルの写真。</p>
+									<p>7面: 「注目ワード 魔法少女まどか☆マギカ」（福田淳）、8話放送時点での作品紹介。虚淵玄のコメント「夢と希望の物語で終わらせるつもりだけど、見ている人がそう思ってくれるかどうかは分からない」。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
 							<newspaper-name>産経新聞（東京）</newspaper-name>
-							<newspaper-release>2015-10-03</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>1面: 「「蒼樹うめ展」きょう開幕」まどか☆マギカエリアの写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（東京）</newspaper-name>
-							<newspaper-release>2015-10-01</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>16面（特集）: <em>蒼樹うめ展新聞</em> 小林宏之（「まんがタイムきらら」グループ編集長）、蒼樹うめコメント。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞</newspaper-name>
-							<newspaper-release>2015-09-29</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>21面（文化）: 「「蒼樹うめ展」3日スタート」蒼樹うめコメント（予備校時代や『ひだまりスケッチ』に関する話のみ）。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>河北新報</newspaper-name>
-							<newspaper-release>2015-08-12</newspaper-release>
+							<newspaper-release>2011-03-03</newspaper-release>
 							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>29面（社会）: さくら野百貨店 仙台店「まどか☆マギカショップ」の広告（モノクロ）。</p>
+									<p>13面（Web）: 「今週のネット語」に「僕と契約して、魔法少女になってよ!」。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>河北新報</newspaper-name>
-							<newspaper-release>2015-08-05</newspaper-release>
+							<newspaper-name>毎日新聞（大阪）</newspaper-name>
+							<newspaper-release>2011-03-09</newspaper-release>
 							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>22面（みやぎ）: さくら野百貨店 仙台店「まどか☆マギカショップ」の広告（カラー）。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2015-03-31</newspaper-release>
-							<newspaper-class>popstyle</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>3面: <a href="https://web.archive.org/web/20151012214219/http://sugoi-japan.jp/2015" class="htmlbuild-host">SUGOI JAPAN</a>「グランプリは「魔法少女まどか☆マギカ」」表彰式での岩上敦宏、久保田光俊の写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2015-03-21</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>5面: <a href="https://web.archive.org/web/20151012214219/http://sugoi-japan.jp/2015" class="htmlbuild-host">SUGOI JAPAN</a><em>「初代グランプリは「魔法少女まどか☆マギカ」」</em>岩上敦宏、久保田光俊コメント掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2015-03-13</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>37面（社会）: SUGOI JAPAN で<a href="http://sugoi-japan.jp/2015/result.html" class="htmlbuild-host">グランプリに選ばれた</a>こと。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（東京）</newspaper-name>
-							<newspaper-release>2015-01-08</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>19面（特集）: 「産経新聞社 2015 主な文化事業」に蒼樹うめ展（上野の森美術館）情報。『きらきらころころ』イラスト掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2014年</h2>
-						</div>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>毎日新聞（北海道）</newspaper-name>
-							<newspaper-release>2014-11-03</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>25面: 新千歳空港で開催中の「国際アニメーション映画祭」の紹介。巴マミ等身大フィギュアの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>新潟日報</newspaper-name>
-							<newspaper-release>2014-10-03</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>17面（新潟・佐渡）: 「[マンガ・アニメ情報館] 誘客明暗 [マンガの家]」まどか☆マギカ展にも言及。杏さや等身大フィギュアの写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>河北新報</newspaper-name>
-							<newspaper-release>2014-08-05</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>15面（みやぎ）: さくら野百貨店 仙台店「まどか☆マギカショップ」の広告（カラー）。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞（新潟）</newspaper-name>
-							<newspaper-release>2014-08-01</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>22面（第2新潟）: 「まどか☆マギカ展」新潟の紹介。暁美ほむら等身大フィギュア写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>千歳民報</newspaper-name>
-							<newspaper-release>2014-07-28</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>11面（社会）: 「アニメフェア始まる 新千歳の夏休みイベント」<a href="http://www.new-chitose-airport.jp/ja/corporate/press/pdf/pdf-20140725_natuyasumi.pdf" class="htmlbuild-host">新千歳空港アニメフェア2014</a>の記事。ラッピングカー（ランボルギーニ）の写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>新潟日報</newspaper-name>
-							<newspaper-release>2014-07-26</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>15面: 「人気アニメを体感」まどか☆マギカ展 新潟の紹介。内覧会での暁美ほむら等身大フィギュア写真（カラー）。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞（新潟）</newspaper-name>
-							<newspaper-release>2014-07-21</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>32面（第2新潟）: 「大切なこと 新潟で学んだ」吉田聖子（上条恭介役）のインタビュー。まどか☆マギカ展新潟会場の告知。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2014-07-14</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>32面（クール）: ジャパンエキスポでの Kalafina 出演の紹介。 [新編] キービジュアル掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2014-06-10</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>2面: 「お菓子はエンタメ」（和田浩司）、あにしゅがクリスマスケーキの話。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>中日新聞</newspaper-name>
-							<newspaper-release>2014-04-28</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>6面（文化）: ラノベのすゝめ 「まどマギ」小説版から。波戸岡景汰（明治大准教授）による紹介。小説版(上)の表紙掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>東京新聞</newspaper-name>
-							<newspaper-release>2014-04-28</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>6面（文化）: ラノベのすゝめ 「まどマギ」小説版から。波戸岡景汰（明治大准教授）による紹介。小説版(上)の表紙掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2014-02-21</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>32面（地域）: 「アニメの画像歩いてゲット」東京都杉並区で行われている<a href="https://web.archive.org/web/20140313184014/http://www.chuosen-rr.com/aniwalk.html" class="htmlbuild-host">アニ×ウォーク</a>の記事。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2013年</h2>
-						</div>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>毎日新聞（西部）</newspaper-name>
-							<newspaper-release>2013-12-07</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>25面（地域）: 映画コラムニストのナンシー下関による [新編] の紹介。「複雑で難解なSF」「（悪役魔女の造形から）娯楽映画のジャンルを超越し、アートの領域に踏み出している」との評。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>Los Angels Times</newspaper-name>
-							<newspaper-release>2013-12-06</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>CALENDAR D15面: 「Trippy anime fired by magic」[新編]の紹介。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2013-11-25</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>18面（文化）: 「ハードな展開+こだわり映像」[新編]紹介、新房昭之コメント。（東京版の11月16日の記事と同内容）</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（東京）</newspaper-name>
-							<newspaper-release>2013-11-16</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>13面（文化）: 「かわいさとシリアス 混沌の魅力」[新編]紹介、新房昭之コメント。</p>
-								</div>
-
-								<ul class="p-notes">
-									<li><a href="https://www.sankei.com/entertainments/news/131116/ent1311160004-n1.html" class="htmlbuild-host">産経ニュース</a>で全文が公開されている。</li>
-								</ul>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞（新潟）</newspaper-name>
-							<newspaper-release>2013-11-15</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>31面（地域）: 「真夜中封切りアニメ満席」新編公開の話題。「T・ジョイ新潟万代」では初めて午前0時の上映を行ったが完売したこと。「T・ジョイ長岡」の暁美ほむら等身大パネルの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞</newspaper-name>
-							<newspaper-release>2013-11-02</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>3面（文化）: <em>「あの結末には続きがあった」</em>[新編]紹介。新房昭之、須川亜紀子（関西外国語大講師）のコメント。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>日経MJ（流通新聞）</newspaper-name>
-							<newspaper-release>2013-10-09</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>9面: 長栄交通（北海道）の痛タクシー紹介。『まどか☆マギカ』ラッピング車両の写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞（大阪）</newspaper-name>
-							<newspaper-release>2013-09-22</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>29面（地域）: 「りんくうにぎわいフェスタ」で絵コンテや複製原画の展示が行われていること。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2013-06-06</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>11面: 「語り継ぐテレビ60年」で少女アニメの話題。『まどか☆マギカ』についても少し触れられる。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞（名古屋）</newspaper-name>
-							<newspaper-release>2013-03-27</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>30面: <em>SQフィギュア〜佐倉杏子〜の全面広告</em>（カラー）。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2012年</h2>
-						</div>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞</newspaper-name>
-							<newspaper-release>2012-11-10</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>28面（第2東京）: 「練馬アニメカーニバル」紹介。文化庁メディア芸術祭アニメ部門大賞「魔法少女まどか☆マギカ」（ダイジェスト版）上映。</p>
+									<p>22面（大阪）: Kalafinaの新曲「Magia」紹介。3人のコメント。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
 							<newspaper-name>読売新聞（東京）</newspaper-name>
-							<newspaper-release>2012-10-18</newspaper-release>
+							<newspaper-release>2011-04-21</newspaper-release>
 							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>34面（地域）: スポーツ報知「魔法少女まどか☆マギカ特別号」発行告知。</p>
+									<p>18面（広告）: <em>「完結編 本日放送 魔法少女まどか☆マギカ」</em>TBSにて27時00分より 第10話・第11話・第12話 連続放送</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>徳島新聞</newspaper-name>
-							<newspaper-release>2012-10-07</newspaper-release>
-							<newspaper-class>マチ★アソビ速報 vol.9</newspaper-class>
+							<newspaper-name>読売新聞（大阪）</newspaper-name>
+							<newspaper-release>2011-04-21</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>「ufotable CINEMA」で行われた舞台挨拶（喜多村英梨、加藤英美里）の写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>徳島新聞</newspaper-name>
-							<newspaper-release>2012-10-06</newspaper-release>
-							<newspaper-class>マチ★アソビ速報 vol.9</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>眉山ロープウェイのアナウンスを行った悠木碧、斎藤千和のコメントを掲載（コメント自体には作品に関わる内容はほとんどない）。</p>
+									<p>12面（広告）: <em>「完結編 本日放送 魔法少女まどか☆マギカ」</em>MBSにて26時40分より第11話・第12話 連続放送</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
 							<newspaper-name>朝日新聞</newspaper-name>
-							<newspaper-release>2012-07-14</newspaper-release>
+							<newspaper-release>2011-05-07</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>3面（文化）: 茶話アニメ「魔法少女の成長物語」（藤津亮太）、鹿目家の母娘の関係に焦点を当てた考察。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>2018年発行の<a href="https://www.amazon.co.jp/dp/B07D9QS816/" class="htmlbuild-host htmlbuild-amazon-associate">新聞に載ったアニメレビュー</a>にも収録。</li>
+								</ul>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2011-06-04</newspaper-release>
 							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>b4面: 『まどか☆マギカ』紹介。Blu-ray1巻パッケージ掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>徳島新聞</newspaper-name>
-							<newspaper-release>2012-05-03</newspaper-release>
-							<newspaper-class>号外（マチ★アソビ速報 vol.8）</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>『魔法少女まどか☆マギカ ポータブル』のイラストが描かれた「橋の下美術館」の写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（大阪）</newspaper-name>
-							<newspaper-release>2012-04-06</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>20面（文化）: 「「まどか☆マギカ」3賞受賞」東京国際アニメフェア2012での第11回アニメアワード表彰式（テレビ部門優秀作品賞、個人部門監督賞、脚本賞）。虚淵玄、久保田光俊の写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>熊本日日新聞</newspaper-name>
-							<newspaper-release>2012-03-31</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>8面: 「「魔法少女まどか☆マギカ」が3賞」東京国際アニメフェア2012での第11回アニメアワード表彰式（テレビ部門優秀作品賞、個人部門監督賞、脚本賞）。虚淵玄、久保田光俊の写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>中日スポーツ</newspaper-name>
-							<newspaper-release>2012-03-21</newspaper-release>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>24面: 「名古屋で魔法少女まどか☆マギカ展 限定グッズにファン長い列」グッズ待機列と巴マミ等身大フィギュア写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>中日新聞</newspaper-name>
-							<newspaper-release>2012-03-21</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>18面（愛知）: 「魔法少女まどか☆マギカ 名シーン再現の企画展」まどか☆マギカ展（名古屋）の紹介。巴マミ等身大フィギュアの写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>中日新聞</newspaper-name>
-							<newspaper-release>2012-03-20</newspaper-release>
-							<newspaper-class>「魔法少女まどか☆マギカ」特集号</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>表面: <em>「新時代の「魔法少女」に託すアニメーションの可能性」</em>新房監督インタビュー（16日朝刊に掲載された記事の再構成）。キーイラスト・キャラクター画像等掲載。作品紹介。</p>
-									<p>裏面: まどか☆マギカ展名古屋会場の情報。会場マップ、トークショースケジュール、物販グッズ。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>中日新聞</newspaper-name>
-							<newspaper-release>2012-03-16</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>29面（全面広告）: <em>「新時代の「魔法少女」に託すアニメーションの可能性」</em>、新房昭之インタビュー。震災後の一挙放送は、本音としては1話ずつ見せたかったことなど。下部は「まどか☆マギカ展」名古屋会場広告。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-					</section>
-					<section class="p-section -hdg-a htmlbuild-heading-self-link">
-						<div class="p-section__hdg">
-							<h2>2011年</h2>
-						</div>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>東京新聞</newspaper-name>
-							<newspaper-release>2011-12-06</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>15面（芸能ワイド）: 「オリジナル作品 快進撃」2011年のアニメ総括。MBS丸山博雄プロデューサーのコメント。『まどか☆マギカ』以外にも『TIGER&amp;BUNNY』や『輪るピングドラム』などの名も挙がる。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞</newspaper-name>
-							<newspaper-release>2011-12-05</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>30面（文化）: 空気系アニメの紹介で『けいおん!』が紹介され、一見すると空気系だが異なる興奮をもたらしたアニメとして『まどか☆マギカ』の名が挙がる。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>産経新聞（東京）</newspaper-name>
-							<newspaper-release>2011-12-01</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>16面: ネット流行語大賞2011の3位（銅賞）に「僕と契約して、○○になってよ!」がランクイン。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>東京新聞</newspaper-name>
-							<newspaper-release>2011-10-13</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>14面（芸能ワイド）: タイムライン（TOKYO FM）で『まどか☆マギカ』が取り上げられる旨紹介。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>徳島新聞</newspaper-name>
-							<newspaper-release>2011-10-10</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>24面（社会）: マチ☆アソビの新町橋東公園で『まどか☆マギカ』の声優トークショーがあり、約800人が集まったこと。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>徳島新聞</newspaper-name>
-							<newspaper-release>2011-10-10</newspaper-release>
-							<newspaper-class>号外（マチ★アソビ速報 vol.7）</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>9日午後に行われた『魔法少女まどか☆マギカ ポータブル』トークショーの写真掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>徳島新聞</newspaper-name>
-							<newspaper-release>2011-10-09</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>1面（総合）: <em>「アニメ賞 21部門決定」</em>アニメアワードの記事。トロフィーを受け取る岩上敦宏、久保田光俊の写真掲載。</p>
-									<p>28面（社会）: アニメアワードの記事。野外スクリーンで流れる10話の写真。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>徳島新聞</newspaper-name>
-							<newspaper-release>2011-10-09</newspaper-release>
-							<newspaper-class>号外（マチ★アソビ速報 vol.7）</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>9日午後に行われた『魔法少女まどか☆マギカ ポータブル』トークショーと、喜多村英梨のライブに関する記事。</p>
+									<p>25面（スポーツ）: <em>「アニメの明日へ、あなたの思いを。」</em>（アニプレックス求人広告）に鹿目まどかのイラスト。なお、同日の朝日新聞27面（スポーツ）には『あの日見た花の名前を僕達はまだ知らない。』のめんまが掲載。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
 							<newspaper-name>毎日新聞</newspaper-name>
-							<newspaper-release>2011-10-05</newspaper-release>
+							<newspaper-release>2011-06-13</newspaper-release>
 							<newspaper-class>夕刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>4面（文化）: そのほかのニュース「覇権アニメの研究」（萩原魚雷）</p>
+									<p>2面（特集ワイド）: 「まんたんプレス」で『まどか☆マギカ』紹介。多根清史（「オトナアニメ」スーパーバイザー）、岩上敦宏のコメント掲載。最終話放送の新聞全面広告の話や、「続編も作りたい」という制作陣のコメント。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>日本経済新聞</newspaper-name>
-							<newspaper-release>2011-10-04</newspaper-release>
+							<newspaper-name>東京新聞</newspaper-name>
+							<newspaper-release>2011-06-24</newspaper-release>
 							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>31面（消費）: グッドスマイルカンパニーと鉄人化計画が秋葉原にカフェを開設した記事。</p>
+									<p>11面（首都圏情報）: 千葉県松戸市の「グッドスマイルカフェ」情報。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>日経MJ（流通新聞）</newspaper-name>
+							<newspaper-release>2011-06-27</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>7面: 「震災とサブカルチャー」震災、原発からアニメを読み解くテーマで『まどか☆マギカ』も題材に挙げられる。文化誌「Switch」、月刊誌「サイゾー」で取り上げられた例も紹介。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>日経MJ（流通新聞）</newspaper-name>
+							<newspaper-release>2011-07-29</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>16面: <em>「型破り「魔法少女」度肝抜く展開」</em>岩上敦宏、虚淵玄コメント。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞</newspaper-name>
+							<newspaper-release>2011-08-30</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>18面（文化）: <em>「過去からの予言5」</em>虚淵玄インタビュー。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
@@ -1078,145 +208,1015 @@
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞</newspaper-name>
-							<newspaper-release>2011-08-30</newspaper-release>
+							<newspaper-name>日本経済新聞</newspaper-name>
+							<newspaper-release>2011-10-04</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>31面（消費）: グッドスマイルカンパニーと鉄人化計画が秋葉原にカフェを開設した記事。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>毎日新聞</newspaper-name>
+							<newspaper-release>2011-10-05</newspaper-release>
 							<newspaper-class>夕刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>18面（文化）: <em>「過去からの予言5」</em>虚淵玄インタビュー。</p>
+									<p>4面（文化）: そのほかのニュース「覇権アニメの研究」（萩原魚雷）</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>日経MJ（流通新聞）</newspaper-name>
-							<newspaper-release>2011-07-29</newspaper-release>
+							<newspaper-name>徳島新聞</newspaper-name>
+							<newspaper-release>2011-10-09</newspaper-release>
+							<newspaper-class>号外（マチ★アソビ速報 vol.7）</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>16面: <em>「型破り「魔法少女」度肝抜く展開」</em>岩上敦宏、虚淵玄コメント。</p>
+									<p>9日午後に行われた『魔法少女まどか☆マギカ ポータブル』トークショーと、喜多村英梨のライブに関する記事。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>日経MJ（流通新聞）</newspaper-name>
-							<newspaper-release>2011-06-27</newspaper-release>
+							<newspaper-name>徳島新聞</newspaper-name>
+							<newspaper-release>2011-10-09</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>7面: 「震災とサブカルチャー」震災、原発からアニメを読み解くテーマで『まどか☆マギカ』も題材に挙げられる。文化誌「Switch」、月刊誌「サイゾー」で取り上げられた例も紹介。</p>
+									<p>1面（総合）: <em>「アニメ賞 21部門決定」</em>アニメアワードの記事。トロフィーを受け取る岩上敦宏、久保田光俊の写真掲載。</p>
+									<p>28面（社会）: アニメアワードの記事。野外スクリーンで流れる10話の写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>徳島新聞</newspaper-name>
+							<newspaper-release>2011-10-10</newspaper-release>
+							<newspaper-class>号外（マチ★アソビ速報 vol.7）</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>9日午後に行われた『魔法少女まどか☆マギカ ポータブル』トークショーの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>徳島新聞</newspaper-name>
+							<newspaper-release>2011-10-10</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>24面（社会）: マチ☆アソビの新町橋東公園で『まどか☆マギカ』の声優トークショーがあり、約800人が集まったこと。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
 							<newspaper-name>東京新聞</newspaper-name>
-							<newspaper-release>2011-06-24</newspaper-release>
+							<newspaper-release>2011-10-13</newspaper-release>
 							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>11面（首都圏情報）: 千葉県松戸市の「グッドスマイルカフェ」情報。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>毎日新聞</newspaper-name>
-							<newspaper-release>2011-06-13</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>2面（特集ワイド）: 「まんたんプレス」で『まどか☆マギカ』紹介。多根清史（「オトナアニメ」スーパーバイザー）、岩上敦宏のコメント掲載。最終話放送の新聞全面広告の話や、「続編も作りたい」という制作陣のコメント。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2011-06-04</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>25面（スポーツ）: <em>「アニメの明日へ、あなたの思いを。」</em>（アニプレックス求人広告）に鹿目まどかのイラスト。なお、同日の朝日新聞27面（スポーツ）には『あの日見た花の名前を僕達はまだ知らない。』のめんまが掲載。</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>朝日新聞</newspaper-name>
-							<newspaper-release>2011-05-07</newspaper-release>
-							<newspaper-class>夕刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>3面（文化）: 茶話アニメ「魔法少女の成長物語」（藤津亮太）、鹿目家の母娘の関係に焦点を当てた考察。</p>
-								</div>
-
-								<ul class="p-notes">
-									<li>2018年発行の<a href="https://www.amazon.co.jp/dp/B07D9QS816/" class="htmlbuild-host htmlbuild-amazon-associate">新聞に載ったアニメレビュー</a>にも収録。</li>
-								</ul>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞（大阪）</newspaper-name>
-							<newspaper-release>2011-04-21</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>12面（広告）: <em>「完結編 本日放送 魔法少女まどか☆マギカ」</em>MBSにて26時40分より第11話・第12話 連続放送</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>読売新聞（東京）</newspaper-name>
-							<newspaper-release>2011-04-21</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>18面（広告）: <em>「完結編 本日放送 魔法少女まどか☆マギカ」</em>TBSにて27時00分より 第10話・第11話・第12話 連続放送</p>
-								</div>
-							</newspaper-contents>
-						</htmlbuild-newspaper>
-
-						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>毎日新聞（大阪）</newspaper-name>
-							<newspaper-release>2011-03-09</newspaper-release>
-							<newspaper-class>朝刊</newspaper-class>
-							<newspaper-contents>
-								<div class="p-text">
-									<p>22面（大阪）: Kalafinaの新曲「Magia」紹介。3人のコメント。</p>
+									<p>14面（芸能ワイド）: タイムライン（TOKYO FM）で『まどか☆マギカ』が取り上げられる旨紹介。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
 							<newspaper-name>産経新聞（東京）</newspaper-name>
-							<newspaper-release>2011-03-03</newspaper-release>
+							<newspaper-release>2011-12-01</newspaper-release>
 							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>13面（Web）: 「今週のネット語」に「僕と契約して、魔法少女になってよ!」。</p>
+									<p>16面: ネット流行語大賞2011の3位（銅賞）に「僕と契約して、○○になってよ!」がランクイン。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞</newspaper-name>
+							<newspaper-release>2011-12-05</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>30面（文化）: 空気系アニメの紹介で『けいおん!』が紹介され、一見すると空気系だが異なる興奮をもたらしたアニメとして『まどか☆マギカ』の名が挙がる。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>東京新聞</newspaper-name>
+							<newspaper-release>2011-12-06</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>15面（芸能ワイド）: 「オリジナル作品 快進撃」2011年のアニメ総括。MBS丸山博雄プロデューサーのコメント。『まどか☆マギカ』以外にも『TIGER&amp;BUNNY』や『輪るピングドラム』などの名も挙がる。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2012年</h2>
+						</div>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>中日新聞</newspaper-name>
+							<newspaper-release>2012-03-16</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>29面（全面広告）: <em>「新時代の「魔法少女」に託すアニメーションの可能性」</em>、新房昭之インタビュー。震災後の一挙放送は、本音としては1話ずつ見せたかったことなど。下部は「まどか☆マギカ展」名古屋会場広告。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>中日新聞</newspaper-name>
+							<newspaper-release>2012-03-20</newspaper-release>
+							<newspaper-class>「魔法少女まどか☆マギカ」特集号</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>表面: <em>「新時代の「魔法少女」に託すアニメーションの可能性」</em>新房監督インタビュー（16日朝刊に掲載された記事の再構成）。キーイラスト・キャラクター画像等掲載。作品紹介。</p>
+									<p>裏面: まどか☆マギカ展名古屋会場の情報。会場マップ、トークショースケジュール、物販グッズ。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>中日新聞</newspaper-name>
+							<newspaper-release>2012-03-21</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>18面（愛知）: 「魔法少女まどか☆マギカ 名シーン再現の企画展」まどか☆マギカ展（名古屋）の紹介。巴マミ等身大フィギュアの写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>中日スポーツ</newspaper-name>
+							<newspaper-release>2012-03-21</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>24面: 「名古屋で魔法少女まどか☆マギカ展 限定グッズにファン長い列」グッズ待機列と巴マミ等身大フィギュア写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>熊本日日新聞</newspaper-name>
+							<newspaper-release>2012-03-31</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>8面: 「「魔法少女まどか☆マギカ」が3賞」東京国際アニメフェア2012での第11回アニメアワード表彰式（テレビ部門優秀作品賞、個人部門監督賞、脚本賞）。虚淵玄、久保田光俊の写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2012-04-06</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>20面（文化）: 「「まどか☆マギカ」3賞受賞」東京国際アニメフェア2012での第11回アニメアワード表彰式（テレビ部門優秀作品賞、個人部門監督賞、脚本賞）。虚淵玄、久保田光俊の写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>徳島新聞</newspaper-name>
+							<newspaper-release>2012-05-03</newspaper-release>
+							<newspaper-class>号外（マチ★アソビ速報 vol.8）</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>『魔法少女まどか☆マギカ ポータブル』のイラストが描かれた「橋の下美術館」の写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞</newspaper-name>
+							<newspaper-release>2012-07-14</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>b4面: 『まどか☆マギカ』紹介。Blu-ray1巻パッケージ掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>徳島新聞</newspaper-name>
+							<newspaper-release>2012-10-06</newspaper-release>
+							<newspaper-class>マチ★アソビ速報 vol.9</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>眉山ロープウェイのアナウンスを行った悠木碧、斎藤千和のコメントを掲載（コメント自体には作品に関わる内容はほとんどない）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>徳島新聞</newspaper-name>
+							<newspaper-release>2012-10-07</newspaper-release>
+							<newspaper-class>マチ★アソビ速報 vol.9</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>「ufotable CINEMA」で行われた舞台挨拶（喜多村英梨、加藤英美里）の写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞（東京）</newspaper-name>
+							<newspaper-release>2012-10-18</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>34面（地域）: スポーツ報知「魔法少女まどか☆マギカ特別号」発行告知。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞</newspaper-name>
+							<newspaper-release>2012-11-10</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>28面（第2東京）: 「練馬アニメカーニバル」紹介。文化庁メディア芸術祭アニメ部門大賞「魔法少女まどか☆マギカ」（ダイジェスト版）上映。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2013年</h2>
+						</div>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞（名古屋）</newspaper-name>
+							<newspaper-release>2013-03-27</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>30面: <em>SQフィギュア〜佐倉杏子〜の全面広告</em>（カラー）。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
 							<newspaper-name>読売新聞</newspaper-name>
-							<newspaper-release>2011-03-02</newspaper-release>
+							<newspaper-release>2013-06-06</newspaper-release>
 							<newspaper-class>夕刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>7面: 「注目ワード 魔法少女まどか☆マギカ」（福田淳）、8話放送時点での作品紹介。虚淵玄のコメント「夢と希望の物語で終わらせるつもりだけど、見ている人がそう思ってくれるかどうかは分からない」。</p>
+									<p>11面: 「語り継ぐテレビ60年」で少女アニメの話題。『まどか☆マギカ』についても少し触れられる。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>
 
 						<htmlbuild-newspaper heading-level="3">
-							<newspaper-name>毎日新聞</newspaper-name>
-							<newspaper-release>2011-01-21</newspaper-release>
+							<newspaper-name>読売新聞（大阪）</newspaper-name>
+							<newspaper-release>2013-09-22</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
 							<newspaper-contents>
 								<div class="p-text">
-									<p>2面（特集ワイド）: 「まんたんプレス」で1月期の深夜アニメ紹介。『まどか☆マギカ』については「事前情報がほとんどないのも話題になっている」と紹介。</p>
+									<p>29面（地域）: 「りんくうにぎわいフェスタ」で絵コンテや複製原画の展示が行われていること。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>日経MJ（流通新聞）</newspaper-name>
+							<newspaper-release>2013-10-09</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>9面: 長栄交通（北海道）の痛タクシー紹介。『まどか☆マギカ』ラッピング車両の写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞</newspaper-name>
+							<newspaper-release>2013-11-02</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>3面（文化）: <em>「あの結末には続きがあった」</em>[新編]紹介。新房昭之、須川亜紀子（関西外国語大講師）のコメント。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞（新潟）</newspaper-name>
+							<newspaper-release>2013-11-15</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>31面（地域）: 「真夜中封切りアニメ満席」新編公開の話題。「T・ジョイ新潟万代」では初めて午前0時の上映を行ったが完売したこと。「T・ジョイ長岡」の暁美ほむら等身大パネルの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（東京）</newspaper-name>
+							<newspaper-release>2013-11-16</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>13面（文化）: 「かわいさとシリアス 混沌の魅力」[新編]紹介、新房昭之コメント。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li><a href="https://www.sankei.com/entertainments/news/131116/ent1311160004-n1.html" class="htmlbuild-host">産経ニュース</a>で全文が公開されている。</li>
+								</ul>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2013-11-25</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>18面（文化）: 「ハードな展開+こだわり映像」[新編]紹介、新房昭之コメント。（東京版の11月16日の記事と同内容）</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>Los Angels Times</newspaper-name>
+							<newspaper-release>2013-12-06</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>CALENDAR D15面: 「Trippy anime fired by magic」[新編]の紹介。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>毎日新聞（西部）</newspaper-name>
+							<newspaper-release>2013-12-07</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>25面（地域）: 映画コラムニストのナンシー下関による [新編] の紹介。「複雑で難解なSF」「（悪役魔女の造形から）娯楽映画のジャンルを超越し、アートの領域に踏み出している」との評。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2014年</h2>
+						</div>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2014-02-21</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>32面（地域）: 「アニメの画像歩いてゲット」東京都杉並区で行われている<a href="https://web.archive.org/web/20140313184014/http://www.chuosen-rr.com/aniwalk.html" class="htmlbuild-host">アニ×ウォーク</a>の記事。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>東京新聞</newspaper-name>
+							<newspaper-release>2014-04-28</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>6面（文化）: ラノベのすゝめ 「まどマギ」小説版から。波戸岡景汰（明治大准教授）による紹介。小説版(上)の表紙掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>中日新聞</newspaper-name>
+							<newspaper-release>2014-04-28</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>6面（文化）: ラノベのすゝめ 「まどマギ」小説版から。波戸岡景汰（明治大准教授）による紹介。小説版(上)の表紙掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2014-06-10</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>2面: 「お菓子はエンタメ」（和田浩司）、あにしゅがクリスマスケーキの話。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2014-07-14</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>32面（クール）: ジャパンエキスポでの Kalafina 出演の紹介。 [新編] キービジュアル掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞（新潟）</newspaper-name>
+							<newspaper-release>2014-07-21</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>32面（第2新潟）: 「大切なこと 新潟で学んだ」吉田聖子（上条恭介役）のインタビュー。まどか☆マギカ展新潟会場の告知。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>新潟日報</newspaper-name>
+							<newspaper-release>2014-07-26</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>15面: 「人気アニメを体感」まどか☆マギカ展 新潟の紹介。内覧会での暁美ほむら等身大フィギュア写真（カラー）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>千歳民報</newspaper-name>
+							<newspaper-release>2014-07-28</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>11面（社会）: 「アニメフェア始まる 新千歳の夏休みイベント」<a href="http://www.new-chitose-airport.jp/ja/corporate/press/pdf/pdf-20140725_natuyasumi.pdf" class="htmlbuild-host">新千歳空港アニメフェア2014</a>の記事。ラッピングカー（ランボルギーニ）の写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞（新潟）</newspaper-name>
+							<newspaper-release>2014-08-01</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>22面（第2新潟）: 「まどか☆マギカ展」新潟の紹介。暁美ほむら等身大フィギュア写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>河北新報</newspaper-name>
+							<newspaper-release>2014-08-05</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>15面（みやぎ）: さくら野百貨店 仙台店「まどか☆マギカショップ」の広告（カラー）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>新潟日報</newspaper-name>
+							<newspaper-release>2014-10-03</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>17面（新潟・佐渡）: 「[マンガ・アニメ情報館] 誘客明暗 [マンガの家]」まどか☆マギカ展にも言及。杏さや等身大フィギュアの写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>毎日新聞（北海道）</newspaper-name>
+							<newspaper-release>2014-11-03</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>25面: 新千歳空港で開催中の「国際アニメーション映画祭」の紹介。巴マミ等身大フィギュアの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2015年</h2>
+						</div>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（東京）</newspaper-name>
+							<newspaper-release>2015-01-08</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>19面（特集）: 「産経新聞社 2015 主な文化事業」に蒼樹うめ展（上野の森美術館）情報。『きらきらころころ』イラスト掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2015-03-13</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>37面（社会）: SUGOI JAPAN で<a href="http://sugoi-japan.jp/2015/result.html" class="htmlbuild-host">グランプリに選ばれた</a>こと。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2015-03-21</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>5面: <a href="https://web.archive.org/web/20151012214219/http://sugoi-japan.jp/2015" class="htmlbuild-host">SUGOI JAPAN</a><em>「初代グランプリは「魔法少女まどか☆マギカ」」</em>岩上敦宏、久保田光俊コメント掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2015-03-31</newspaper-release>
+							<newspaper-class>popstyle</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>3面: <a href="https://web.archive.org/web/20151012214219/http://sugoi-japan.jp/2015" class="htmlbuild-host">SUGOI JAPAN</a>「グランプリは「魔法少女まどか☆マギカ」」表彰式での岩上敦宏、久保田光俊の写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>河北新報</newspaper-name>
+							<newspaper-release>2015-08-05</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>22面（みやぎ）: さくら野百貨店 仙台店「まどか☆マギカショップ」の広告（カラー）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>河北新報</newspaper-name>
+							<newspaper-release>2015-08-12</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>29面（社会）: さくら野百貨店 仙台店「まどか☆マギカショップ」の広告（モノクロ）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞</newspaper-name>
+							<newspaper-release>2015-09-29</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>21面（文化）: 「「蒼樹うめ展」3日スタート」蒼樹うめコメント（予備校時代や『ひだまりスケッチ』に関する話のみ）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（東京）</newspaper-name>
+							<newspaper-release>2015-10-01</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>16面（特集）: <em>蒼樹うめ展新聞</em> 小林宏之（「まんがタイムきらら」グループ編集長）、蒼樹うめコメント。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（東京）</newspaper-name>
+							<newspaper-release>2015-10-03</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>1面: 「「蒼樹うめ展」きょう開幕」まどか☆マギカエリアの写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2015-12-23</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>23面（芸能）: 「MADOGATARI展 27日まで開催」大阪会場ウェルカムトンネルの写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2016年</h2>
+						</div>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>Frankfurter Allgemeine</newspaper-name>
+							<newspaper-release>2016-01-15</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>Feuilleton 11面: 「Eine Mädchentragödie」ドイツでのDVD発売に伴う『まどか☆マギカ』作品紹介。新編の場面ショット掲載（カラー）。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>17日付けで Web サイトでも記事が公開、<a href="http://www.faz.net/aktuell/feuilleton/kino/anime-madoka-magica-eine-maedchentragoedie-14014295.html" class="htmlbuild-host">Animé „Madoka Magica“: Eine Mädchentragödie - Kino - FAZ</a>。</li>
+								</ul>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2016-02-06</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>21面: 「「MADOGATARI展」像登場」さっぽろ雪まつりの雪像とMADOGATARI展（札幌）の紹介。まどか、忍、キュゥべえの雪像写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2016-02-07</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>21面: 「個性的キャラの”素顔”を見よう」蒼樹うめ展 in 大阪の紹介。前後編イメージビジュアル、『ひだまりスケッチ×ハニカム』キービジュアル掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2016-02-09</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>10面（社会）: 「蒼樹うめ展 in 大阪」の広告（カラー）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2016-02-10</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>22面（芸能）: 「「MADOGATARI展」札幌で開幕」まどかコーナーの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>北海道新聞</newspaper-name>
+							<newspaper-release>2016-02-12</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>7面: 「札幌で「MADOGATARI展」」物販コーナー脇に掲出された大型タペストリーの写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2016-02-16</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>6面（特集）: 「蒼樹うめ展 in 大阪」の広告（カラー）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2016-03-06</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>8面（読書）: 「蒼樹うめ展 in 大阪」の紹介。『ひだまりスケッチ』のイラスト掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2016-03-07</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>11面（特集）: 「蒼樹うめ展 in 大阪」の広告（カラー）。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞（東京）</newspaper-name>
+							<newspaper-release>2016-03-11</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>4面（文化）: スペイン映画<a href="http://www.bitters.co.jp/magicalgirl/" class="htmlbuild-host">『マジカル・ガール』</a>の紹介で、ベルムト監督が影響を受けた作品として『まどか☆マギカ』の名が挙がる。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2016-03-17</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>21面（文化）: 「19日から「蒼樹うめ展 in 大阪」」</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（大阪）</newspaper-name>
+							<newspaper-release>2016-03-19</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>27面: 「イラスト原画や作業机公開」蒼樹うめ展大阪会場の開催案内。劇場版色紙コーナーの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>中日新聞</newspaper-name>
+							<newspaper-release>2016-04-30</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>32面（テレビ欄）: MADOGATARI展名古屋会場の広告。キービジュアル（ほむら、忍）カラー掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>中日新聞</newspaper-name>
+							<newspaper-release>2016-05-05</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>10面（市民）: 「まどか☆マギカ アニメ原画展示」MADOGATARI展（名古屋）の紹介。まどかコーナーの写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2016-05-05</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>25面: 「「MADOGATARI展」名古屋で開幕」3面シアターでコンセプトムービーを上映中の写真。</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>レイアウトは大阪と中部が同じ、東京は異なる。読売新聞中部支社版は21面。</li>
+								</ul>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>The Japan News</newspaper-name>
+							<newspaper-release>2016-07-30</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>9面: C90のスポーツ報知によるMADOGATARI展グッズ販売紹介。（※英語）</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2016-08-12</newspaper-release>
+							<newspaper-class>コミケ特別号外（C90）</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>2面: C90で販売されるMADOGATARI展グッズ紹介。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2016-09-23</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>22面: 「「MADOGATARI展」開幕」東京アンコール展の紹介。スポーツ報知ブース写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2016-09-27</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>20面: 「SLOT魔法少女まどか☆マギカ2」の紹介。筐体写真やゲーム内映像が多数掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>北國新聞</newspaper-name>
+							<newspaper-release>2016-12-23</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>32面: 「アニメ原画 目凝らす 21美「マドガタリ」開幕」</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2016-12-23</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>28面: 「「MADOGATARI展」金沢21世紀美術館で開幕」。物販エリアの撮影コーナーの写真。（※読売新聞中部支社版は24面）</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>スポーツ報知</newspaper-name>
+							<newspaper-release>2016-12-29</newspaper-release>
+							<newspaper-class>コミケ特別号外（C91）</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>2面: C91で販売されるMADOGATARI展グッズ紹介。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2017年</h2>
+						</div>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>fumufumu J（新潟日報社のこども新聞）</newspaper-name>
+							<newspaper-release>2017-02-12</newspaper-release>
+							<newspaper-class>vol.43</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>5面: 『ひだまりスケッチ』の紹介と共に「蒼樹うめ展 in 新潟」の告知。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞（新潟）</newspaper-name>
+							<newspaper-release>2017-02-18</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>23面（新潟）: 「蒼樹うめ展 きょう新潟で開幕」。ひだまりスケッチエリアの写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞（新潟）</newspaper-name>
+							<newspaper-release>2017-02-20</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>23面（新潟）: 「蒼樹うめさんの世界 スケッチやセットに」蒼樹うめ展in新潟の紹介。キービジュアルのパネル展示写真。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2017-05-15</newspaper-release>
+							<newspaper-class>夕刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>9面: 5月3日にNHK BSプレミアムで放送された<a href="https://web.archive.org/web/20170517133312/http://www.nhk.or.jp/anime/anime100/program/" class="htmlbuild-host">ニッポンアニメ100 発表！あなたが選ぶアニメ ベスト100</a>で『まどか☆マギカ』（TVシリーズ）が3位になったこと。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>陸奥新報</newspaper-name>
+							<newspaper-release>2017-11-11</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>2面: 「外壁に「キュゥべえ」」蒼樹うめ展in青森の紹介。青森放送本社のキュゥべえラッピングの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>東奥日報</newspaper-name>
+							<newspaper-release>2017-11-11</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>22面（第4社会）: 『壁にキュゥべえの顔「蒼樹うめ展を」PR』蒼樹うめ展in青森の紹介。青森放送本社のキュゥべえラッピングの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>デーリー東北</newspaper-name>
+							<newspaper-release>2017-11-11</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>22面（第2社会）: 「来月からイラストレーター蒼樹うめ氏作品展 青森放送 ラッピングでPR」蒼樹うめ展in青森の紹介。青森放送本社のキュゥべえラッピングの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>陸奥新報</newspaper-name>
+							<newspaper-release>2017-12-17</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>2面: 「愛らしいキャラ 多彩に」蒼樹うめ展in青森の紹介。館内『ひだまりスケッチ』コーナーの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>産経新聞</newspaper-name>
+							<newspaper-release>2017-12-17</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>24面: 「愛らしいキャラ 一堂に」蒼樹うめ展in青森の紹介。館内『ひだまりスケッチ』コーナーの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>東奥日報</newspaper-name>
+							<newspaper-release>2017-12-17</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>18面（第4社会）: 「蒼樹うめの世界 丸ごと」蒼樹うめ展in青森の紹介。館内『ひだまりスケッチ』コーナーの写真掲載。</p>
+								</div>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2018年</h2>
+						</div>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>読売新聞</newspaper-name>
+							<newspaper-release>2018-10-29</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>27面（広告）: <em>「――明かされる百江なぎさの過去」</em>マギアレコード、なぎさ全面広告（カラー）</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>中部版は25面、大阪版は29面、北海道版、北陸版、西部版は未確認。</li>
+								</ul>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>朝日新聞</newspaper-name>
+							<newspaper-release>2018-10-29</newspaper-release>
+							<newspaper-class>朝刊</newspaper-class>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>20面（広告）: <em>「明かされる百江なぎさの過去――」</em>マギアレコード、なぎさ全面広告（カラー）</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>北海道版は17面、大阪版は28面、西部版は22面、名古屋版は未確認。</li>
+								</ul>
+							</newspaper-contents>
+						</htmlbuild-newspaper>
+					</section>
+					<section class="p-section -hdg-a htmlbuild-heading-self-link">
+						<div class="p-section__hdg">
+							<h2>2019年</h2>
+						</div>
+
+						<htmlbuild-newspaper heading-level="3">
+							<newspaper-name>日刊スポーツ</newspaper-name>
+							<newspaper-release>2019-01-19</newspaper-release>
+							<newspaper-contents>
+								<div class="p-text">
+									<p>8面: 「メドベ&amp;ザギトワ日本CMでコラボ」21日から放送されるマギレコCM出演について。本文は<a href="https://www.nikkansports.com/sports/news/201901180000877.html" class="htmlbuild-host">ウェブ記事</a>より多少削減されている。</p>
 								</div>
 							</newspaper-contents>
 						</htmlbuild-newspaper>

--- a/html/madoka/library/newspaper.html
+++ b/html/madoka/library/newspaper.html
@@ -28,7 +28,7 @@
 					</div>
 
 					<div class="p-title">
-						<h1 itemprop="name">新聞</h1>
+						<h1 itemprop="name">メディア紹介 — 新聞</h1>
 						<%- include('./_include/_contents_header_date') %>
 					</div>
 

--- a/html/madoka/library/newspaper.html
+++ b/html/madoka/library/newspaper.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja" itemscope="" itemtype="http://schema.org/WebPage">
 	<head>
-		<title>まどか書籍ライブラリ | 新聞</title>
+		<title>『魔法少女まどか☆マギカ』が新聞で紹介された例</title>
 
 		<meta itemprop="dateModified" content="2019-01-19" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/html/madoka/library/newspaper.html
+++ b/html/madoka/library/newspaper.html
@@ -3,6 +3,7 @@
 	<head>
 		<title>まどか書籍ライブラリ | 新聞</title>
 
+		<meta itemprop="dateModified" content="2019-01-19" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<%- include('./_include/_head_ogp_madoka') %>
 
@@ -28,6 +29,7 @@
 
 					<div class="p-title">
 						<h1 itemprop="name">新聞</h1>
+						<%- include('./_include/_contents_header_date') %>
 					</div>
 
 					<nav class="p-local-nav htmlbuild-localnav">


### PR DESCRIPTION
ほか、以下の変更を実施

- `<title>`, `<h1>` のテキストを見直し
- 更新日データがなかったので、それぞれ最後のデータの発売日を設定