### PR TITLE
ガワのマークアップ変更（主に見出し回り）

### DIFF
--- a/packages/frontend/style/admin.css
+++ b/packages/frontend/style/admin.css
@@ -14,6 +14,7 @@
 @import url("object/component/_embedded.css") layer(component);
 @import url("object/component/_form.css") layer(component);
 @import url("object/component/_layout.css") layer(component);
+@import url("object/component/_sidebar.css") layer(component);
 
 /* Object - Project */
 @import url("object/project/_header.css") layer(project);

--- a/packages/frontend/style/kumeta.css
+++ b/packages/frontend/style/kumeta.css
@@ -15,6 +15,7 @@
 @import url("object/component/_embedded.css") layer(component);
 @import url("object/component/_form.css") layer(component);
 @import url("object/component/_layout.css") layer(component);
+@import url("object/component/_sidebar.css") layer(component);
 
 /* Object - Project */
 @import url("object/project/_header.css") layer(project);

--- a/packages/frontend/style/madoka.css
+++ b/packages/frontend/style/madoka.css
@@ -16,6 +16,7 @@
 @import url("object/component/_embedded.css") layer(component);
 @import url("object/component/_form.css") layer(component);
 @import url("object/component/_layout.css") layer(component);
+@import url("object/component/_sidebar.css") layer(component);
 
 /* Object - Project */
 @import url("object/project/_header.css") layer(project);

--- a/packages/frontend/style/object/component/_sidebar.css
+++ b/packages/frontend/style/object/component/_sidebar.css
@@ -1,0 +1,71 @@
+/* ==============================
+ *   サイドバー
+ * ============================== */
+
+/* ===== リンクリスト ===== */
+.c-sidebar-link {
+	--_padding-block: 0.5em;
+	--_padding-inline: 0.5em;
+	--_bg-color: var(--color-verylightblue);
+
+	& a {
+		display: block;
+		contain: content;
+		outline-width: var(--outline-width-bold);
+		outline-offset: -1px;
+		background: var(--_bg-color);
+		padding: var(--_padding-block) var(--_padding-inline);
+		min-block-size: var(--_min-block-size);
+		font-size: calc(100% / var(--font-ratio-1));
+
+		&:any-link {
+			--_bg-color: var(--color-white);
+			--_icon-color: var(--color-lightgray); /* アイコンの色 */
+			--_icon-inline-size: 0.67em; /* アイコンの幅 */
+			--_icon-block-size: 1em; /* アイコンの高さ */
+			--_icon-gap: 0.75em; /* テキストとアイコンの間隔 */
+
+			padding-inline-end: calc(var(--_icon-gap) + var(--_icon-inline-size) + var(--_padding-inline));
+			text-decoration: none;
+
+			&::after {
+				position: absolute;
+				clip-path: var(--shape-link-arrow);
+				inset-block-start: calc(50% - var(--_icon-block-size) / 2);
+				inset-inline-end: var(--_padding-inline);
+				border-block-start: var(--_icon-block-size) solid var(--_icon-color);
+				inline-size: var(--_icon-inline-size);
+				content: "";
+			}
+
+			&:hover {
+				--_bg-color: var(--color-lightyellow);
+				--_icon-color: var(--color-gray);
+			}
+		}
+	}
+
+	& > li {
+		& + li {
+			border-block-start: 1px dotted var(--color-border-dark);
+		}
+
+		/* 奇数行 */
+		&:nth-child(2n + 1) {
+			& a {
+				&:any-link {
+					--_bg-color: var(--color-bg-superlight);
+
+					&:hover {
+						--_bg-color: var(--color-lightyellow);
+					}
+				}
+			}
+		}
+	}
+
+	/* 記事 */
+	&.-entry {
+		--_min-block-size: 2em;
+	}
+}

--- a/packages/frontend/style/object/project/_footer.css
+++ b/packages/frontend/style/object/project/_footer.css
@@ -46,3 +46,6 @@
 		display: block;
 	}
 }
+
+.p-footer-ads__hdg {
+}

--- a/packages/frontend/style/object/project/_sidebar.css
+++ b/packages/frontend/style/object/project/_sidebar.css
@@ -72,14 +72,14 @@
 }
 
 /* ===== 日記記事リスト ===== */
-.p-sidebar-blog-entry {
+.p-sidebar-blog-entries {
 	--_heading-offset: calc(-0.5em * var(--line-height-narrow));
 
 	border: 1px solid var(--color-border-dark);
 	border-radius: var(--border-radius-normal) var(--border-radius-normal) 0 0;
 }
 
-.p-sidebar-blog-entry__hdg {
+.p-sidebar-blog-entries__hdg {
 	display: inline-block;
 	position: relative;
 	margin-inline: 10px;

--- a/packages/frontend/style/object/project/_sidebar.css
+++ b/packages/frontend/style/object/project/_sidebar.css
@@ -21,12 +21,15 @@
 	inset-block-start: var(--_heading-offset);
 	background: var(--page-bg-color);
 	padding: 0 0.5em;
+
+	& + * {
+		margin-block-start: calc(10px + var(--_heading-offset));
+	}
 }
 
 .p-sidebar-profile__info {
 	display: flow-root; /* for Safari */
 	contain: layout;
-	margin-block-start: calc(10px + var(--_heading-offset));
 }
 
 .p-sidebar-profile__address {
@@ -83,76 +86,8 @@
 	inset-block-start: var(--_heading-offset);
 	background: var(--page-bg-color);
 	padding: 0 0.5em;
-}
 
-.p-sidebar-blog-entry__link {
-	margin-block-start: var(--_heading-offset);
-}
-
-/* ===== リンクリスト ===== */
-.p-sidebar-links {
-	--_padding-block: 0.5em;
-	--_padding-inline: 0.5em;
-	--_bg-color: var(--color-verylightblue);
-
-	& a {
-		display: block;
-		contain: content;
-		outline-width: var(--outline-width-bold);
-		outline-offset: -1px;
-		background: var(--_bg-color);
-		padding: var(--_padding-block) var(--_padding-inline);
-		min-block-size: var(--_min-block-size);
-		font-size: calc(100% / var(--font-ratio-1));
-
-		&:any-link {
-			--_bg-color: var(--color-white);
-			--_icon-color: var(--color-lightgray); /* アイコンの色 */
-			--_icon-inline-size: 0.67em; /* アイコンの幅 */
-			--_icon-block-size: 1em; /* アイコンの高さ */
-			--_icon-gap: 0.75em; /* テキストとアイコンの間隔 */
-
-			padding-inline-end: calc(var(--_icon-gap) + var(--_icon-inline-size) + var(--_padding-inline));
-			text-decoration: none;
-
-			&::after {
-				position: absolute;
-				clip-path: var(--shape-link-arrow);
-				inset-block-start: calc(50% - var(--_icon-block-size) / 2);
-				inset-inline-end: var(--_padding-inline);
-				border-block-start: var(--_icon-block-size) solid var(--_icon-color);
-				inline-size: var(--_icon-inline-size);
-				content: "";
-			}
-
-			&:hover {
-				--_bg-color: var(--color-lightyellow);
-				--_icon-color: var(--color-gray);
-			}
-		}
-	}
-
-	& > li {
-		& + li {
-			border-block-start: 1px dotted var(--color-border-dark);
-		}
-
-		/* 奇数行 */
-		&:nth-child(2n + 1) {
-			& a {
-				&:any-link {
-					--_bg-color: var(--color-bg-superlight);
-
-					&:hover {
-						--_bg-color: var(--color-lightyellow);
-					}
-				}
-			}
-		}
-	}
-
-	/* 記事 */
-	&.-entry {
-		--_min-block-size: 2em;
+	& + * {
+		margin-block-start: var(--_heading-offset);
 	}
 }

--- a/packages/frontend/style/tokyu.css
+++ b/packages/frontend/style/tokyu.css
@@ -17,6 +17,7 @@
 @import url("object/component/_embedded.css") layer(component);
 @import url("object/component/_form.css") layer(component);
 @import url("object/component/_layout.css") layer(component);
+@import url("object/component/_sidebar.css") layer(component);
 
 @import url("object/component/_tokyu.css") layer(component);
 

--- a/packages/frontend/style/w0s.css
+++ b/packages/frontend/style/w0s.css
@@ -14,6 +14,7 @@
 @import url("object/component/_embedded.css") layer(component);
 @import url("object/component/_form.css") layer(component);
 @import url("object/component/_layout.css") layer(component);
+@import url("object/component/_sidebar.css") layer(component);
 
 /* Object - Project */
 @import url("object/project/_header.css") layer(project);

--- a/views/_include/footer.ejs
+++ b/views/_include/footer.ejs
@@ -15,7 +15,9 @@
 
 	<%_ if (!['/contact'].includes(pagePathAbsoluteUrl) && !pagePathAbsoluteUrl.startsWith('/admin/')) { _%>
 	<div class="l-footer__ads">
-		<section class="p-footer-ads" aria-label="広告">
+		<section class="p-footer-ads">
+			<h2 class="p-footer-ads__hdg">広告</h2>
+
 			<ins class="adsbygoogle js-ads-google" data-ad-layout="in-article" data-ad-format="fluid" data-ad-client="ca-pub-3297715785193216" data-ad-slot="9399879773"></ins>
 		</section>
 	</div>

--- a/views/_include/header_kumeta.ejs
+++ b/views/_include/header_kumeta.ejs
@@ -1,14 +1,17 @@
 <header id="header" class="l-header">
 	<div class="l-header__main">
 		<div class="l-header__site">
-			<div class="p-header-site">
-				<%_ if (pagePathAbsoluteUrl === '/kumeta/') { _%>
+			<%_ if (pagePathAbsoluteUrl === '/kumeta/') { _%>
+			<hgroup class="p-header-site">
 				<h1 class="p-header-site__name"><a aria-current="page">久米田康治データベース</a></h1>
-				<%_ } else { _%>
-				<p class="p-header-site__name"><a href="/kumeta/">久米田康治データベース</a></p>
-				<%_ } _%>
+				<p class="p-header-site__summary">漫画家・久米田康治先生の作品データや周辺動向を紹介するファンサイト</p>
+			</hgroup>
+			<%_ } else { _%>
+			<div class="p-header-site">
+				<div class="p-header-site__name"><a href="/kumeta/">久米田康治データベース</a></div>
 				<p class="p-header-site__summary">漫画家・久米田康治先生の作品データや周辺動向を紹介するファンサイト</p>
 			</div>
+			<%_ } _%>
 		</div>
 		<div class="l-header__nav">
 			<div class="p-header-nav">

--- a/views/_include/header_madoka.ejs
+++ b/views/_include/header_madoka.ejs
@@ -1,14 +1,17 @@
 <header id="header" class="l-header">
 	<div class="l-header__main">
 		<div class="l-header__site">
-			<div class="p-header-site">
-				<%_ if (pagePathAbsoluteUrl === '/madoka/') { _%>
+			<%_ if (pagePathAbsoluteUrl === '/madoka/') { _%>
+			<hgroup class="p-header-site">
 				<h1 class="p-header-site__name"><a aria-current="page">まどか資料館</a></h1>
-				<%_ } else { _%>
-				<p class="p-header-site__name"><a href="/madoka/">まどか資料館</a></p>
-				<%_ } _%>
+				<p class="p-header-site__summary">『魔法少女まどか☆マギカ』の各種データやイベントレポートを紹介するサイト</p>
+			</hgroup>
+			<%_ } else { _%>
+			<div class="p-header-site">
+				<div class="p-header-site__name"><a href="/madoka/">まどか資料館</a></div>
 				<p class="p-header-site__summary">『魔法少女まどか☆マギカ』の各種データやイベントレポートを紹介するサイト</p>
 			</div>
+			<%_ } _%>
 		</div>
 		<div class="l-header__nav">
 			<div class="p-header-nav">

--- a/views/_include/header_tokyu.ejs
+++ b/views/_include/header_tokyu.ejs
@@ -1,14 +1,17 @@
 <header id="header" class="l-header">
 	<div class="l-header__main">
 		<div class="l-header__site">
-			<div class="p-header-site">
-				<%_ if (pagePathAbsoluteUrl === '/tokyu/') { _%>
+			<%_ if (pagePathAbsoluteUrl === '/tokyu/') { _%>
+			<hgroup class="p-header-site">
 				<h1 class="p-header-site__name"><a aria-current="page">東急電車形態研究</a></h1>
-				<%_ } else { _%>
-				<p class="p-header-site__name"><a href="/tokyu/">東急電車形態研究</a></p>
-				<%_ } _%>
+				<p class="p-header-site__summary">東急電車の車両形態や自動放送を紹介するサイト</p>
+			</hgroup>
+			<%_ } else { _%>
+			<div class="p-header-site">
+				<div class="p-header-site__name"><a href="/tokyu/">東急電車形態研究</a></div>
 				<p class="p-header-site__summary">東急電車の車両形態や自動放送を紹介するサイト</p>
 			</div>
+			<%_ } _%>
 		</div>
 		<div class="l-header__nav">
 			<div class="p-header-nav">

--- a/views/_include/sidebar.ejs
+++ b/views/_include/sidebar.ejs
@@ -1,6 +1,6 @@
 <div id="sidebar" class="l-sidebar">
-	<section class="p-sidebar-profile" aria-labelledby="sidebar-profile-heading">
-		<h2 class="p-sidebar-profile__hdg" id="sidebar-profile-heading">プロフィール</h2>
+	<section class="p-sidebar-profile">
+		<h2 class="p-sidebar-profile__hdg">プロフィール</h2>
 
 		<div class="p-sidebar-profile__info">
 			<%_ if (pagePathAbsoluteUrl !== '/info') { _%>
@@ -56,8 +56,8 @@
 		</ul>
 	</section>
 
-	<aside class="p-sidebar-blog-entry" aria-labelledby="sidebar-blog-entries-heading" hidden="">
-		<h2 class="p-sidebar-blog-entry__hdg" id="sidebar-blog-entries-heading">最近の日記記事</h2>
+	<aside class="p-sidebar-blog-entry" hidden="">
+		<h2 class="p-sidebar-blog-entry__hdg">最近の日記記事</h2>
 
 		<div class="p-sidebar-blog-entry__link">
 			<ul class="c-sidebar-link -entry">

--- a/views/_include/sidebar.ejs
+++ b/views/_include/sidebar.ejs
@@ -56,15 +56,13 @@
 		</ul>
 	</section>
 
-	<aside class="p-sidebar-blog-entry" hidden="">
-		<h2 class="p-sidebar-blog-entry__hdg">最近の日記記事</h2>
+	<aside class="p-sidebar-blog-entries" hidden="">
+		<h2 class="p-sidebar-blog-entries__hdg">最近の日記記事</h2>
 
-		<div class="p-sidebar-blog-entry__link">
-			<ul class="c-sidebar-link -entry">
-				<template id="sidebar-blog-newly-template">
-					<li><a href=""></a></li>
-				</template>
-			</ul>
-		</div>
+		<ul class="c-sidebar-link -entry">
+			<template id="sidebar-blog-newly-template">
+				<li><a href=""></a></li>
+			</template>
+		</ul>
 	</aside>
 </div>

--- a/views/_include/sidebar.ejs
+++ b/views/_include/sidebar.ejs
@@ -60,7 +60,7 @@
 		<h2 class="p-sidebar-blog-entry__hdg" id="sidebar-blog-entries-heading">最近の日記記事</h2>
 
 		<div class="p-sidebar-blog-entry__link">
-			<ul class="p-sidebar-links -entry">
+			<ul class="c-sidebar-link -entry">
 				<template id="sidebar-blog-newly-template">
 					<li><a href=""></a></li>
 				</template>


### PR DESCRIPTION
- ランドマークの乱用をやめる
- アウトラインアルゴリズムの廃止に伴い `<hgroup>` はもう使って問題ない
