### PR TITLE
漫画雑誌の表紙情報を小さな掲載例も含めて全事例を追加

### DIFF
--- a/html/kumeta/index.ejs
+++ b/html/kumeta/index.ejs
@@ -128,6 +128,12 @@
 						<div class="p-top-update__main">
 							<ul class="p-top-update-list">
 								<li>
+									<div class="p-top-update-list__date"><span class="htmlbuild-datetime">2023年4月26日</span></div>
+									<div class="p-top-update-list__info">
+										<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>において、これまで表紙情報は単独表紙ないし大きく掲載された事例のみとしていたが、小さな掲載例も含めてすべての事例を掲載。</p>
+									</div>
+								</li>
+								<li>
 									<div class="p-top-update-list__date"><span class="htmlbuild-datetime">2023年3月29日</span></div>
 									<div class="p-top-update-list__info">
 										<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に日本経済新聞2023年3月28日の記事を追加。</p>
@@ -149,12 +155,6 @@
 									<div class="p-top-update-list__date"><span class="htmlbuild-datetime">2023年3月14日</span></div>
 									<div class="p-top-update-list__info">
 										<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に週刊少年サンデー 1993年30号の表紙情報を追加。</p>
-									</div>
-								</li>
-								<li>
-									<div class="p-top-update-list__date"><span class="htmlbuild-datetime">2023年3月11日</span></div>
-									<div class="p-top-update-list__info">
-										<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「アルスラーン戦記　公式アニメガイド」のデータを追加。</p>
 									</div>
 								</li>
 							</ul>

--- a/html/kumeta/library/manga.ejs
+++ b/html/kumeta/library/manga.ejs
@@ -5,7 +5,7 @@
 			{
 				"title": "久米田康治作品の漫画雑誌での紹介例",
 				"heading": "メディア紹介 — 漫画雑誌",
-				"dateModified": "2023-03-24",
+				"dateModified": "2023-04-26",
 				"description": "漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。",
 				"breadcrumb": [{ "path": "/kumeta/", "name": "ホーム" }],
 				"localNav": [
@@ -172,8 +172,10 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 1991年10号</book-name>
 							<book-release>1991-02-13</book-release>
+							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: アイスホッケー姿の月斗<small>（『DADA!』と混じっての掲載）</small></p>
 									<p>pp.267–308: 『行け!!南国アイスホッケー部』第1話</p>
 									<p>p.309: 新人コミック大賞のお知らせ、久米田先生のメッセージ掲載<q>まんがは99%の経験と1%の努力だ!!</q></p>
 								</div>
@@ -187,7 +189,7 @@
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: スティックを持った月斗</p>
+									<p>表紙: アイスホッケー姿の月斗</p>
 									<p>pp.7–48: 『行け!!南国アイスホッケー部』第2話、冒頭4ページカラー</p>
 								</div>
 							</book-contents>
@@ -231,8 +233,19 @@
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 月斗（元気いっぱい　新連載第2弾!!）</p>
+									<p>表紙: 月斗と浜津学園の生徒達（<q>元気いっぱい　新連載第2弾!!</q>）</p>
 									<p>pp.3–36: 『行け!!南国アイスホッケー部』連載再開、冒頭4ページカラー<small>（単行本でのサブタイトルは「真夏の激突! 　月斗VS.ロブ」）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 1991年30号</book-name>
+							<book-release>1991-07-03</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: アイスホッケー姿の月斗<small>（『GS美神　極楽大作戦!!』と混じっての掲載）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -243,7 +256,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 正月晴着の月斗（集合イラスト）</p>
+									<p>表紙: 正月晴着の月斗<small>（集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -333,10 +346,12 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 1993年3・4号</book-name>
 							<book-release>1992-12-22</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>企画</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 私服でスティックを構える月斗<small>（集合イラスト）</small></p>
 									<p>p.10: 「'93年サンデー人気キャラうらない」の11月に月斗（※占いの内容は作品やキャラクターとは無関係）</p>
 									<p>pp.57–64: 「初笑い!!スーパーギャグスペシャル」の特集内で北崎拓先生との共同マンガ『行け!!南国なふ・た・り』（2ページ・2色カラー）掲載</p>
 								</div>
@@ -362,9 +377,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 1993年16号</book-name>
 							<book-release>1993-03-24</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>企画</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 私服でスティックを構える月斗<small>（『らんま1/2』『ゴリガン』と混じっての掲載、イラストは1993年3・4号表紙の流用）</small></p>
 									<p>pp.178–210: 『行け!!南国アイスホッケー部』2本立て（「キレイな月斗」「ママは高校二年生」）</p>
 									<p>p.194: 2本立ての扉絵間違い探し（6か所）、「ママは高校二年生」内に描かれた“ブルマーク”（5か所）の合計点数を回答することによるプレゼント企画</p>
 								</div>
@@ -417,10 +434,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 1993年30号</book-name>
 							<book-release>1993-06-30</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>イベント</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 私服でスティックを構える月斗（『GS美神 極楽大作戦!!』と混じっての掲載）</p>
+									<p>表紙: 私服でスティックを構える月斗<small>（『GS美神　極楽大作戦!!』と混じっての掲載、イラストは1993年3・4号表紙の流用）</small></p>
 									<p>p.111: '93ビッグサマー「超元気まつり」告知記事（2色カラー）</p>
 								</div>
 							</book-contents>
@@ -477,7 +495,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 月斗（集合イラスト）</p>
+									<p>表紙: 礼装の月斗<small>（創刊2000号記念の集合イラスト）</small></p>
 									<p>p.11: 創刊2000号記念「メモリアル　キャラクターズ　グラフティ」に月斗（カラー）</p>
 								</div>
 							</book-contents>
@@ -511,7 +529,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 月斗（集合イラスト）</p>
+									<p>表紙: 私服姿の月斗<small>（集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -528,6 +546,17 @@
 							<book-contents>
 								<div class="p-text">
 									<p>pp.127–142: 『行け!!南国アイスホッケー部』第133話「リサイクルウォーズ」、冒頭4ページ2色カラー（4ページ目は月斗のみ色付きなし）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 1994年15号</book-name>
+							<book-release>1994-03-16</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 私服姿の月斗<small>（創刊35周年の集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -553,7 +582,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 浜辺の月斗&amp;そあら</p>
+									<p>表紙: 浜辺で水着のそあら&amp;月斗</p>
 									<p>pp.3–22: 『行け!!南国アイスホッケー部』第149話「時代は大ズモウ」、冒頭4ページカラー</p>
 								</div>
 							</book-contents>
@@ -611,11 +640,11 @@
 
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 1995年4号</book-name>
-							<book-release>1994-12</book-release>
+							<book-release>1994-12-27</book-release>
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: チャイナ服を着た月斗（他作品と混じっての掲載）</p>
+									<p>表紙: チャイナ服の月斗<small>（集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -632,6 +661,17 @@
 							<book-contents>
 								<div class="p-text">
 									<p>pp.449–452: 「投稿コミックショー」連載作家の年賀状プレゼント企画、久米田先生は月斗のイラスト<q>95 あけましておめでとう　友情　努力　下ネタ</q></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 1995年14号</book-name>
+							<book-release>1995-03-08</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: チアリーダーのそあら<small>（創刊36周年の集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -657,6 +697,17 @@
 								</div>
 							</book-contents>
 						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 1996年3・4号</book-name>
+							<book-release>1995-12-22</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 冬服の月斗<small>（集合イラスト）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
 					</section>
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
@@ -677,10 +728,12 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊ヤングサンデー 1996年7号</book-name>
 							<book-release>1996-01-18</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>読切</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 不動産屋の女性<small>（多田亜沙美と混じっての掲載、イラストは扉ページの流用）</small></p>
 									<p>pp.92–116: 読切『幽良物件仲介します』、扉ページカラー</p>
 								</div>
 							</book-contents>
@@ -693,6 +746,17 @@
 							<book-contents>
 								<div class="p-text">
 									<p>pp.45–48: 短編漫画「ダビスタの未来を考える」</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 1996年14号</book-name>
+							<book-release>1996-03-06</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 月斗<small>（創刊37周年の集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -765,6 +829,17 @@
 								</div>
 							</book-contents>
 						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 1997年4号</book-name>
+							<book-release>1996-12-24</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: ポカポカ<small>（集合イラスト）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
 					</section>
 					<section class="p-section -hdg-a htmlbuild-heading-self-link">
 						<div class="p-section__hdg">
@@ -778,6 +853,17 @@
 							<book-contents>
 								<div class="p-text">
 									<p>pp.469–472: 「投稿コミックショー」連載作家の年賀状プレゼント企画、久米田先生はポカポカのイラスト</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 1997年14号</book-name>
+							<book-release>1997-03</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: ポカポカ<small>（創刊38周年の集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -825,7 +911,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 科特部メンバー（他作品と混じっての掲載）</p>
+									<p>表紙: 科特部メンバー<small>（他作品と混じっての掲載）</small></p>
 									<p>pp.113–138: 『かってに改蔵』第1話</p>
 								</div>
 							</book-contents>
@@ -878,9 +964,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 1999年4号</book-name>
 							<book-release>1998-12-30</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>年賀状</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 改蔵&amp;地丹<small>（集合イラスト）</small></p>
 									<p>pp.469–471: 「投稿コミックショー」連載作家の年賀状プレゼント企画、久米田先生は地丹（下っぱスーツ）のイラスト<q>出世 '99　下っぱ</q></p>
 								</div>
 							</book-contents>
@@ -908,7 +996,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 改蔵（創刊40周年記念、他作品と混じっての掲載）</p>
+									<p>表紙: 制服の改蔵<small>（創刊40周年の集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -921,7 +1009,7 @@
 							<book-tag>企画</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 改蔵（単行本1巻表紙の部分流用、他作品と混じっての掲載）</p>
+									<p>表紙: 改蔵<small>（『ARMS』『まじっく快斗』と混じっての掲載、イラストは単行本1巻表紙の部分流用）</small></p>
 									<p>pp.111–126: 『かってに改蔵』第48話「対改蔵最終兵器!?」、冒頭4ページ2色カラー</p>
 									<p>p.117: 連載1周年記念　特製下っぱーかープレゼント</p>
 									<p>pp.444–445: 「投稿コミックショー」連載1周年『かってに改蔵』応援スペシャル!!</p>
@@ -948,7 +1036,7 @@
 							<book-tag>イベント</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 改蔵&amp;地丹（他作品と混じっての掲載）</p>
+									<p>表紙: 改蔵&amp;地丹<small>（『DAN DOH!!』など他作品と混じっての掲載、イラストは1999年4号表紙の流用）</small></p>
 									<p>pp.127–142: 『かってに改蔵』第65話「今年の思春期…!?」、冒頭4ページ2色カラー</p>
 									<p>pp.444–446: 「おかげサマー! 日本全国サンデー祭り!!」メッセージビデオ内容紹介、久米田先生は<q>猪熊先生、ご結婚おめでとうございます。え〜、19歳のお嫁さんだそうで……ボクも19歳のお嫁さんがほしいです。（以上）</q></p>
 								</div>
@@ -963,7 +1051,7 @@
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 改蔵&amp;羽美（単行本1巻表紙の部分流用、他作品と混じっての掲載）</p>
+									<p>表紙: 改蔵&amp;羽美<small>（『H2』『名探偵コナン』と混じっての掲載、イラストは単行本1巻表紙の部分流用）</small></p>
 									<p>pp.7–9: サンデー40周年記念ドリンク（明治乳業）をコナン、犬夜叉、改蔵が取材、紹介</p>
 									<p>pp.107–126: 『かってに改蔵』第74話「人気者でいこう…よ」、冒頭4ページ2色カラー</p>
 								</div>
@@ -992,7 +1080,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 改蔵（他作品と混じっての掲載）</p>
+									<p>表紙: 制服の改蔵<small>（集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -1094,7 +1182,7 @@
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 下っぱスーツ地丹（他作品と混じっての掲載）</p>
+									<p>表紙: 下っぱスーツの地丹<small>（『トガリ』など他作品と混じっての掲載）</small></p>
 									<p>pp.139–156: 『かってに改蔵』第121話「サービスエース」、冒頭3ページカラー</p>
 								</div>
 							</book-contents>
@@ -1183,7 +1271,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: うらら&amp;冬馬（黒川智花&amp;他作品と混じっての掲載）</p>
+									<p>表紙: うらら&amp;冬馬<small>（黒川智花&amp;他作品と混じっての掲載、<a href="https://www.amazon.co.jp/dp/4091236421/" class="htmlbuild-amazon-associate htmlbuild-host">単行本A巻</a>裏表紙で採用）</small></p>
 									<p>pp.328–330: 『育ってダーリン!!』スペシャル（編集部、ももちゃんによる「はじまりの事情」および連載中断前のダイジェストが掲載）</p>
 									<p>pp.331–348: 『育ってダーリン!!』前編</p>
 								</div>
@@ -1217,7 +1305,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 下っぱスーツ地丹（他作品と混じっての掲載）<small>（作品の掲載はないが、当号の読者プレゼントに『かってに改蔵』グッズがある）</small></p>
+									<p>表紙: 下っぱスーツの地丹<small>（他作品と混じっての掲載、当号に『かってに改蔵』の掲載はないが読者プレゼントにグッズがある）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -1229,7 +1317,7 @@
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 「200+7」のアニバーサリーTシャツを着た改蔵（他作品と混じっての掲載）</p>
+									<p>表紙: 「200+7」アニバーサリーTシャツを着た改蔵<small>（『美鳥の日々』など他作品と混じっての掲載）</small></p>
 									<p>pp.171–186: 『かってに改蔵』第207話「イノセントワールド」、冒頭4ページカラー</p>
 								</div>
 							</book-contents>
@@ -1341,7 +1429,7 @@
 							<book-tag>企画</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 改蔵（他作品と混じっての掲載）</p>
+									<p>表紙: 私服の改蔵<small>（黒川智花&amp;他作品と混じっての掲載、イラストは週刊少年サンデー 2002年39号扉ページの流用）</small></p>
 									<p>pp.395–397: かってに改蔵スーパーマンス「かってに人生相談室」第1回</p>
 								</div>
 							</book-contents>
@@ -1433,7 +1521,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 改蔵（集合イラスト、サンデー維新）</p>
+									<p>表紙: 着物姿の改蔵<small>（創刊45周年の集合イラスト、サンデー維新）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -1496,7 +1584,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 浴衣姿の改蔵（サンデー夏祭りの集合イラストとして他作品と混じっての掲載）</p>
+									<p>表紙: 浴衣姿の改蔵<small>（集合イラスト、サンデー夏祭り）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -1553,10 +1641,12 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>ヤングガンガン 2005年No.9</book-name>
 							<book-release>2005-04-22</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>読切</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 羽美<small>（グラビア女子6人&amp;他作品と混じっての掲載、イラストは扉ページの流用）</small></p>
 									<p>pp.127–146: 読切『いいがかり姉さん』、冒頭4ページカラー</p>
 								</div>
 							</book-contents>
@@ -1569,7 +1659,7 @@
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 望（上戸彩&amp;他作品と混じっての掲載）</p>
+									<p>表紙: 望<small>（上戸彩&amp;他作品と混じっての掲載）</small></p>
 									<p>pp.15–30: 『さよなら絶望先生』第一話「さよなら絶望先生」、冒頭3ページカラー</p>
 									<p>pp.31–38: 『さよなら絶望先生』第二話「帰ってきた絶望先生」</p>
 								</div>
@@ -1579,10 +1669,12 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊ヤングサンデー 2005年27号</book-name>
 							<book-release>2005-06-02</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>読切</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 久米田康治の自画像<small>（森下千里&amp;他作品と混じっての掲載）</small></p>
 									<p>pp.79–94: 読切『特に負けても構わない戦いがそこにはある 〜サレジオ落穂によろしく（仮題）〜』、冒頭2ページカラー</p>
 								</div>
 							</book-contents>
@@ -1594,7 +1686,18 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 望（大人気大増20P!!）</p>
+									<p>表紙: 望<small>（北乃きい&amp;他作品と混じっての掲載、イラストは週刊少年マガジン 2005年22・23号の流用）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年マガジン 2005年41号</book-name>
+							<book-release>2005-09</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 望<small>（秋の大GAGフェスタ、『金田一少年の事件簿』など他作品と混じっての掲載、イラストは週刊少年マガジン 2005年22・23号の流用）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -1602,9 +1705,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2005年43号</book-name>
 							<book-release>2005-09</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 望<small>（『金田一少年の事件簿』など他作品と混じっての掲載、イラストは単行本一集表紙の流用）</small></p>
 									<p>p.236: 『さよなら絶望先生』第二十一話「きもすぎて悲しみの市」、扉ページカラー（単行本一集広告）</p>
 								</div>
 							</book-contents>
@@ -1634,9 +1739,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2006年25号</book-name>
 							<book-release>2006-05-24</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 望<small>（安田美沙子&amp;他作品と混じっての掲載、イラストは単行本三集表紙の流用）</small></p>
 									<p>pp.171–184: 連載50回記念『さよなら絶望先生』第五十話「新しくない人よ、目覚めよ」、冒頭2ページカラー</p>
 								</div>
 							</book-contents>
@@ -1660,7 +1767,7 @@
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 望（超絶望的センターカラー!!さよなら絶望先生）</p>
+									<p>表紙: 望（<q>超絶望的センターカラー!!さよなら絶望先生</q>）<small>（岩佐真悠子&amp;他作品と混じっての掲載、イラストは単行本三集表紙の流用）</small></p>
 									<p>pp.175–188: 『さよなら絶望先生』第七十三話「七五三四郎」、冒頭2ページカラー</p>
 								</div>
 							</book-contents>
@@ -1723,7 +1830,7 @@
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 望（2周年記念でなにやらお知らせが!?）</p>
+									<p>表紙: 望（<q>2周年記念でなにやらお知らせが!?</q>）<small>（中川翔子&amp;他作品と混じっての掲載、イラストは単行本三集表紙の流用）</small></p>
 									<p>p.256: 『さよなら絶望先生』第九十二話「おめでたき　こともなき世を　おめでたく」、扉ページカラー（TV アニメ化!）</p>
 								</div>
 							</book-contents>
@@ -1786,10 +1893,9 @@
 							<book-release>2007-07</book-release>
 							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
-							<book-amazon asin="B00BQ60ZAC" image-id="51lhm8nhZWL" width="120" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 望（TV アニメ 7/7 スタート!!）</p>
+									<p>表紙: 望（<q>TV アニメ 7/7 スタート!!</q>）<small>（綾瀬はるか&amp;他作品と混じっての掲載、イラストは単行本三集表紙の流用）</small></p>
 									<p>p.308: 「TV アニメ放送（暴走）開始」第1話放送開始日、主題歌情報</p>
 								</div>
 							</book-contents>
@@ -1798,9 +1904,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2007年32号</book-name>
 							<book-release>2007-07-11</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 望（<q>TV アニメ絶賛放送中!!</q>）<small>（鹿谷弥生&amp;他作品と混じっての掲載、イラストは週刊少年マガジン 2006年50号に掲載された第七十三話扉ページの部分流用）</small></p>
 									<p>pp.207–209: 『さよなら絶望先生』TV アニメ放送開始記念カラー特集!!、新房昭之、神谷浩史、野中藍インタビュー掲載</p>
 								</div>
 							</book-contents>
@@ -1821,9 +1929,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2007年40号</book-name>
 							<book-release>2007-09-05</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 望（<q>超話題の TV アニメ観てる!?</q>）<small>（上戸彩&amp;他作品と混じっての掲載、イラストは単行本三集表紙の流用）</small></p>
 									<p>pp.246–258: 『さよなら絶望先生』第百八話「奥の抜け道」、扉ページカラー</p>
 								</div>
 							</book-contents>
@@ -1842,9 +1952,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2007年45号</book-name>
 							<book-release>2007-10</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 望（<q>大好評につき TV アニメ第2弾決定!!</q>）<small>（ほしのあき&amp;他作品と混じっての掲載、イラストは週刊少年マガジン 2006年50号に掲載された第七十三話扉ページの部分流用）</small></p>
 									<p>pp.241–242: 『さよなら絶望先生』TV アニメ第2期製作決定情報ページ、1期プレイバック（カラー）</p>
 								</div>
 							</book-contents>
@@ -1913,11 +2025,24 @@
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年マガジン 2008年10号</book-name>
+							<book-release>2008-02</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 望（<q>TV アニメ絶好調!!</q>）<small>（倉科カナ&amp;他作品と混じっての掲載、イラストは週刊少年マガジン 2007年28号 TV アニメ情報ページの流用）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2008年13号</book-name>
 							<book-release>2008-02-27</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 望（<q>TV アニメ大人気カラー!!</q>）<small>（南明奈&amp;他作品と混じっての掲載、イラストは週刊少年マガジン 2007年21・22号に掲載された第九十二話扉ページの部分流用）</small></p>
 									<p>pp.143–158: 『さよなら絶望先生』第百二十九話「花係の森」、冒頭2ページカラー</p>
 								</div>
 							</book-contents>
@@ -1950,8 +2075,10 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2008年32号</book-name>
 							<book-release>2008-07</book-release>
+							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 望（<q>アニメ DVD 付き KC 発売決定!!</q>）<small>（桜庭ななみ&amp;他作品と混じっての掲載、イラストは週刊少年マガジン 2007年28号 TV アニメ情報ページの流用）</small></p>
 									<p>p.242: 『獄・さよなら絶望先生』OAD 付き KC 限定版のお知らせ（カラー）</p>
 								</div>
 							</book-contents>
@@ -1960,8 +2087,10 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2008年38号</book-name>
 							<book-release>2008-08-20</book-release>
+							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 望<small>（『ダイヤのA』など他作品と混じっての掲載、イラストは単行本十四集表紙の流用）</small></p>
 									<p>p.8: 『さよなら絶望先生』OAD 付き限定版 KC のお知らせ（第15〜16集）</p>
 								</div>
 							</book-contents>
@@ -2061,7 +2190,7 @@
 							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 望（集合イラスト、ボクシング）</p>
+									<p>表紙: ボクシング姿の望<small>（『はじめの一歩』を中央に添えた集合イラスト）</small></p>
 									<p>p.10: 週刊少年マガジン50周年記念コメント</p>
 								</div>
 							</book-contents>
@@ -2144,7 +2273,7 @@
 							<book-amazon asin="B002MQJCZO" image-id="61q1v5xV6bL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 魔梨威（他作品と混じっての掲載）</p>
+									<p>表紙: 魔梨威<small>（『どうぶつの国』など他作品と混じっての掲載）</small></p>
 									<p>pp.3–5: PEACH-PIT 超特大レアポスター（糸色倫イラストの折り込みポスター）</p>
 									<p>
 										pp.539–546: 『じょしらく』一日目「犬と猫の災難」、扉ページ&amp;作者紹介カラー<small>（扉ページの魔梨威イラストのみ<a href="https://www.amazon.co.jp/dp/B009KYCNC0/" class="htmlbuild-amazon-associate htmlbuild-host">単行本壱巻</a> p.1 に収録）</small>
@@ -2178,7 +2307,7 @@
 							<book-tag>企画</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 望<q>絶望しつづけて200回! 一教師絶望</q>（優木まおみと混じっての掲載）</p>
+									<p>表紙: 望（<q>絶望しつづけて200回! 一教師絶望</q>）<small>（優木まおみ&amp;他作品と混じっての掲載、イラストは単行本十六集表紙の流用、優木まおみのキャッチコピー<q>全男子待望</q>の“望”と『絶望先生』のキャッチコピー<q>一教師絶望</q>の“望”が重なるデザイン）</small></p>
 									<p>
 										pp.14–28: 連載200回記念『さよなら絶望先生』第二百話「長い長いさっしん」、見開き扉ページカラー<small>（扉ページは<a href="https://www.amazon.co.jp/dp/B00A765CVY/" class="htmlbuild-amazon-associate htmlbuild-host">単行本二一集</a>に収録）</small>
 									</p>
@@ -2272,8 +2401,10 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2010年24号</book-name>
 							<book-release>2010-05-12</book-release>
+							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 魔梨威<small>（仲里依紗&amp;他作品と混じっての掲載、イラストは別冊少年マガジン 2009年11月号表紙の流用）</small></p>
 									<p>pp.351–352: じょしらく1巻特別版情報、木胡桃役・小野恵令奈の写真掲載</p>
 									<p>pp.353–364: 『じょしらく』特別編「ふだん問答」（『さよなら絶望先生』も通常どおり掲載）</p>
 								</div>
@@ -2330,7 +2461,7 @@
 							<book-amazon asin="B004GI13FS" image-id="6120TLYNhPL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 魔梨威（『進撃の巨人』と混じっての掲載）</p>
+									<p>表紙: 魔梨威<small>（『進撃の巨人』と混じっての掲載）</small></p>
 									<p>pp.2–3: 「別マガコミックスのお知らせ」（カラー）</p>
 									<p>pp.4–5: 「じょしらく噺家ごっこ」セット全員サービス（扇子&amp;手拭い）</p>
 									<p>
@@ -2391,7 +2522,7 @@
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 望（サン×マガコラボ、他作品と混じっての掲載）</p>
+									<p>表紙: 改蔵と握手をする望<small>（サン×マガコラボ、『銀の匙 Silver Spoon』など他作品と混じっての掲載）</small></p>
 									<p>p.205: 『かってに改蔵』OVA 情報（櫻井孝宏、喜多村英梨のコメント掲載）</p>
 									<p>pp.207–218: 『さよなら絶望先生』特別番外編</p>
 								</div>
@@ -2406,7 +2537,7 @@
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 改蔵（サン×マガコラボ、他作品と混じっての掲載）</p>
+									<p>表紙: 望と握手をする改蔵<small>（サン×マガコラボ、井上真央&amp;他作品と混じっての掲載）</small></p>
 									<p>pp.181–194: 『かってに改蔵』特別番外編「損して得とれない」掲載、扉ページカラー</p>
 									<p>p.182: 『かってに改蔵』OVA、『俗・さよなら絶望先生』Blu-ray BOX 情報</p>
 								</div>
@@ -2468,7 +2599,7 @@
 							<book-amazon asin="B006MI8JQQ" image-id="61FnrnVD7-L" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: じょしらくメンバー5人「アニメ化決定!!」</p>
+									<p>表紙: 制服姿のじょしらくメンバー5人（<q>じょしらくアニメ化決定!!</q>）</p>
 									<p>p.8: 「さよならじょしらく」（さよなら絶望先生×じょしらくコラボ）2012年カレンダー全員サービス（カラー）</p>
 								</div>
 							</book-contents>
@@ -2501,10 +2632,9 @@
 							<book-release>2012-05-09</book-release>
 							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
-							<book-amazon asin="B007VQG9RE" image-id="61TM2KTOypL" width="113" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 魔梨威（他作品と混じっての掲載）</p>
+									<p>表紙: 魔梨威<small>（『さんかれあ』など他作品と混じっての掲載、イラストは単行本壱巻表紙の流用）</small></p>
 									<p>pp.439–440: 『じょしらく』アニメ化最新情報、キャラ設定画・キャスト5人発表（カラー）</p>
 								</div>
 							</book-contents>
@@ -2518,7 +2648,7 @@
 							<book-amazon asin="B0085MLZEA" image-id="61HaLG1dLkL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 魔梨威&amp;丸京の水着イラスト</p>
+									<p>表紙: 水着の魔梨威&amp;丸京（<q>「じょしらく」アニメ! 7月5日放送開始!!</q>）</p>
 									<p>pp.601–603: 『じょしらく』アニメ化最新情報、第1回アフレコ後のメインキャラ5人のキャストコメント掲載</p>
 									<p>pp.604–606: 「マンガの現場」第6回　ゲスト：ヤス（仕事部屋の写真、本号表紙イラスト作画風景などがカラーで掲載）</p>
 								</div>
@@ -2556,7 +2686,7 @@
 							<book-amazon asin="B008DHYF9O" image-id="61VuIYgc5iL" width="110" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 魔梨威（じょしらくアニメ! 放送開始!!）</p>
+									<p>表紙: 魔梨威（<q>じょしらくアニメ! 放送開始!!</q>）</p>
 									<p>pp.6–8: 『じょしらく』TV アニメ通信、水島監督インタビュー（カラー）</p>
 								</div>
 							</book-contents>
@@ -2623,6 +2753,17 @@
 						<div class="p-section__hdg">
 							<h2>2013年</h2>
 						</div>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>別冊少年マガジン 2013年3月号</book-name>
+							<book-release>2013-02</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 魔梨威<small>（『ベイビー・ワールドエンド』など他作品と混じっての掲載、イラストは別冊少年マガジン 2012年8月号表紙の流用）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
 							<book-name>ヤングジャンプ 2013年31号</book-name>
@@ -2700,8 +2841,19 @@
 							<book-amazon asin="B00GM5RRNK" image-id="51qJAT1xvDL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: サンジェルマン伯爵<q>『さよなら絶望先生』から1年5か月…久米田康治新連載</q>（「ももいろクローバーZ」と混じっての掲載）</p>
+									<p>表紙: サンジェルマン伯爵（<q>『さよなら絶望先生』から1年5か月…久米田康治新連載</q>）<small>（ももいろクローバーZ&amp;他作品と混じっての掲載）</small></p>
 									<p>pp.10–44: 『せっかち伯爵と時間どろぼう』00′01″「 せっかち伯爵と時間どろぼう」、冒頭3ページカラー</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年マガジン 2013年51号</book-name>
+							<book-release>2013-11</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: サンジェルマン伯爵<small>（『ダイヤのA』など他作品と混じっての掲載、イラストは週刊少年マガジン 2013年49号表紙の流用）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -2711,10 +2863,9 @@
 							<book-release>2013-12</book-release>
 							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
-							<book-amazon asin="B00H2XSGUY" image-id="A1Om9oO5AmL" width="109" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: サンジェルマン伯爵（他作品と混じっての掲載）</p>
+									<p>表紙: サンジェルマン伯爵<small>（集合イラスト）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -2727,9 +2878,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2014年11号</book-name>
 							<book-release>2014-02</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: サンジェルマン伯爵<small>（『風夏』など他作品と混じっての掲載、イラストは週刊少年マガジン 2014年1号表紙の流用）</small></p>
 									<p>pp.223–242: 『せっかち伯爵と時間どろぼう』00′12″「時をかける幼女」、扉ページカラー<small>（扉絵は単行本未収録、『悔画展』にカラー収録）</small></p>
 									<p>p.224: 『せっかち伯爵と時間どろぼう』1巻広告</p>
 								</div>
@@ -2741,9 +2894,10 @@
 							<book-release>2014-02-20</book-release>
 							<book-tag>表紙</book-tag>
 							<book-tag>企画</book-tag>
+							<book-amazon asin="B00I8S17T4" image-id="61TECKAdzHL" width="112" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: サンジェルマン伯爵（他作品と混じっての掲載）</p>
+									<p>表紙: サンジェルマン伯爵<small>（『七つの大罪』など他作品と混じっての掲載、イラストは週刊少年マガジン 2013年49号表紙の流用）</small></p>
 									<p>p.9: 「サンジェルマンの超長定規 featuring コテカ」（応募者全員サービス）の紹介ページ（カラー）</p>
 									<p>p.80: 「サンジェルマンの超長定規 featuring コテカ」の説明ページ</p>
 									<p>
@@ -2808,9 +2962,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年マガジン 2014年43号</book-name>
 							<book-release>2014-09-24</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: サンジェルマン伯爵<small>（堀北真希&amp;他作品と混じっての掲載、イラストは週刊少年マガジン 2014年1号表紙の流用）</small></p>
 									<p>pp.140–156: 『せっかち伯爵と時間どろぼう』00′39″「伯爵時空を股にかける」、扉ページカラー<small>（扉絵は単行本モノクロ収録、『悔画展』にカラー収録）</small></p>
 									<p>pp.157–160: オマケ漫画「せっかち伯爵をせっかちにおさらい」</p>
 								</div>
@@ -2894,7 +3050,7 @@
 							<book-amazon asin="B00R3BMQKQ" image-id="61K6W2O9nYL" width="110" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 千代（他作品と混じっての掲載）</p>
+									<p>表紙: 千代<small>（他作品と混じっての掲載）</small></p>
 									<p>pp.119–128: 読切『オフサイドトラップ』</p>
 								</div>
 							</book-contents>
@@ -2959,9 +3115,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>別冊少年マガジン 2015年8月号</book-name>
 							<book-release>2015-07-09</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: じょしらくメンバー5人<small>（『アルスラーン戦記』など他作品と混じっての掲載）</small></p>
 									<p>pp.373–378: 『じょしらく』特別編「お記憶の皿」</p>
 									<p>p.379: 『じょしらく』ブルーレイ BOX 発売のお知らせ（カラー）</p>
 								</div>
@@ -2994,11 +3152,12 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2016年1月号</book-name>
 							<book-release>2015-12-04</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-amazon asin="B018SD2K3U" image-id="61FnexVb9AL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 可久士&amp;姫（他作品と混じっての掲載）</p>
+									<p>表紙: 可久士&amp;姫<small>（『RiN』など他作品と混じっての掲載）</small></p>
 									<p>
 										pp.261–292: 『かくしごと』第1話、扉ページカラー<small>（<a href="https://www.amazon.co.jp/dp/B01GRDKGZW/" class="htmlbuild-amazon-associate htmlbuild-host">単行本1巻</a>表紙で採用）</small>
 									</p>
@@ -3019,21 +3178,28 @@
 							<book-amazon asin="B019W1P54I" image-id="61zCxNqAjML" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
+									<p>紙版表紙: 可久士&amp;姫<small>（『修羅の刻　昭和編』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
 									<p>
-										表紙: 可久士&amp;姫<small>（1月号扉イラストと同じ、<a href="https://www.amazon.co.jp/dp/B01GRDKGZW/" class="htmlbuild-amazon-associate htmlbuild-host">単行本1巻</a>表紙で採用）</small>
+										電子版表紙: 可久士&amp;姫<small>（イラストは2016年1月号扉ページの流用、<a href="https://www.amazon.co.jp/dp/B01GRDKGZW/" class="htmlbuild-amazon-associate htmlbuild-host">単行本1巻</a>表紙で採用）</small>
 									</p>
 									<p>p.285: 「後藤可久士の「描く仕事」!!」第1回</p>
 								</div>
+
+								<ul class="p-notes">
+									<li>電子版には『修羅の刻　昭和編』が収録されていないため、紙版と電子版では表紙が異なる。</li>
+								</ul>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 2016年9号</book-name>
 							<book-release>2016-01-27</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>読切</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: とも子<small>（『銀の匙 Silver Spoon』など他作品と混じっての掲載）</small></p>
 									<p>pp.81–104: 読切・クメショート『タワマンとも子』『リゾマンとも子』、扉ページカラー</p>
 								</div>
 							</book-contents>
@@ -3042,9 +3208,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2016年3月号</book-name>
 							<book-release>2016-02-05</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 可久士&amp;姫<small>（『RiN』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
 									<p>pp.263–296: 『かくしごと』第3話、冒頭2ページカラー</p>
 									<p>p.297: 「後藤可久士の「描く仕事」!!」第2回</p>
 								</div>
@@ -3070,7 +3238,7 @@
 							<book-amazon asin="B01BDAANXY" image-id="61I68gRjU9L" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: なんくる姉さん</p>
+									<p>表紙: なんくる姉さん<small>（『もののけ◇しぇありんぐ』など他作品と混じっての掲載）</small></p>
 									<p>pp.3–26: 『なんくる姉さん』第1ざわ話「なんくる姉さん」、冒頭3ページカラー</p>
 									<p>p.6: 連載開始記念サイン入り複製原画プレゼント&amp;『かくしごと』広告（カラー）</p>
 								</div>
@@ -3090,20 +3258,28 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>ヤングマガジンサード 2016年 Vol.5</book-name>
 							<book-release>2016-04-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>特別付録: 『かくしごと』&amp;『なんくる姉さん』クリアファイル</p>
+									<p>紙版表紙: 『かくしごと』&amp;『なんくる姉さん』クリアファイル<small>（『グレイプニル』など他作品と混じっての掲載）</small></p>
+									<p>特別付録: 『かくしごと』&amp;『なんくる姉さん』クリアファイル<small>（『かくしごと』イラストは月刊少年マガジン 2016年3月号扉ページの流用）</small></p>
 								</div>
+
+								<ul class="p-notes">
+									<li>電子版はクリアファイル付録なし、表紙掲載なし</li>
+								</ul>
 							</book-contents>
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2016年6月号</book-name>
 							<book-release>2016-05-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-tag>イベント</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 可久士&amp;姫<small>（『さよなら私のクラマー』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
 									<p>
 										pp.294–320: 『かくしごと』扉ページカラー<q>娘を愛す、娘はアイス</q><small>（<a href="https://www.amazon.co.jp/dp/B01M7O7KP9/" class="htmlbuild-amazon-associate htmlbuild-host">単行本2巻</a>表紙で採用）</small>
 									</p>
@@ -3122,10 +3298,15 @@
 							<book-amazon asin="B01GFTJ2Y4" image-id="61RMUSF2NSL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 可久士&amp;姫</p>
-									<p>pp.3–30: 『かくしごと』扉ページカラー<small>（本号表紙と同じ、単行本未収録）</small></p>
+									<p>紙版表紙: 可久士&amp;姫<small>（『龍帥の翼　史記・留侯世家異伝』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
+									<p>電子版表紙: 可久士&amp;姫</p>
+									<p>pp.3–30: 『かくしごと』扉ページカラー<small>（本号電子版表紙と同じ、単行本未収録）</small></p>
 									<p>pp.31–32: 『かくしごと』1巻発売記念サイン会、プロモーションビデオ、画集「悔画展」、原画展「一挙後悔中」などの広告</p>
 								</div>
+
+								<ul class="p-notes">
+									<li>電子版には『龍帥の翼　史記・留侯世家異伝』が収録されていないため、紙版と電子版では表紙が異なる。</li>
+								</ul>
 							</book-contents>
 						</htmlbuild-book>
 
@@ -3138,7 +3319,7 @@
 							<book-amazon asin="B01GFTJ1YA" image-id="51yKpuadnjL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: なんくる姉さん（麦わら帽子&amp;水着）</p>
+									<p>表紙: 水着に麦わら帽子のなんくる姉さん</p>
 									<p>pp.3–28: 『なんくる姉さん』第5ざわ話「つまずいたっていいじゃないか、ちゅらさんだもの」、扉ページカラー</p>
 									<p>p.4: 「悔画展」「一挙後悔中」広告（カラー）</p>
 								</div>
@@ -3215,13 +3396,21 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2016年11月号</book-name>
 							<book-release>2016-10-06</book-release>
+							<book-tag>表紙</book-tag>
+							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>紙版表紙: 可久士&amp;姫<small>（『龍帥の翼　史記・留侯世家異伝』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
+									<p>電子版表紙: 可久士&amp;姫<small>（『さよなら私のクラマー』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
 									<p>
 										pp.520–552: 『かくしごと』扉ページカラー<small>（<a href="https://www.amazon.co.jp/dp/B071G5C4Q1/" class="htmlbuild-amazon-associate htmlbuild-host">単行本4巻</a>表紙で採用）</small>
 									</p>
 									<p>p.553: 『かくしごと』2巻、『なんくる姉さん』1巻広告</p>
 								</div>
+
+								<ul class="p-notes">
+									<li>電子版には『龍帥の翼　史記・留侯世家異伝』が収録されていないため、紙版と電子版では表紙が異なる。</li>
+								</ul>
 							</book-contents>
 						</htmlbuild-book>
 
@@ -3232,7 +3421,7 @@
 							<book-amazon asin="B01MQCXJVV" image-id="61X+dNzLcSL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: なんくる姉さん（水着）</p>
+									<p>表紙: 水着のなんくる姉さん</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -3240,9 +3429,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2017年1月号</book-name>
 							<book-release>2016-12-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 可久士&amp;姫<small>（『ましろのおと』など他作品と混じっての掲載、イラストは可久士が月刊少年マガジン 2016年1月号表紙の流用、姫が同号扉ページの流用）</small></p>
 									<p>
 										pp.3–36: 『かくしごと』扉ページカラー（Weekend House Alley をバックに可久士&amp;姫が歩くイラスト）<small>（単行本未収録、<a href="https://www.youtube.com/watch?v=cHYeFFGcjdc&amp;t=21s" class="htmlbuild-host">TV アニメ OP</a> に採用）</small>
 									</p>
@@ -3262,7 +3453,7 @@
 							<book-amazon asin="B06XCLXR8V" image-id="61INdouKcWL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: なんくる姉さん（ひな祭り）</p>
+									<p>表紙: 和服のなんくる姉さん（ひな祭り）</p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -3280,11 +3471,29 @@
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
+							<book-name>月刊少年マガジン 2017年9月号</book-name>
+							<book-release>2017-08-06</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>紙版表紙: 姫<small>（『龍帥の翼　史記・留侯世家異伝』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
+									<p>電子版表紙: 可久士&amp;姫<small>（『終わりのセラフ』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
+								</div>
+
+								<ul class="p-notes">
+									<li>電子版には『龍帥の翼　史記・留侯世家異伝』が収録されていないため、紙版と電子版では表紙が異なる。</li>
+								</ul>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2017年11月号</book-name>
 							<book-release>2017-10-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 姫<small>（『ましろのおと』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
 									<p>
 										pp.391–426: 『かくしごと』扉ページカラー<small>（<a href="https://www.amazon.co.jp/dp/B07788BKMZ/" class="htmlbuild-amazon-associate htmlbuild-host">単行本5巻</a>表紙で採用）</small>
 									</p>
@@ -3295,9 +3504,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>ヤングマガジンサード 2018年 Vol.1</book-name>
 							<book-release>2017-12-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: ワンピース姿のなんくる姉さん<small>（『魔女と野獣』など他作品と混じっての掲載）</small></p>
 									<p>p.5: 『なんくる姉さん』単行本3巻広告（カラー）</p>
 									<p>pp.6–26: 『なんくる姉さん』第22ざわ話「私が誰よりイッチン」、扉ページカラー</p>
 								</div>
@@ -3356,12 +3567,17 @@
 							<book-amazon asin="B07CMYGMJJ" image-id="61ELt+4qXvL" width="111" height="160"></book-amazon>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 可久士&amp;姫（浜辺）</p>
+									<p>紙版表紙: 可久士&amp;姫<small>（『龍帥の翼　史記・留侯世家異伝』など他作品と混じっての掲載、イラストは可久士が月刊少年マガジン 2016年1月号表紙の流用、姫が同号扉ページの流用）</small></p>
+									<p>電子版表紙: 浜辺の可久士&amp;姫</p>
 									<p>
-										pp.3–36: 『かくしごと』扉ページカラー<small>（<a href="https://www.amazon.co.jp/dp/B07CSQY8YP/" class="htmlbuild-amazon-associate htmlbuild-host">単行本6巻</a>表紙で採用）</small>
+										pp.3–36: 『かくしごと』扉ページカラー<small>（本号電子版表紙と同じ、<a href="https://www.amazon.co.jp/dp/B07CSQY8YP/" class="htmlbuild-amazon-associate htmlbuild-host">単行本6巻</a>表紙で採用）</small>
 									</p>
 									<p>p.37: 『かくしごと』6巻広告</p>
 								</div>
+
+								<ul class="p-notes">
+									<li>電子版には『龍帥の翼　史記・留侯世家異伝』が収録されていないため、紙版と電子版では表紙が異なる。</li>
+								</ul>
 							</book-contents>
 						</htmlbuild-book>
 
@@ -3404,9 +3620,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2019年10月号</book-name>
 							<book-release>2019-09-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 姫<small>（『終わりのセラフ』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
 									<p>
 										pp.3–40: 『かくしごと』扉ページカラー<small>（<a href="https://www.amazon.co.jp/dp/B07XBY5XKK/" class="htmlbuild-amazon-associate htmlbuild-host">単行本9巻</a>表紙で採用）</small>
 									</p>
@@ -3449,9 +3667,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2020年1月号</book-name>
 							<book-release>2019-12-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 可久士&amp;姫<small>（『DEAR BOYS』『虚構推理』など他作品と混じっての掲載、イラストは可久士が月刊少年マガジン 2016年1月号表紙の流用、姫が同号扉ページの流用）</small></p>
 									<p>p.295: 『かくしごと』TV アニメ特報、キービジュアルイラスト掲載</p>
 								</div>
 							</book-contents>
@@ -3475,9 +3695,11 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2020年4月号</book-name>
 							<book-release>2020-03-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 姫<small>（『虚構推理』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年1月号扉ページの流用）</small></p>
 									<p>pp.4–5: 『かくしごと』TV アニメ特集、花江夏樹コメント</p>
 								</div>
 							</book-contents>
@@ -3486,9 +3708,13 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2020年5月号</book-name>
 							<book-release>2020-04-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>
+										表紙: 可久士&amp;姫<small>（『龍帥の翼　史記・留侯世家異伝』など他作品と混じっての掲載、イラストは<a href="https://www.amazon.co.jp/dp/B07QQBQZ19/" class="htmlbuild-amazon-associate htmlbuild-host">単行本8巻</a>表紙の流用）</small>
+									</p>
 									<p>
 										pp.3–36: 『かくしごと』扉ページカラー<small>（<a href="https://www.amazon.co.jp/dp/B085L7QSHK/" class="htmlbuild-amazon-associate htmlbuild-host">単行本11巻</a>表紙で採用）</small>
 									</p>
@@ -3500,9 +3726,13 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2020年6月号</book-name>
 							<book-release>2020-05-02</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>
+										表紙: 可久士&amp;姫<small>（『ましろのおと』など他作品と混じっての掲載、イラストは<a href="https://www.amazon.co.jp/dp/B01N3CRBG8/" class="htmlbuild-amazon-associate htmlbuild-host">単行本3巻</a>表紙の流用）</small>
+									</p>
 									<p>pp:231-232: 『かくしごと』TV アニメ特集、高橋李依インタビュー（カラー）</p>
 								</div>
 							</book-contents>
@@ -3511,9 +3741,13 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2020年7月号</book-name>
 							<book-release>2020-06-05</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>アニメ</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>
+										表紙: 姫<small>（『ノラガミ』など他作品と混じっての掲載、イラストは<a href="https://www.amazon.co.jp/dp/B01N3CRBG8/" class="htmlbuild-amazon-associate htmlbuild-host">単行本3巻</a>表紙の流用）</small>
+									</p>
 									<p>p.293: 『かくしごと』Blu-ray&amp;DVD 第1巻、コラボ CD などの広告（カラー）</p>
 								</div>
 							</book-contents>
@@ -3522,9 +3756,13 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>月刊少年マガジン 2020年8月号</book-name>
 							<book-release>2020-07-06</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>
+										表紙: 可久士&amp;姫<small>（『龍帥の翼　史記・留侯世家異伝』など他作品と混じっての掲載、イラストは月刊少年マガジン 2016年6月号扉ページの流用）</small>
+									</p>
 									<p>pp.423–472: 『かくしごと』最終話、ラスト2ページカラー</p>
 								</div>
 							</book-contents>
@@ -3580,10 +3818,12 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 2021年48号</book-name>
 							<book-release>2021-10-27</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>カラー</book-tag>
 							<book-tag>畑健二郎</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 制服姿の振り向き逸子<small>（佐々木美玲&amp;他作品と混じっての掲載、イラストは扉ページの流用）</small></p>
 									<p>pp.24–30: 『シブヤニアファミリー』第1話「この街は足腰にいいんだって。」、扉ページカラー</p>
 									<p>pp.31–48: 『トニカクカワイイ』第168話「ハヤテのごとく! 2」（『新しい恥図』のアンサー漫画）</p>
 								</div>
@@ -3591,12 +3831,80 @@
 						</htmlbuild-book>
 
 						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2021年49号</book-name>
+							<book-release>2021-11-02</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 制服姿の振り向き逸子<small>（川津明日香&amp;他作品と混じっての掲載、イラストは週刊少年サンデー 2021年48号扉ページの流用）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2021年50号</book-name>
+							<book-release>2021-11-10</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 制服姿の振り向き逸子<small>（『トニカクカワイイ』など他作品と混じっての掲載、イラストは週刊少年サンデー 2021年48号扉ページの流用）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2021年51号</book-name>
+							<book-release>2021-11-17</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 制服姿の振り向き逸子<small>（『よふかしのうた』など他作品と混じっての掲載、イラストは週刊少年サンデー 2021年48号扉ページの流用）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 2021年52号</book-name>
 							<book-release>2021-11-24</book-release>
+							<book-tag>表紙</book-tag>
 							<book-tag>年賀状</book-tag>
 							<book-contents>
 								<div class="p-text">
+									<p>表紙: 制服姿の振り向き逸子<small>（『葬送のフリーレン』など他作品と混じっての掲載、イラストは週刊少年サンデー 2021年48号扉ページの流用）</small></p>
 									<p>pp.3–5: 「2022年年賀状プレゼント」で『シブヤニアファミリー』予告編のイラスト（※描き下ろしではない）</p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2022年1号</book-name>
+							<book-release>2021-12-01</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 制服姿の振り向き逸子<small>（『名探偵コナン』など他作品と混じっての掲載、イラストは週刊少年サンデー 2021年48号扉ページの流用）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2022年2・3号</book-name>
+							<book-release>2021-12-08</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 制服姿の振り向き逸子<small>（賀喜遥香&amp;他作品と混じっての掲載、イラストは週刊少年サンデー 2021年48号扉ページの流用）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2022年4・5号</book-name>
+							<book-release>2021-12-22</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: 制服姿の振り向き逸子<small>（Snow Man&amp;他作品と混じっての掲載、イラストは週刊少年サンデー 2021年48号扉ページの流用）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -3609,9 +3917,21 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 2022年16号</book-name>
 							<book-release>2022-03-16</book-release>
+							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: ドレス姿の逸子（創刊63周年の集合イラスト）</p>
+									<p>表紙: ドレス姿の逸子<small>（創刊63周年の集合イラスト）</small></p>
+								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2022年27号</book-name>
+							<book-release>2022-06-01</book-release>
+							<book-tag>表紙</book-tag>
+							<book-contents>
+								<div class="p-text">
+									<p>表紙: ドレス姿の逸子<small>（ハロー! プロジェクト&amp;他作品と混じっての掲載、イラストは週刊少年サンデー 2022年16号表紙の流用）</small></p>
 								</div>
 							</book-contents>
 						</htmlbuild-book>
@@ -3648,10 +3968,25 @@
 						<htmlbuild-book heading-level="3">
 							<book-name>週刊少年サンデー 2023年16号</book-name>
 							<book-release>2023-03-15</book-release>
+							<book-tag>表紙</book-tag>
 							<book-contents>
 								<div class="p-text">
-									<p>表紙: 制服姿の逸子（創刊64周年の集合イラスト）</p>
+									<p>表紙: 制服姿の逸子<small>（創刊64周年の集合イラスト）</small></p>
 								</div>
+							</book-contents>
+						</htmlbuild-book>
+
+						<htmlbuild-book heading-level="3">
+							<book-name>週刊少年サンデー 2023年21号</book-name>
+							<book-release>2023-04-19</book-release>
+							<book-contents>
+								<div class="p-text">
+									<p>pp.14–15: 『ホビーの楽園!!』の「夢の最強ラインナップを考えよう! 週刊少年サンデー編」企画でお笑いタレント・川島明から『行け!!南国アイスホッケー部』の名前が挙がる（カラー）</p>
+								</div>
+
+								<ul class="p-notes">
+									<li>読売テレビで2023年4月2日（1日深夜）に放送された<a href="https://www.ytv.co.jp/manganuma/" class="htmlbuild-host">『川島・山内のマンガ沼』</a>第112巻の紹介記事</li>
+								</ul>
 							</book-contents>
 						</htmlbuild-book>
 					</section>


### PR DESCRIPTION
漫画雑誌の表紙情報はこれまで単独表紙ないし大きく掲載された事例のみとしていたが、小さな掲載例も含めてすべての事例を掲載するようにした