### PR TITLE
脚注などから `.p-table` 内へのページ内アンカーで移動した際のスクロール位置調整機能が動いていない

### DIFF
--- a/astro/script/component/TableTheadStickey.ts
+++ b/astro/script/component/TableTheadStickey.ts
@@ -35,7 +35,7 @@ export default class {
 			return;
 		}
 
-		this.#thisElement.style.setProperty('--stickey-thead-height', `${theadElement.scrollHeight}px`);
+		this.#thisElement.style.setProperty('--stickey-thead-block-size', `${theadElement.scrollHeight}px`);
 	}
 
 	/**


### PR DESCRIPTION
#128 で対応を行ったが、#181 の改修で CS 変数名を変えたのに対して JS 側の変更漏れがあり、以来動いていなかった。
