### PR TITLE
本番サーバーでのビルド時のメモリ対策

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -4,7 +4,8 @@
 	"type": "module",
 	"scripts": {
 		"dev": "astro dev",
-		"build": "run-s _astro-build:*",
+		"build-dev": "astro check && tsc --noEmit && run-s _astro-build:*",
+		"build-prod": "NODE_OPTIONS=\"--max-old-space-size=500\" run-s _astro-build:*",
 		"lint": "eslint src/**/*.{astro,ts}",
 		"node-lint": "eslint build/*.js",
 		"html-lint": "markuplint dist/client/**/*.html",
@@ -14,8 +15,6 @@
 		"js-build-watch": "rollup -c -w",
 		"js-build-all": "rollup -c",
 		"js-lint": "eslint script/**/*.ts",
-		"_astro-build:check": "astro check",
-		"_astro-build:tsc": "tsc --noEmit",
 		"_astro-build:build": "astro build",
 		"_astro-build:html": "node build/html.js -d dist/client",
 		"_astro-build:svg": "node build/svg.js -f dist/client/**/*.svg -f dist/client/favicon.ico -c svgo.config.cjs",


### PR DESCRIPTION
本番サーバーで `astro check` や `astro build` を行うと `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` が発生する。

そのため、開発環境で実施済み（のはず）の `astro check` は省略し、また `astro build` の実行に際しては `--max-old-space-size` オプションを指定する。
