### PR TITLE
作品リスト、メディア紹介に情報追記

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -105,6 +105,12 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2023-08-04">
+					<p><a href="/kumeta/manga/list">作品リスト</a>のページに『せっかち伯爵と時間どろぼう』の4コマ漫画2作を追加。</p>
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>のページに「マガジン SPECIAL 2014年1号」、「マガジン SPECIAL 2014年2号」「マガジン SPECIAL 2014年8号」「楽園 Le Paradis 16号」を追加。</p>
+					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>のページに「声優グランプリ 2009年11月号」、「アニサマ公式メモリアル」（2010年）、「戦国大戦　攻略虎の巻」（2011年）、「戦国大戦 —1560 尾張の風雲児— 天下布武への道　〜攻略絵巻　春の陣〜」（2011年）を追加。</p>
+					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>のページに「東京中日スポーツ 2021年7月12日」を追加。</p>
+				</TopUpdate>
 				<TopUpdate date="2023-06-20">
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>のページに「日本TVアニメーション大全」（2014年）を追加。</p>
 				</TopUpdate>
@@ -116,9 +122,6 @@ const slugger = new GithubSlugger();
 				</TopUpdate>
 				<TopUpdate date="2023-03-29">
 					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に日本経済新聞2023年3月28日の記事を追加。</p>
-				</TopUpdate>
-				<TopUpdate date="2023-03-24">
-					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に週刊少年マガジン 2014年1号の表紙情報を追加。</p>
 				</TopUpdate>
 			</ul>
 		</div>

--- a/astro/src/pages/kumeta/library/book.astro
+++ b/astro/src/pages/kumeta/library/book.astro
@@ -11,7 +11,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の図書、一般雑誌での紹介例',
 	heading: 'メディア紹介 — 図書、一般雑誌',
-	dateModified: dayjs('2023-06-20'),
+	dateModified: dayjs('2023-08-04'),
 	description: '本や雑誌（漫画雑誌を除く）において久米田先生のインタビューや描き下ろしイラストが掲載された事例、また久米田作品が紹介された事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
 	localNav: [
@@ -911,6 +911,12 @@ const slugger = new GithubSlugger();
 			</div>
 		</LibraryItemBook>
 
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="声優グランプリ 2009年11月号" release="2009-10-10" tags={['音楽']} amazonAsin="B002P4V4TU" amazonImageId="61G0xe0fylL" amazonImageWidth={127} amazonImageHeight={160}>
+			<div class="p-text">
+				<p>pp.36–39: <LinkExternal href="https://anisama.tv/2009/">Animelo Summer Live 2009 —RE:BRIDGE—</LinkExternal>のレポート<small>（2日目に「大槻ケンヂと絶望少女達」が出演）</small></p>
+			</div>
+		</LibraryItemBook>
+
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="ニュータイプ・ロマンス 2009年12月号(秋)" release="2009-10-20" tags={['版権イラスト']} amazonAsin="B002PDDTRQ" amazonImageId="61sQFxkT2lL" amazonImageWidth={124} amazonImageHeight={160}>
 			<div class="p-text">
 				<p>
@@ -1038,6 +1044,12 @@ const slugger = new GithubSlugger();
 			</div>
 		</LibraryItemBook>
 
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="アニサマ公式メモリアル" release="2010-08-27" tags={['音楽']} isbn="978-4-05-404685-6" amazonAsin="4054046851" amazonImageId="51W334EGQNL" amazonImageWidth={112} amazonImageHeight={160}>
+			<div class="p-text">
+				<p>p.74–83: <LinkExternal href="https://anisama.tv/2009/">Animelo Summer Live 2009 —RE:BRIDGE—</LinkExternal>2日目のレポート<small>（「大槻ケンヂと絶望少女達」が出演）</small></p>
+			</div>
+		</LibraryItemBook>
+
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="ニュータイプ 2010年10月号" release="2010-09-10" tags={['インタビュー', 'アニメ']} amazonAsin="B003ZZEWZQ" amazonImageId="613gf73+8SL" amazonImageWidth={124} amazonImageHeight={160}>
 			<div class="p-text">
 				<p>p.137: 「新房昭之とおシゴトな仲間達」新房昭之×久米田康治の対談、久米田先生による新房監督の似顔絵掲載</p>
@@ -1080,6 +1092,12 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<H slot="heading">2011年</H>
 
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="戦国大戦　攻略虎の巻" release="2011-01-31" tags={['ゲーム']} isbn="978-4-7986-0178-6" amazonAsin="4798601780" amazonImageId="61uEQDmRptL" amazonImageWidth={113} amazonImageHeight={160}>
+			<div class="p-text">
+				<p>p.80: 「全カード解説 – 戦国の数寄」に久米田先生イラストの竹中半兵衛（SS010 SS）掲載</p>
+			</div>
+		</LibraryItemBook>
+
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="エースの系譜" release="2011-03-18" tags={['描き下ろし']} isbn="978-4-06-216794-9" amazonAsin="B00JIMMVLC" amazonImageId="51yYO-AmYwL" amazonImageWidth={112} amazonImageHeight={160}>
 			<div class="p-text">
 				<p>装画を担当</p>
@@ -1099,6 +1117,12 @@ const slugger = new GithubSlugger();
 			<ul class="p-notes">
 				<li>巻末（p.111）の読者プレゼントで久米田先生のサイン色紙もあるが、紙面では「制作中」での掲載だった。後日<LinkExternal href="https://ameblo.jp/otonaanime/entry-10858531567.html">オトナアニメ編集部のブログで画像が公開</LinkExternal>されている。</li>
 			</ul>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="戦国大戦 —1560 尾張の風雲児— 天下布武への道　〜攻略絵巻　春の陣〜" release="2011-03-30" tags={['ゲーム']} isbn="978-4-04-727260-6" amazonAsin="4047272604" amazonImageId="61gs1CJisuL" amazonImageWidth={132} amazonImageHeight={160}>
+			<div class="p-text">
+				<p>p.23: 「お役立ちカードリスト – 他家」に久米田先生イラストの竹中半兵衛（SS010 SS）掲載</p>
+			</div>
 		</LibraryItemBook>
 
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="リスアニ! Vol.05" release="2011-04-25" tags={['音楽']} isbn="978-4-7897-7126-9" amazonAsin="4789771261" amazonImageId="51a05+jM7ML" amazonImageWidth={113} amazonImageHeight={160}>

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -11,7 +11,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の漫画雑誌での紹介例',
 	heading: 'メディア紹介 — 漫画雑誌',
-	dateModified: dayjs('2023-04-26'),
+	dateModified: dayjs('2023-08-04'),
 	description: '漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
 	localNav: [
@@ -1663,9 +1663,22 @@ const slugger = new GithubSlugger();
 				<li>2016年に<LinkExternal href="https://www.comiczin.jp/info/comic/index.cgi?no=5937">「悔画展」の COMIC ZIN 店舗特典（イラストカード）</LinkExternal>で全身イラストが公開された。</li>
 			</ul>
 		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="マガジン SPECIAL 2014年1号" release="2013-12-20" tags={['企画']}>
+			<div class="p-text">
+				<p>p.647: 「新年特別企画大よんこま!」に赤松健による4コマ漫画「刀太の夢」掲載（『UQ HOLDER!』×『せっかち伯爵と時間どろぼう』パロディ）</p>
+				<p>p.650: 「新年特別企画大よんこま!」に4コマ漫画「コマセレブ」掲載</p>
+			</div>
+		</LibraryItemBook>
 	</Section>
 	<Section slugger={slugger}>
 		<H slot="heading">2014年</H>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="マガジン SPECIAL 2014年2号" release="2014-01-20">
+			<div class="p-text">
+				<p>pp.654–657: 『漫画で次号予告　ひとつきさきみちゃん』（木下由一）の「『裏切りの罪』の巻」で次号の『せっかち伯爵と時間どろぼう』出張番外編の告知、サンジェルマン伯爵登場</p>
+			</div>
+		</LibraryItemBook>
 
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年マガジン 2014年11号" release="2014-02" tags={['表紙', 'カラー']}>
 			<div class="p-text">
@@ -1683,7 +1696,8 @@ const slugger = new GithubSlugger();
 				<p>
 					pp.81–84: 『せっかち伯爵と時間どろぼう』出張掲載「4Pでわかる上人類講座」<small>（<LinkExternal href="https://www.amazon.co.jp/dp/B00LC9YFOK/">単行本2巻</LinkExternal>に収録）</small>
 				</p>
-				<p>pp.85–89: 「まんがたり! No.007」（野中コウ）で久米田康治ゲスト</p>
+				<p>pp.85–89: 『まんがたり! No.007』（野中コウ）で久米田康治ゲスト</p>
+				<p>p.666: アンケートプレゼントとして『七つの大罪』『UQ HOLDER』に混じり『せっかち伯爵と時間どろぼう』1話16ページ目<small>（<q>私の名はサンジェルマン伯爵</q>と自己紹介するページ）</small>の複製原画</p>
 			</div>
 		</LibraryItemBook>
 
@@ -1709,6 +1723,16 @@ const slugger = new GithubSlugger();
 			<div class="p-text">
 				<p>p.273: 全作品あらすじ紹介!! 『せっかち伯爵と時間どろぼう』</p>
 			</div>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="マガジン SPECIAL 2014年8号" release="2014-07-19" tags={['企画']}>
+			<div class="p-text">
+				<p>p.448: 「よんこま!」に4コマ漫画「堕センションは8万〜」掲載<small>（お題の「南国」にちなんだ下ネタのオチ）</small></p>
+			</div>
+
+			<ul class="p-notes">
+				<li>『せっかち伯爵と時間どろぼう』の単行本には収録されなかったが、4巻の店舗特典ペーパーで再掲された。</li>
+			</ul>
 		</LibraryItemBook>
 
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年マガジン 2014年36・37号" release="2014-08-06">
@@ -1740,6 +1764,12 @@ const slugger = new GithubSlugger();
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2014年48号" release="2014-10-29" tags={['畑健二郎', 'イラスト']}>
 			<div class="p-text">
 				<p>p.6: 『ハヤテのごとく！』連載10周年お祝い色紙（ハヤテ&amp;ナギのイラストとコメント<q>10周年おめでとう　そろそろ畑先生の新しい作品も読みたいな。</q>）（カラー）</p>
+			</div>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="楽園 Le Paradis 16号" release="2014-10-31">
+			<div class="p-text">
+				<p>p.452: 『スタジオパルプ』連載予告、長髪女子のイラスト掲載（役者丸ひろ子の原型?）</p>
 			</div>
 		</LibraryItemBook>
 

--- a/astro/src/pages/kumeta/library/newspaper.astro
+++ b/astro/src/pages/kumeta/library/newspaper.astro
@@ -11,7 +11,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の新聞での紹介例',
 	heading: 'メディア紹介 — 新聞',
-	dateModified: dayjs('2023-03-29'),
+	dateModified: dayjs('2023-08-04'),
 	description: '新聞紙上において久米田先生のインタビューや作品紹介などが掲載された事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
 	localNav: [
@@ -240,9 +240,19 @@ const slugger = new GithubSlugger();
 			</div>
 		</LibraryItemNewspaper>
 
+		<LibraryItemNewspaper slugger={slugger} headingLevel={3} title="東京中日スポーツ" release="2021-07-12" tags={['アニメ']}>
+			<div class="p-text">
+				<p>18面: 「高橋李依「『じわじわ』願ってます」」映画『かくしごと』舞台挨拶レポート、登壇者写真掲載（声優陣5人のみ）</p>
+			</div>
+
+			<ul class="p-notes">
+				<li>同日の中日スポーツは休刊で代わりに「特別販売版」が発行されたようだが、そちらへの掲載可否は未確認</li>
+			</ul>
+		</LibraryItemNewspaper>
+
 		<LibraryItemNewspaper slugger={slugger} headingLevel={3} title="中日スポーツ" release="2021-07-18" tags={['アニメ']}>
 			<div class="p-text">
-				<p>20面: 「原作者が半ギレ」映画『かくしごと』舞台挨拶レポート、登壇者写真掲載（カラー）</p>
+				<p>20面: 「原作者が半ギレ」映画『かくしごと』舞台挨拶レポート、登壇者6人の写真掲載（カラー）</p>
 			</div>
 		</LibraryItemNewspaper>
 

--- a/astro/src/pages/kumeta/manga/list.astro
+++ b/astro/src/pages/kumeta/manga/list.astro
@@ -9,7 +9,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品のリスト',
 	heading: '作品リスト',
-	dateModified: dayjs('2022-09-16'),
+	dateModified: dayjs('2023-08-04'),
 	description: '連載作品から読み切り、企画作品まで、漫画形態で制作された作品のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
 };
@@ -302,7 +302,7 @@ const structuredData: StructuredData = {
 								<LinkExternal href="https://www.amazon.co.jp/dp/B001KP1IV4/">マガジン SPECIAL 2008年12号</LinkExternal>
 							</td>
 							<td class="u-cell -center">✘</td>
-							<td>「よんこま!」第5回（瀬尾公治、氏家ト全、久米田康治、宗田豪、山本航暉によるクリスマスをテーマにした4コマ企画）</td>
+							<td>「よんこま!」第5回<small>（瀬尾公治、氏家ト全、久米田康治、宗田豪、山本航暉によるクリスマスをテーマにした4コマ企画）</small></td>
 						</tr>
 						<tr>
 							<td>楽天大賞</td>
@@ -428,6 +428,13 @@ const structuredData: StructuredData = {
 					</thead>
 					<tbody>
 						<tr>
+							<td>コマセレブ</td>
+							<td>2013年12月20日</td>
+							<td> マガジンSPECIAL 2014年1号</td>
+							<td class="u-cell -center">✘</td>
+							<td>「新年特別企画大よんこま!」企画<small>（赤松健による『せかどろ』パロディも掲載）</small></td>
+						</tr>
+						<tr>
 							<td>4Pでわかる上人類講座</td>
 							<td>2014年2月20日</td>
 							<td>
@@ -437,6 +444,13 @@ const structuredData: StructuredData = {
 								<LinkExternal href="https://www.amazon.co.jp/dp/B00LC9YFOK/">2巻</LinkExternal>
 							</td>
 							<td></td>
+						</tr>
+						<tr>
+							<td>堕センションは8万〜</td>
+							<td>2014年7月19日</td>
+							<td> マガジンSPECIAL 2014年8号</td>
+							<td class="u-cell -center">✘</td>
+							<td>「よんこま!」企画<small>（お題の「南国」にちなんだ下ネタのオチ）</small>、単行本4巻の店舗特典ペーパーで再掲</td>
 						</tr>
 						<tr>
 							<td>せっかち伯爵をせっかちにおさらい</td>


### PR DESCRIPTION
- [作品リスト](https://w0s.jp/kumeta/manga/list)のページに『せっかち伯爵と時間どろぼう』の4コマ漫画2作を追加。
- [メディア紹介 — 漫画雑誌](https://w0s.jp/kumeta/library/manga)のページに「マガジン SPECIAL 2014年1号」、「マガジン SPECIAL 2014年2号」「マガジン SPECIAL 2014年8号」「楽園 Le Paradis 16号」を追加。
- [メディア紹介 — 図書、一般雑誌](https://w0s.jp/kumeta/library/book)のページに「声優グランプリ 2009年11月号」、「アニサマ公式メモリアル」（2010年）、「戦国大戦　攻略虎の巻」（2011年）、「戦国大戦 —1560 尾張の風雲児— 天下布武への道　〜攻略絵巻　春の陣〜」（2011年）を追加。
- [メディア紹介 — 新聞](https://w0s.jp/kumeta/library/newspaper)のページに「東京中日スポーツ 2021年7月12日」を追加。
