### PR TITLE
'matomo.js'  の読み込みタグを async に戻す

### DIFF
--- a/views/_include/head.ejs
+++ b/views/_include/head.ejs
@@ -10,7 +10,7 @@
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>
 <%_ } _%> <%_ } _%>
-<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
+<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 <script src="/assets/script/analytics.js" defer=""></script>
 
 <title><%= structuredData.title %></title>

--- a/views/_include/head_kumeta.ejs
+++ b/views/_include/head_kumeta.ejs
@@ -11,7 +11,7 @@
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>
 <%_ } _%> <%_ } _%>
-<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
+<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 <script src="/assets/script/analytics.js" defer=""></script>
 
 <title><%= structuredData.title %></title>

--- a/views/_include/head_madoka.ejs
+++ b/views/_include/head_madoka.ejs
@@ -11,7 +11,7 @@
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>
 <%_ } _%> <%_ } _%>
-<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
+<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 <script src="/assets/script/analytics.js" defer=""></script>
 
 <title><%= structuredData.title %></title>

--- a/views/_include/head_tokyu.ejs
+++ b/views/_include/head_tokyu.ejs
@@ -11,7 +11,7 @@
 <%_ if (typeof moduleScripts !== 'undefined') { _%> <%_ for (const fileName of moduleScripts) { _%>
 <script src="/assets/script/<%= fileName %>" type="module"></script>
 <%_ } _%> <%_ } _%>
-<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
+<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 <script src="/assets/script/analytics.js" defer=""></script>
 
 <title><%= structuredData.title %></title>


### PR DESCRIPTION
#289 で `<script>` 要素による外部ファイル読み込みを `defer` に統一したが、アクセス解析用途の 'matomo.js' は `async` でしか動かないため元に戻す