### PR TITLE
GitHub Actions の `paths` で一行内に複数の拡張子は指定不可

### DIFF
--- a/.github/workflows/astro@html-lint.yml
+++ b/.github/workflows/astro@html-lint.yml
@@ -4,13 +4,15 @@ on:
     branches:
       - main
     paths:
-      - 'astro/src/**/*.{astro,ts}'
+      - 'astro/src/**/*.astro'
+      - 'astro/src/**/*.ts'
       - 'astro/.markuplintrc'
   push:
     branches:
       - main
     paths:
-      - 'astro/src/**/*.{astro,ts}'
+      - 'astro/src/**/*.astro'
+      - 'astro/src/**/*.ts'
       - 'astro/.markuplintrc'
   workflow_dispatch:
 

--- a/.github/workflows/astro@lint.yml
+++ b/.github/workflows/astro@lint.yml
@@ -4,13 +4,15 @@ on:
     branches:
       - main
     paths:
-      - 'astro/src/**/*.{astro,ts}'
+      - 'astro/src/**/*.astro'
+      - 'astro/src/**/*.ts'
       - 'astro/.eslintrc.json'
   push:
     branches:
       - main
     paths:
-      - 'astro/src/**/*.{astro,ts}'
+      - 'astro/src/**/*.astro'
+      - 'astro/src/**/*.ts'
       - 'astro/eslintrc.json'
   workflow_dispatch:
 


### PR DESCRIPTION
[GitHub Actions のワークフロー構文 - GitHub Docs](https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)によると、`paths` の glob パターンに `*.{html, htm}` のような { } を使った複数の拡張子パターンは指定できないようだ。