### PR TITLE
Markuplint の `excludeFiles` から巨大 HTML ファイルを削除

### DIFF
--- a/.markuplintrc
+++ b/.markuplintrc
@@ -8,14 +8,7 @@
 	"excludeFiles": [
 		"views/feed/*.ejs",
 		"views/mail/*.ejs",
-		"views/xml/*.ejs",
-		"public/kumeta/manga/comment.html",
-		"public/kumeta/library/book.html",
-		"public/kumeta/library/manga.html",
-		"public/kumeta/manga/subtitle.html",
-		"public/madoka/library/magazine.html",
-		"public/madoka/yomoyama/namae.html",
-		"public/madoka/video/shinpen.html"
+		"views/xml/*.ejs"
 	],
 	"rules": {
 		"disallowed-element": [
@@ -64,6 +57,12 @@
 			"selector": "input",
 			"rules": {
 				"id-duplication": false
+			}
+		},
+		{
+			"selector": "summary",
+			"rules": {
+				"permitted-contents": false
 			}
 		},
 		{


### PR DESCRIPTION
これまで比較的サイズの大きいファイルはエラーが発生して lint 処理ができなかったため、`excludeFiles` で除外設定をしていたが、いつの間にか解消されていたので除外を止める。