### PR TITLE
`Ssr.getPageUrl()` にてインデックスページの URL が正しく取得できていなかったバグを修正

### DIFF
--- a/astro/src/+util/Ssr.ts
+++ b/astro/src/+util/Ssr.ts
@@ -44,27 +44,30 @@ export default class SsrUtil {
 	 * Astro.url を元にページ URL を組み立てる
 	 *
 	 * @param astroUrl - Astro.url <https://docs.astro.build/en/reference/api-reference/#astrourl>
+	 * @param astroFilePath - Astro.self.moduleId
 	 *
 	 * @returns ページ URL
 	 */
-	static getPageUrl = async (astroUrl: URL): Promise<string> => {
+	static getPageUrl = (astroUrl: URL, astroFilePath: string | undefined): string => {
 		const astroPathname = astroUrl.pathname;
 
-		const parsed = path.parse(astroPathname);
-		if (parsed.ext === '') {
+		const urlParsed = path.parse(astroPathname);
+		if (urlParsed.ext === '') {
 			/* 拡張子がない場合（開発環境ないしトップページ） */
 			return astroPathname;
 		}
 
-		const dir = parsed.dir === '/' ? '' : parsed.dir;
+		const dir = urlParsed.dir === '/' ? '' : urlParsed.dir;
 
 		/* 拡張子を除去する */
-		const urlExclusionExt = `${dir}/${parsed.name}`;
+		const urlExclusionExt = `${dir}/${urlParsed.name}`;
 
-		try {
-			await fs.promises.access(`${urlExclusionExt}/`);
-			return `${urlExclusionExt}/`;
-		} catch {}
+		if (astroFilePath !== undefined) {
+			if (path.basename(astroFilePath) === 'index.astro') {
+				/* トップページ以外のインデックスページ */
+				return `${urlExclusionExt}/`;
+			}
+		}
 
 		return urlExclusionExt;
 	};

--- a/astro/src/layouts/Admin.astro
+++ b/astro/src/layouts/Admin.astro
@@ -12,12 +12,13 @@ import TocUtil from '@util/Toc.js';
 
 interface Props {
 	pagePath?: string;
+	astroFilePath: string | undefined;
 	structuredData: StructuredData;
 }
 
-const { pagePath: pagePathTemp, structuredData } = Astro.props;
+const { pagePath: pagePathTemp, astroFilePath, structuredData } = Astro.props;
 
-const pagePath = pagePathTemp ?? (await SsrUtil.getPageUrl(Astro.url));
+const pagePath = pagePathTemp ?? (SsrUtil.getPageUrl(Astro.url, astroFilePath));
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/layouts/Kumeta.astro
+++ b/astro/src/layouts/Kumeta.astro
@@ -25,7 +25,7 @@ interface Props {
 
 const { pagePath: pagePathTemp, astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
 
-const pagePath = pagePathTemp ?? (await SsrUtil.getPageUrl(Astro.url));
+const pagePath = pagePathTemp ?? (SsrUtil.getPageUrl(Astro.url, astroFilePath));
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/layouts/Madoka.astro
+++ b/astro/src/layouts/Madoka.astro
@@ -25,7 +25,7 @@ interface Props {
 
 const { pagePath: pagePathTemp, astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
 
-const pagePath = pagePathTemp ?? (await SsrUtil.getPageUrl(Astro.url));
+const pagePath = pagePathTemp ?? (SsrUtil.getPageUrl(Astro.url, astroFilePath));
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/layouts/Tokyu.astro
+++ b/astro/src/layouts/Tokyu.astro
@@ -25,7 +25,7 @@ interface Props {
 
 const { pagePath: pagePathTemp, astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
 
-const pagePath = pagePathTemp ?? (await SsrUtil.getPageUrl(Astro.url));
+const pagePath = pagePathTemp ?? (SsrUtil.getPageUrl(Astro.url, astroFilePath));
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/layouts/W0s.astro
+++ b/astro/src/layouts/W0s.astro
@@ -25,7 +25,7 @@ interface Props {
 
 const { pagePath: pagePathTemp, astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
 
-const pagePath = pagePathTemp ?? (await SsrUtil.getPageUrl(Astro.url));
+const pagePath = pagePathTemp ?? (SsrUtil.getPageUrl(Astro.url, astroFilePath));
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/pages/admin/crawler-news/data.astro
+++ b/astro/src/pages/admin/crawler-news/data.astro
@@ -23,7 +23,7 @@ const structuredData: StructuredData = {
 	],
 };
 
-const pagePath = await SsrUtil.getPageUrl(Astro.url);
+const pagePath = SsrUtil.getPageUrl(Astro.url, Astro.self.moduleId);
 
 const requestParams = RequestUtil.getParams(Astro.url);
 const requestBody = Astro.request.method === 'POST' ? await Astro.request.formData() : undefined;
@@ -51,7 +51,7 @@ if (requestQuery.action_delete) {
 const newsDataList = requestQuery.url !== null ? await dao.getNewsDataList(requestQuery.url) : []; // 新着データ
 ---
 
-<Layout pagePath={pagePath} structuredData={structuredData}>
+<Layout pagePath={pagePath} astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<p><a href={requestQuery.url} referrerpolicy="no-referrer" class="c-link">{requestQuery.url}</a></p>
 
 	<table class="p-table p-admin-crawler-table">

--- a/astro/src/pages/admin/crawler-news/index.astro
+++ b/astro/src/pages/admin/crawler-news/index.astro
@@ -32,7 +32,7 @@ const structuredData: StructuredData = {
 	breadcrumb: [{ path: '/admin/', name: 'ホーム' }],
 };
 
-const pagePath = await SsrUtil.getPageUrl(Astro.url);
+const pagePath = SsrUtil.getPageUrl(Astro.url, Astro.self.moduleId);
 
 const slugger = new GithubSlugger();
 
@@ -136,7 +136,7 @@ for (const newsPage of newsPageListDto) {
 }
 ---
 
-<Layout pagePath={pagePath} structuredData={structuredData}>
+<Layout pagePath={pagePath} astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<Section slugger={slugger}>
 		<H slot="heading">データ登録</H>
 

--- a/astro/src/pages/admin/crawler-resource/diff.astro
+++ b/astro/src/pages/admin/crawler-resource/diff.astro
@@ -29,7 +29,7 @@ const requestQuery: RequestQuery = {
 	diff: RequestUtil.strings(requestParams.getAll('diff[]')),
 };
 
-let diff: Diff.Change[] = [];
+let diffs: Diff.Change[] = [];
 let fileList: string[] = [];
 
 if (requestQuery.dir !== null) {
@@ -39,8 +39,8 @@ if (requestQuery.dir !== null) {
 			/* 差分チェック */
 			const [file1, file2] = await Promise.all([fs.promises.readFile(`${dir}/${requestQuery.diff.at(0)}`), fs.promises.readFile(`${dir}/${requestQuery.diff.at(1)}`)]);
 
-			diff = Diff.diffLines(Buffer.from(file2).toString(), Buffer.from(file1).toString(), { newlineIsToken: true });
-			diff.forEach((diffPart, index) => {
+			diffs = Diff.diffLines(Buffer.from(file2).toString(), Buffer.from(file1).toString(), { newlineIsToken: true });
+			diffs.forEach((diffPart, index) => {
 				if (diffPart.count !== undefined && diffPart.count > configure.crawler_resource.diff.max_line && !diffPart.added && !diffPart.removed) {
 					const lines = diffPart.value.split('\n');
 
@@ -49,7 +49,7 @@ if (requestQuery.dir !== null) {
 							.slice(lines.length - configure.crawler_resource.diff.max_line + 1)
 							.concat(configure.crawler_resource.diff.omit)
 							.join('\n');
-					} else if (index === diff.length - 1) {
+					} else if (index === diffs.length - 1) {
 						diffPart.value = [configure.crawler_resource.diff.omit].concat(lines.slice(0, configure.crawler_resource.diff.max_line)).join('\n');
 					} else if (diffPart.count > configure.crawler_resource.diff.max_line * 2) {
 						diffPart.value = lines
@@ -60,7 +60,7 @@ if (requestQuery.dir !== null) {
 				}
 			});
 
-			logger.debug('Diff mode', requestQuery.diff, diff);
+			logger.debug('Diff mode', requestQuery.diff, diffs);
 		}
 
 		/* 初期表示 */
@@ -69,12 +69,12 @@ if (requestQuery.dir !== null) {
 }
 ---
 
-<Layout structuredData={structuredData}>
+<Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	{
-		diff.length >= 1 && (
+		diffs.length >= 1 && (
 			<table class="p-admin-crawler-diff">
 				<tbody>
-					{diff.map((part) => (
+					{diffs.map((part) => (
 						<>
 							{!part.added && !part.removed && (
 								<tr class="p-admin-crawler-diff__line">

--- a/astro/src/pages/admin/crawler-resource/index.astro
+++ b/astro/src/pages/admin/crawler-resource/index.astro
@@ -30,7 +30,7 @@ const structuredData: StructuredData = {
 	breadcrumb: [{ path: '/admin/', name: 'ホーム' }],
 };
 
-const pagePath = await SsrUtil.getPageUrl(Astro.url);
+const pagePath = SsrUtil.getPageUrl(Astro.url, Astro.self.moduleId);
 
 const slugger = new GithubSlugger();
 
@@ -128,7 +128,7 @@ for (const resoursePage of resourcePageListDto) {
 }
 ---
 
-<Layout pagePath={pagePath} structuredData={structuredData}>
+<Layout pagePath={pagePath} astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<Section slugger={slugger}>
 		<H slot="heading">データ登録</H>
 

--- a/astro/src/pages/admin/crawler-resource/log.astro
+++ b/astro/src/pages/admin/crawler-resource/log.astro
@@ -45,7 +45,7 @@ if (requestQuery.dir !== null && requestQuery.file !== null) {
 }
 ---
 
-<Layout structuredData={structuredData}>
+<Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<p>
 		<strong>データがありません。</strong>
 	</p>


### PR DESCRIPTION
具体的な影響として、`/tokyu/data` など東急サイトのインデックスページでグローバルナビの現在地表示ができていなかった。
