### PR TITLE
「ウェブ巡回（リソース）」の差分比較をコンテンツの長さ→ハッシュ値に変更

### DIFF
--- a/html/admin/crawler-resource.ejs
+++ b/html/admin/crawler-resource.ejs
@@ -125,6 +125,7 @@
 				<th scope="col">🌐</th>
 				<th scope="col">セレクター</th>
 				<th scope="col">ハッシュ値</th>
+				<th scope="col">エラー</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -144,10 +145,11 @@
 					<a href="<%= resourcePage.url %>" referrerpolicy="no-referrer"><%= resourcePage.title %></a>
 					<p style="margin-block-start: 0.5em; font-size: 80%"><%= resourcePage.url %></p>
 				</td>
-				<td><%= resourcePage.priority %></td>
-				<td><%_ if (resourcePage.browser) { _%>✔<%_ } _%></td>
+				<td class="u-cell -center"><%= resourcePage.priority %></td>
+				<td class="u-cell -center"><%_ if (resourcePage.browser) { _%>✔<%_ } _%></td>
 				<td class="u-cell -wrap-anywhere"><%= resourcePage.selector %></td>
 				<td><%= resourcePage.content_hash %></td>
+				<td class="u-cell -center"><%_ if (resourcePage.error) { _%><strong style="color: red">✗</strong><%_ } _%></td>
 			</tr>
 			<%_ } _%>
 		</tbody>

--- a/html/admin/crawler-resource.ejs
+++ b/html/admin/crawler-resource.ejs
@@ -124,8 +124,7 @@
 				<th scope="col">優先</th>
 				<th scope="col">🌐</th>
 				<th scope="col">セレクター</th>
-				<th scope="col">サイズ</th>
-				<th scope="col">更新日時</th>
+				<th scope="col">ハッシュ値</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -148,12 +147,7 @@
 				<td><%= resourcePage.priority %></td>
 				<td><%_ if (resourcePage.browser) { _%>✔<%_ } _%></td>
 				<td class="u-cell -wrap-anywhere"><%= resourcePage.selector %></td>
-				<td><%= resourcePage.content_length %></td>
-				<%_ if (resourcePage.last_modified !== null) { _%>
-				<td><%= resourcePage.last_modified.format('YYYY年M月D日 H時m分') %></td>
-				<%_ } else { _%>
-				<td></td>
-				<%_ } _%>
+				<td><%= resourcePage.content_hash %></td>
 			</tr>
 			<%_ } _%>
 		</tbody>

--- a/packages/backend/node/@types/view.d.ts
+++ b/packages/backend/node/@types/view.d.ts
@@ -61,6 +61,7 @@ declare namespace CrawlerResourceView {
 		browser: boolean;
 		selector: string | null;
 		content_hash: string;
+		error: boolean;
 	}
 }
 

--- a/packages/backend/node/@types/view.d.ts
+++ b/packages/backend/node/@types/view.d.ts
@@ -60,8 +60,7 @@ declare namespace CrawlerResourceView {
 		priority: string;
 		browser: boolean;
 		selector: string | null;
-		content_length: number;
-		last_modified: import('dayjs').Dayjs | null;
+		content_hash: string;
 	}
 }
 

--- a/packages/backend/node/src/controller/CrawlerResourceController.ts
+++ b/packages/backend/node/src/controller/CrawlerResourceController.ts
@@ -133,6 +133,7 @@ export default class CrawlerResourceController extends Controller implements Con
 				browser: resoursePage.browser,
 				selector: resoursePage.selector,
 				content_hash: resoursePage.content_hash,
+				error: resoursePage.error,
 			});
 
 			resourcePageListView.set(categoryName, resourcePageOfCategoryView);

--- a/packages/backend/node/src/controller/CrawlerResourceController.ts
+++ b/packages/backend/node/src/controller/CrawlerResourceController.ts
@@ -132,8 +132,7 @@ export default class CrawlerResourceController extends Controller implements Con
 				priority: resoursePage.priority,
 				browser: resoursePage.browser,
 				selector: resoursePage.selector,
-				content_length: resoursePage.content_length,
-				last_modified: resoursePage.last_modified,
+				content_hash: resoursePage.content_hash,
 			});
 
 			resourcePageListView.set(categoryName, resourcePageOfCategoryView);

--- a/packages/backend/node/src/dao/CrawlerResourceDao.ts
+++ b/packages/backend/node/src/dao/CrawlerResourceDao.ts
@@ -1,4 +1,3 @@
-import dayjs, { Dayjs } from 'dayjs';
 import CrawlerDao from './CrawlerDao.js';
 import DbUtil from '../util/DbUtil.js';
 
@@ -9,8 +8,7 @@ interface ResourcePage {
 	priority: string;
 	browser: boolean;
 	selector: string | null;
-	content_length: number;
-	last_modified: Dayjs | null;
+	content_hash: string;
 }
 
 interface ReviseData {
@@ -42,8 +40,7 @@ export default class CrawlerResourceDao extends CrawlerDao {
 				p.name AS priority,
 				r.browser AS browser,
 				r.selector AS selector,
-				r.content_length AS content_length,
-				r.last_modified AS last_modified
+				r.content_hash AS content_hash
 			FROM
 				d_resource r,
 				m_class c,
@@ -68,8 +65,7 @@ export default class CrawlerResourceDao extends CrawlerDao {
 				priority: row.priority,
 				browser: Boolean(row.browser),
 				selector: row.selector,
-				content_length: row.content_length,
-				last_modified: row.last_modified !== null ? dayjs.unix(row.last_modified) : null,
+				content_hash: row.content_hash,
 			});
 		}
 

--- a/packages/backend/node/src/dao/CrawlerResourceDao.ts
+++ b/packages/backend/node/src/dao/CrawlerResourceDao.ts
@@ -46,7 +46,7 @@ export default class CrawlerResourceDao extends CrawlerDao {
 				m_class c,
 				m_priority p
 			WHERE
-				r.class = c.fk AND
+				r.category = c.fk AND
 				r.priority = p.fk
 			ORDER BY
 				c.sort,
@@ -90,7 +90,7 @@ export default class CrawlerResourceDao extends CrawlerDao {
 			const sth = await dbh.prepare(`
 				INSERT INTO
 					d_resource
-					(url, title, class, priority, browser, selector)
+					(url, title, category, priority, browser, selector)
 				VALUES
 					(:url, :title, :category, :priority, :browser, :selector)
 			`);
@@ -131,7 +131,7 @@ export default class CrawlerResourceDao extends CrawlerDao {
 					d_resource
 				SET
 					title = :title,
-					class = :category,
+					category = :category,
 					priority = :priority,
 					browser = :browser,
 					selector = :selector
@@ -196,7 +196,7 @@ export default class CrawlerResourceDao extends CrawlerDao {
 		const sth = await dbh.prepare(`
 			SELECT
 				title,
-				class AS category,
+				category,
 				priority,
 				browser,
 				selector

--- a/packages/backend/node/src/dao/CrawlerResourceDao.ts
+++ b/packages/backend/node/src/dao/CrawlerResourceDao.ts
@@ -9,6 +9,7 @@ interface ResourcePage {
 	browser: boolean;
 	selector: string | null;
 	content_hash: string;
+	error: boolean;
 }
 
 interface ReviseData {
@@ -40,7 +41,8 @@ export default class CrawlerResourceDao extends CrawlerDao {
 				p.name AS priority,
 				r.browser AS browser,
 				r.selector AS selector,
-				r.content_hash AS content_hash
+				r.content_hash AS content_hash,
+				r.error AS error
 			FROM
 				d_resource r,
 				m_class c,
@@ -66,6 +68,7 @@ export default class CrawlerResourceDao extends CrawlerDao {
 				browser: Boolean(row.browser),
 				selector: row.selector,
 				content_hash: row.content_hash,
+				error: Boolean(row.error),
 			});
 		}
 


### PR DESCRIPTION
SaekiTominaga/w0s.jp-shell/pull/48 に伴う修正

- 「ハッシュ値」列を追加
- 「サイズ」「更新日時」列を廃止
- 「エラー」列追加