### PR TITLE
highlight.js 11.8 にアップデート

### DIFF
--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -2,9 +2,6 @@
 	"extends": "@w0s/tsconfig",
 	"include": ["@types/*.d.ts", "src/**/*.ts"],
 	"compilerOptions": {
-		/* Modules */
-		"moduleResolution": "Node", // "Node16" だと `node_modules/highlight.js/es/core.d.ts:1:18 - error TS7016` でコンパイル不能
-
 		/* Emit */
 		"outDir": "dist"
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"express-validator": "^6.14.2",
 				"github-slugger": "^2.0.0",
 				"globby": "^13.1.2",
-				"highlight.js": "^11.6.0",
+				"highlight.js": "^11.8.0",
 				"htpasswd-js": "^1.0.2",
 				"image-size": "^1.0.2",
 				"jsdom": "^20.0.1",
@@ -6751,9 +6751,9 @@
 			}
 		},
 		"node_modules/highlight.js": {
-			"version": "11.7.0",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
-			"integrity": "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==",
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+			"integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -19468,9 +19468,9 @@
 			"dev": true
 		},
 		"highlight.js": {
-			"version": "11.7.0",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
-			"integrity": "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ=="
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+			"integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg=="
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"express-validator": "^6.14.2",
 		"github-slugger": "^2.0.0",
 		"globby": "^13.1.2",
-		"highlight.js": "^11.6.0",
+		"highlight.js": "^11.8.0",
 		"htpasswd-js": "^1.0.2",
 		"image-size": "^1.0.2",
 		"jsdom": "^20.0.1",


### PR DESCRIPTION
TypeScript 設定の [`moduleResolution`](https://www.typescriptlang.org/tsconfig#moduleResolution) を `Node16` に上げられる。
👉https://github.com/highlightjs/highlight.js/issues/3481