### PR TITLE
PrettierUtil の更新

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -8,12 +8,14 @@
 		{
 			"files": ["*.html", "*.ejs"],
 			"options": {
+				"parser": "html",
 				"printWidth": 9999
 			}
 		},
 		{
 			"files": "*.css",
 			"options": {
+				"parser": "css",
 				"printWidth": 9999,
 				"singleQuote": false
 			}

--- a/node/__tests__/util/PrettierUtil.test.js
+++ b/node/__tests__/util/PrettierUtil.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, test } from '@jest/globals';
+import PrettierUtil from '../../dist/util/PrettierUtil.js';
+
+describe('configOverrideAssign()', () => {
+	test('files - string', () => {
+		expect(
+			PrettierUtil.configOverrideAssign(JSON.parse(`
+{
+	"printWidth": 100,
+	"overrides": [
+		{
+			"files": ["*.html"],
+			"options": {
+				"printWidth": 200
+			}
+		},
+		{
+			"files": "*.css",
+			"options": {
+				"printWidth": 300
+			}
+		}
+	]
+}
+`), '*.css')
+		).toStrictEqual(JSON.parse(`
+{
+	"printWidth": 300
+}
+`));
+	});
+
+	test('files - array', () => {
+		expect(
+			PrettierUtil.configOverrideAssign(JSON.parse(`
+{
+	"printWidth": 100,
+	"overrides": [
+		{
+			"files": ["*.html"],
+			"options": {
+				"printWidth": 200
+			}
+		},
+		{
+			"files": "*.css",
+			"options": {
+				"printWidth": 300
+			}
+		}
+	]
+}
+`), '*.html')
+		).toStrictEqual(JSON.parse(`
+{
+	"printWidth": 200
+}
+`));
+	});
+
+	test('unmatch overrides', () => {
+		expect(
+			PrettierUtil.configOverrideAssign(JSON.parse(`
+{
+	"printWidth": 100,
+	"overrides": [
+		{
+			"files": ["*.html"],
+			"options": {
+				"printWidth": 200
+			}
+		}
+	]
+}
+`), '*.foo')
+		).toStrictEqual(JSON.parse(`
+{
+	"printWidth": 100
+}
+`));
+	});
+
+	test('no overrides', () => {
+		expect(
+			PrettierUtil.configOverrideAssign(JSON.parse(`
+{
+	"printWidth": 100
+}
+`), '*.css')
+		).toStrictEqual(JSON.parse(`
+{
+	"printWidth": 100
+}
+`));
+	});
+});

--- a/node/src/build/Css.ts
+++ b/node/src/build/Css.ts
@@ -22,7 +22,7 @@ export default class Css extends BuildComponent implements BuildComponentInterfa
 
 		const fileList = await globby(filesPath);
 
-		const prettierOptions = await PrettierUtil.getOptions(this.configBuild.prettier.config, 'css', '*.css');
+		const prettierOptions = PrettierUtil.configOverrideAssign(await PrettierUtil.loadConfig(this.configBuild.prettier.config), '*.css');
 
 		fileList.forEach(async (filePath) => {
 			/* ファイル読み込み */

--- a/node/src/build/Html.ts
+++ b/node/src/build/Html.ts
@@ -38,7 +38,7 @@ export default class Html extends BuildComponent implements BuildComponentInterf
 
 		const fileList = await globby(filesPath);
 
-		const prettierOptions = await PrettierUtil.getOptions(this.configBuild.prettier.config, 'html', '*.html');
+		const prettierOptions = PrettierUtil.configOverrideAssign(await PrettierUtil.loadConfig(this.configBuild.prettier.config), '*.html');
 
 		fileList.forEach(async (filePath) => {
 			/* ファイル読み込み */
@@ -168,7 +168,8 @@ export default class Html extends BuildComponent implements BuildComponentInterf
 			}
 
 			/* 出力 */
-			const distPath = `${this.configCommon.static.root}/${filePath.substring(filePath.indexOf('/') + 1)}`;
+			const distPathParse = path.parse(`${this.configCommon.static.root}/${filePath.substring(filePath.indexOf('/') + 1)}`);
+			const distPath = `${distPathParse.dir}/${distPathParse.name}.html`;
 			await fs.promises.writeFile(distPath, htmlFormatted);
 			this.logger.info(`HTML file created: ${distPath}`);
 		});


### PR DESCRIPTION
- 構成ファイルの読み込みと解析をメソッド分離
- `parser` オプションの強制指定をやめてあくまで構成ファイルに指定するように変更
