### PR TITLE
リンクアイコンの高さ方向の単位を ex → em に変更

### DIFF
--- a/astro/style/object/component/_embedded.css
+++ b/astro/style/object/component/_embedded.css
@@ -13,8 +13,8 @@ Markup:
 Styleguide 1.3.1
 */
 .c-link-icon {
-	vertical-align: -0.25ex;
+	vertical-align: -0.1em;
 	margin-inline: 0.25em;
 	inline-size: auto;
-	block-size: 2ex;
+	block-size: 1em;
 }


### PR DESCRIPTION
通常のテキスト（フォントサイズ 16px）内のアイコンは高さ 16px を若干超えてしまい、高解像度ディスプレイで PNG 画像（32px × 32px）の場合は元画像より引き延ばされてしまう