### PR TITLE
「譲渡車両編成表」の秩父鉄道ミス修正

### DIFF
--- a/astro/src/pages/tokyu/data/form_local.astro
+++ b/astro/src/pages/tokyu/data/form_local.astro
@@ -379,13 +379,13 @@ const structuredData: StructuredData = {
 					<thead>
 						<tr>
 							<th scope="col">
-								<span class="p-tokyu-localform__series -m-dc">デハ7200 <span class="p-tokyu-localform__type">M<span class="u-tokyu-unit">2</span>c</span></span>
+								<span class="p-tokyu-localform__series -m-dc">デハ7000 <span class="p-tokyu-localform__type">M<span class="u-tokyu-unit">1</span>c</span></span>
 							</th>
 							<th scope="col">
 								<span class="p-tokyu-localform__series -t">サハ7100 <span class="p-tokyu-localform__type">T</span></span>
 							</th>
 							<th scope="col">
-								<span class="p-tokyu-localform__series -m-dc">デハ7000 <span class="p-tokyu-localform__type">M<span class="u-tokyu-unit">1</span>c</span></span>
+								<span class="p-tokyu-localform__series -m-dc">デハ7200 <span class="p-tokyu-localform__type">M<span class="u-tokyu-unit">2</span>c</span></span>
 							</th>
 						</tr>
 					</thead>

--- a/astro/src/pages/tokyu/data/form_local.astro
+++ b/astro/src/pages/tokyu/data/form_local.astro
@@ -432,13 +432,13 @@ const structuredData: StructuredData = {
 					<thead>
 						<tr>
 							<th scope="col">
-								<span class="p-tokyu-localform__series -tc">クハ7700 <span class="p-tokyu-localform__type">Tc</span></span>
+								<span class="p-tokyu-localform__series -tc">クハ7700 <span class="p-tokyu-localform__type">Tc<span class="u-tokyu-unit">1</span></span></span>
 							</th>
 							<th scope="col">
-								<span class="p-tokyu-localform__series -m-dc">デハ7600 <span class="p-tokyu-localform__type">M</span></span>
+								<span class="p-tokyu-localform__series -m-dc">デハ7600 <span class="p-tokyu-localform__type">M<span class="u-tokyu-unit">1</span></span></span>
 							</th>
 							<th scope="col">
-								<span class="p-tokyu-localform__series -m-dc">デハ7500 <span class="p-tokyu-localform__type">Mc</span></span>
+								<span class="p-tokyu-localform__series -m-dc">デハ7500 <span class="p-tokyu-localform__type">M<span class="u-tokyu-unit">2</span>c</span></span>
 							</th>
 						</tr>
 					</thead>


### PR DESCRIPTION
- デハ7000とデハ7200が逆になっていたミスを修正
- 7500系の車種記号を修正（出典：[新型車両7500系について 【秩父鉄道からのお知らせ】](https://web.archive.org/web/20100306150007/https://www.chichibu-railway.co.jp/info/2010/03/100302-1.html)）