### PR TITLE
週刊少年マガジン 2014年1号の表紙イラスト補足を追加

### DIFF
--- a/html/kumeta/library/manga.html
+++ b/html/kumeta/library/manga.html
@@ -2833,6 +2833,10 @@
 			<div class="p-text">
 				<p>表紙: サンジェルマン伯爵<small>（集合イラスト）</small></p>
 			</div>
+
+			<ul class="p-notes">
+				<li>2016年に<a href="https://www.comiczin.jp/info/comic/index.cgi?no=5937" class="htmlbuild-host">「悔画展」の COMIC ZIN 店舗特典（イラストカード）</a>で全身イラストが公開された。</li>
+			</ul>
 		</book-contents>
 	</htmlbuild-book>
 </section>


### PR DESCRIPTION
> このカッコいい伯爵のイラストは、マガジンの全キャラ集合表紙用に描かれたもので、完成した表紙では他のキャラに紛れて、顔と帽子しか見えてなかったという憂き目に遭ったものなのです。日の目を見させてあげられて良かったです。

[くめたん（久米田康治先生担当編集ズ）さんはTwitterを使っています](https://twitter.com/kume_tantou/status/746346944994304001)