### PR TITLE
スクリプト有効/無効の区別を付けるクラス名付与を取り止め

### DIFF
--- a/public/assets/script/_src/w0s.ts
+++ b/public/assets/script/_src/w0s.ts
@@ -35,8 +35,6 @@ const reportJsError = new ReportJsError('https://report.w0s.jp/js', {
 });
 reportJsError.init();
 
-document.documentElement.classList.add('js-enabled');
-
 if (window.customElements !== undefined) {
 	if (document.querySelector('w0s-tab') !== null) {
 		/* タブ */


### PR DESCRIPTION
以前は CSS 側で使っていたはずだが、いつの間にか不要になっていたので削除