### PR TITLE
サイトマップに載せるべきでないコンテンツの除外設定

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -19,7 +19,7 @@
 		"_astro-build:html": "node build/html.js -d dist/client",
 		"_astro-build:svg": "node build/svg.js -f dist/client/**/*.svg -f dist/client/favicon.ico -c svgo.config.cjs",
 		"_astro-build:feed": "node build/feed.js -d dist/client",
-		"_astro-build:sitemap": "node build/sitemap.js -d dist/client --ignore error --ignore admin -t template/xml/sitemap.ejs -o sitemap.xml",
+		"_astro-build:sitemap": "node build/sitemap.js -d dist/client --ignore 4** --ignore 5** --ignore admin -t template/xml/sitemap.ejs -o sitemap.xml",
 		"_astro-build:format": "prettier --config ../.prettierrc.mjs -w dist/client/**/*.{html,css}",
 		"_astro-build:compress": "brotli-cli compress -g dist/client/**/*.{html,css,js,mjs,svg,atom} -g dist/client/favicon.ico -m text"
 	},

--- a/astro/template/xml/sitemap.ejs
+++ b/astro/template/xml/sitemap.ejs
@@ -11,7 +11,4 @@
 	<url>
 		<loc>https://w0s.jp/tokyu/data/history/</loc>
 	</url>
-	<url>
-		<loc>https://w0s.jp/kumeta/akamatsu-generator</loc>
-	</url>
 </urlset>


### PR DESCRIPTION
- 4xx, 5xx 系のエラーページは sitemap.xml に載せない
- 赤松健セリフジェネレーターは廃止済みのためサイトマップからも削除（削除忘れ）