### PR TITLE
「メディア紹介 — 漫画雑誌」のページにデータ追加

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -106,6 +106,9 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2023-10-01">
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>のページに「週刊少年サンデー 1995年43号」（『南国』休載代原）、「週刊少年サンデー 2023年39号」（ラムちゃん色紙）を追加。</p>
+				</TopUpdate>
 				<TopUpdate date="2023-08-11">
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>のページに「『週刊少年マガジン』五〇年　漫画表紙コレクション」（2008年）を追加。</p>
 				</TopUpdate>
@@ -120,9 +123,6 @@ const slugger = new GithubSlugger();
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>のページに「マガジン SPECIAL 2014年1号」、「マガジン SPECIAL 2014年2号」「マガジン SPECIAL 2014年8号」「楽園 Le Paradis 16号」を追加。</p>
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>のページに「声優グランプリ 2009年11月号」、「アニサマ公式メモリアル」（2010年）、「戦国大戦　攻略虎の巻」（2011年）、「戦国大戦 —1560 尾張の風雲児— 天下布武への道　〜攻略絵巻　春の陣〜」（2011年）を追加。</p>
 					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>のページに「東京中日スポーツ 2021年7月12日」を追加。</p>
-				</TopUpdate>
-				<TopUpdate date="2023-06-20">
-					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>のページに「日本TVアニメーション大全」（2014年）を追加。</p>
 				</TopUpdate>
 			</ul>
 		</div>

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -11,7 +11,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の漫画雑誌での紹介例',
 	heading: 'メディア紹介 — 漫画雑誌',
-	dateModified: dayjs('2023-08-05'),
+	dateModified: dayjs('2023-10-01'),
 	description: '漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
 	localNav: [
@@ -406,6 +406,17 @@ const slugger = new GithubSlugger();
 			</div>
 		</LibraryItemBook>
 
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1995年43号" release="1995-09-27">
+			<div class="p-text">
+				<p>pp.351–366: 『その道のプロ』（智田うに）扉絵の次ページ（352ページ）欄外に『行け!!南国アイスホッケー部』休載のお詫び文掲載</p>
+			</div>
+
+			<ul class="p-notes">
+				<li>「智田うに」は久米田先生の元アシスタントである熊澤智道のペンネーム（『行け!!南国アイスホッケー部』1巻カバーそでで登場）。空中浮遊をネタにした原稿がボツになり（<LinkExternal href="https://www.amazon.co.jp/dp/B00A765C6O/">『さよなら絶望先生』一四集</LinkExternal>の「紙ブログ」で紹介）、急遽代原で掲載されたことが<LinkExternal href="http://tukigamiteta.blog43.fc2.com/blog-entry-69.html#comment_list">本人の発言</LinkExternal>で明かされている。なお、この号の『行け!!南国アイスホッケー部』の休載理由は<q>久米田先生急病のため</q>となっていた。</li>
+				<li>余談だが、次号（1995年44号）掲載の『行け!!南国アイスホッケー部』第207話「幸せのペンダント!?」（<LinkExternal href="https://www.amazon.co.jp/dp/B009JZH02S/">単行本20巻</LinkExternal>収録）では漫画家志望の「くまざわくん」が原稿採用されるエピソードが（必然性なく）挟まれている。</li>
+			</ul>
+		</LibraryItemBook>
+
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="ダビスタコミック 4R" release="1995-12" tags={['読切']}>
 			<div class="p-text">
 				<p>pp.45–48: 短編漫画「酒と沮とダビスタと女」</p>
@@ -756,6 +767,7 @@ const slugger = new GithubSlugger();
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー超（増刊） 2002年7月号" release="2002-06" tags={['表紙']}>
 			<div class="p-text">
 				<p>表紙: 下っぱスーツの地丹<small>（他作品と混じっての掲載、当号に『かってに改蔵』の掲載はないが読者プレゼントにグッズがある）</small></p>
+				<p>pp.3–4: 「夏休みスケジュールボード」で『からくりサーカス』&amp;『かってに改蔵』のカレンダー<small>（『改蔵』は8月分で、<LinkExternal href="https://www.amazon.co.jp/dp/B009JZGZU6/">単行本12巻</LinkExternal>表紙イラストをバックに、13巻裏表紙&amp;カバーそでイラストから4点と本号表紙の地丹イラストが掲載）</small></p>
 			</div>
 		</LibraryItemBook>
 
@@ -2355,6 +2367,16 @@ const slugger = new GithubSlugger();
 
 			<ul class="p-notes">
 				<li>読売テレビで2023年4月2日（1日深夜）に放送された<LinkExternal href="https://www.ytv.co.jp/manganuma/">『川島・山内のマンガ沼』</LinkExternal>第112巻の紹介記事</li>
+			</ul>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2023年39号" release="2023-08-23">
+			<div class="p-text">
+				<p>p.5: 「うる星やつら45周年記念特別企画」にラムちゃんイラスト色紙寄稿（カラー）</p>
+			</div>
+
+			<ul class="p-notes">
+				<li>ボツイラストが<LinkExternal href="https://twitter.com/shibuyanear/status/1694963216110239961">『シブヤニアファミリー』公式 X アカウント</LinkExternal>で公開</li>
 			</ul>
 		</LibraryItemBook>
 	</Section>


### PR DESCRIPTION
- 「週刊少年サンデー 1995年43号」（『南国』休載代原）
- 「週刊少年サンデー 2023年39号」（ラムちゃん色紙）