### PR TITLE
`<script>` 要素による外部ファイル読み込みを `defer` に統一

### DIFF
--- a/views/_include/head.ejs
+++ b/views/_include/head.ejs
@@ -5,12 +5,12 @@
 <link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 <link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-<script src="/assets/script/trusted-types.js"></script>
+<script src="/assets/script/trusted-types.js" defer=""></script>
 <script src="/assets/script/w0s.mjs" type="module"></script>
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>
 <%_ } _%> <%_ } _%>
-<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
+<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
 <script src="/assets/script/analytics.js" defer=""></script>
 
 <title><%= structuredData.title %></title>

--- a/views/_include/head_admin.ejs
+++ b/views/_include/head_admin.ejs
@@ -5,7 +5,7 @@
 <link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 <link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-<script src="/assets/script/trusted-types.js"></script>
+<script src="/assets/script/trusted-types.js" defer=""></script>
 <script src="/assets/script/w0s.mjs" type="module"></script>
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>

--- a/views/_include/head_kumeta.ejs
+++ b/views/_include/head_kumeta.ejs
@@ -6,12 +6,12 @@
 <link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 <link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-<script src="/assets/script/trusted-types.js"></script>
+<script src="/assets/script/trusted-types.js" defer=""></script>
 <script src="/assets/script/w0s.mjs" type="module"></script>
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>
 <%_ } _%> <%_ } _%>
-<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
+<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
 <script src="/assets/script/analytics.js" defer=""></script>
 
 <title><%= structuredData.title %></title>

--- a/views/_include/head_madoka.ejs
+++ b/views/_include/head_madoka.ejs
@@ -6,12 +6,12 @@
 <link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 <link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-<script src="/assets/script/trusted-types.js"></script>
+<script src="/assets/script/trusted-types.js" defer=""></script>
 <script src="/assets/script/w0s.mjs" type="module"></script>
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>
 <%_ } _%> <%_ } _%>
-<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
+<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
 <script src="/assets/script/analytics.js" defer=""></script>
 
 <title><%= structuredData.title %></title>

--- a/views/_include/head_tokyu.ejs
+++ b/views/_include/head_tokyu.ejs
@@ -6,12 +6,12 @@
 <link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 <link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-<script src="/assets/script/trusted-types.js"></script>
+<script src="/assets/script/trusted-types.js" defer=""></script>
 <script src="/assets/script/w0s.mjs" type="module"></script>
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>
 <%_ } _%> <%_ } _%>
-<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
+<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
 <script src="/assets/script/analytics.js" defer=""></script>
 
 <title><%= structuredData.title %></title>


### PR DESCRIPTION
`defer` 属性や `async` 属性のファイル読み込み順序はブラウザによって異なるが、すべて `defer` に統一した場合は Firefox, Chrome ともソース順に読み込まれる。