### PR TITLE
`@saekitominaga/customelements-input-switch` の `polyfill` 属性を削除

### DIFF
--- a/views/tokyu-car-history.ejs
+++ b/views/tokyu-car-history.ejs
@@ -267,7 +267,7 @@
 
 						<%_ if (searchCount >= 2) { _%>
 						<p>
-							<label class="c-label"><w0s-input-switch checked="" storage-key="tokyu-history-ditto" polyfill="hidden" class="js-button-ditto" data-ditto-for="result-table"></w0s-input-switch><span class="c-label__text">直上と同じ内容のセルを「〃」で表示する</span></label>
+							<label class="c-label"><w0s-input-switch checked="" storage-key="tokyu-history-ditto" class="js-button-ditto" data-ditto-for="result-table"></w0s-input-switch><span class="c-label__text">直上と同じ内容のセルを「〃」で表示する</span></label>
 						</p>
 						<%_ } _%>
 


### PR DESCRIPTION
バージョン 2 でとうに廃止されていた。残っていることに悪影響はないが、不要なので削除する。