### PR TITLE
`.markuplintrc` の見直し

### DIFF
--- a/.markuplintrc
+++ b/.markuplintrc
@@ -3,8 +3,7 @@
 		"./node_modules/@w0s/markuplint-config/.markuplintrc"
 	],
 	"parser": {
-		"\\.ejs$": "@markuplint/ejs-parser",
-		"\\.html$": "@markuplint/ejs-parser"
+		"\\.ejs$": "@markuplint/ejs-parser"
 	},
 	"excludeFiles": [
 		"views/feed/*.ejs",

--- a/.markuplintrc
+++ b/.markuplintrc
@@ -28,9 +28,7 @@
 			"hr",
 			"i",
 			"u",
-			"embed",
-			"area",
-			"noscript"
+			"area"
 		],
 		"label-has-control": false,
 		"require-accessible-name": false,

--- a/.markuplintrc
+++ b/.markuplintrc
@@ -61,12 +61,6 @@
 			}
 		},
 		{
-			"selector": "table",
-			"rules": {
-				"require-accessible-name": false
-			}
-		},
-		{
 			"selector": "input",
 			"rules": {
 				"id-duplication": false
@@ -86,10 +80,19 @@
 		}
 	],
 	"overrides": {
-		"html/**/index.html": {
+		"*.html": {
 			"rules": {
-				"required-h1": false
-			}
+				"label-has-control": true,
+				"require-accessible-name": true
+			},
+			"nodeRules": [
+				{
+					"selector": "table",
+					"rules": {
+						"require-accessible-name": false
+					}
+				}
+			]
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"@types/twitter-text": "^3.1.4",
 				"@types/w3c-css-typed-object-model-level-1": "^20180410.0.4",
 				"@w0s/eslint-config": "^1.1.0",
-				"@w0s/markuplint-config": "^2.3.0",
+				"@w0s/markuplint-config": "^2.4.0",
 				"@w0s/stylelint-config": "^1.1.0",
 				"@w0s/tsconfig": "^1.0.1",
 				"ajv-cli": "^5.0.0",
@@ -2692,9 +2692,9 @@
 			}
 		},
 		"node_modules/@w0s/markuplint-config": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.3.0.tgz",
-			"integrity": "sha512-W3qtw3zOurk2wzLZvRhy3eIMs0biBqTZNIOGVkFSCyqMgAwxqXtSYkpUonSqJgRf3f/jmftyqi2WxQRwzqBWJg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.4.0.tgz",
+			"integrity": "sha512-4tyUwrFolBZtxROOidj5EMbi+n+sElrN+Qip2Qd6Y6A9TErPL/ABQfp0tRTid0uLHECTOBnqFfM1PFxkjWRZmg==",
 			"dev": true,
 			"peerDependencies": {
 				"markuplint": "^3.7.0"
@@ -16386,9 +16386,9 @@
 			}
 		},
 		"@w0s/markuplint-config": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.3.0.tgz",
-			"integrity": "sha512-W3qtw3zOurk2wzLZvRhy3eIMs0biBqTZNIOGVkFSCyqMgAwxqXtSYkpUonSqJgRf3f/jmftyqi2WxQRwzqBWJg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.4.0.tgz",
+			"integrity": "sha512-4tyUwrFolBZtxROOidj5EMbi+n+sElrN+Qip2Qd6Y6A9TErPL/ABQfp0tRTid0uLHECTOBnqFfM1PFxkjWRZmg==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 		"@types/twitter-text": "^3.1.4",
 		"@types/w3c-css-typed-object-model-level-1": "^20180410.0.4",
 		"@w0s/eslint-config": "^1.1.0",
-		"@w0s/markuplint-config": "^2.3.0",
+		"@w0s/markuplint-config": "^2.4.0",
 		"@w0s/stylelint-config": "^1.1.0",
 		"@w0s/tsconfig": "^1.0.1",
 		"ajv-cli": "^5.0.0",


### PR DESCRIPTION
- `embed`, `noscript` 要素の禁止設定を `@w0s/markuplint-config` に移行
- 一部ルールの無効化を `overrides` を使用して HTML ファイルには適用しない（EJS ファイルのみ除外させる）ように