### PR TITLE
「メディア紹介 — 漫画雑誌」にデータ追加

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -107,6 +107,10 @@ const slugger = new GithubSlugger();
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
 				<TopUpdate date="2023-10-01">
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年マガジン 2006年4・5号」（『さよなら絶望先生』イラスト色紙）を追加。</p>
+					<p><a href="/kumeta/yomoyama/kuigaten">「悔画展」収録イラスト一覧</a>に「週刊少年サンデー 1992年7号」表紙情報を追加。</p>
+				</TopUpdate>
+				<TopUpdate date="2023-10-01">
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>のページに「週刊少年サンデー 1995年43号」（『南国』休載代原）、「週刊少年サンデー 2023年39号」（ラムちゃん色紙）を追加。</p>
 				</TopUpdate>
 				<TopUpdate date="2023-08-11">
@@ -117,12 +121,6 @@ const slugger = new GithubSlugger();
 				</TopUpdate>
 				<TopUpdate date="2023-08-05">
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>のページに「週刊少年サンデー 1992年7号」（『南国』センターカラー）を追加。</p>
-				</TopUpdate>
-				<TopUpdate date="2023-08-04">
-					<p><a href="/kumeta/manga/list">作品リスト</a>のページに『せっかち伯爵と時間どろぼう』の4コマ漫画2作を追加。</p>
-					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>のページに「マガジン SPECIAL 2014年1号」、「マガジン SPECIAL 2014年2号」「マガジン SPECIAL 2014年8号」「楽園 Le Paradis 16号」を追加。</p>
-					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>のページに「声優グランプリ 2009年11月号」、「アニサマ公式メモリアル」（2010年）、「戦国大戦　攻略虎の巻」（2011年）、「戦国大戦 —1560 尾張の風雲児— 天下布武への道　〜攻略絵巻　春の陣〜」（2011年）を追加。</p>
-					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>のページに「東京中日スポーツ 2021年7月12日」を追加。</p>
 				</TopUpdate>
 			</ul>
 		</div>

--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -106,7 +106,7 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
-				<TopUpdate date="2023-10-01">
+				<TopUpdate date="2023-10-02">
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年マガジン 2006年4・5号」（『さよなら絶望先生』イラスト色紙）を追加。</p>
 					<p><a href="/kumeta/yomoyama/kuigaten">「悔画展」収録イラスト一覧</a>に「週刊少年サンデー 1992年7号」表紙情報を追加。</p>
 				</TopUpdate>

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -11,7 +11,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の漫画雑誌での紹介例',
 	heading: 'メディア紹介 — 漫画雑誌',
-	dateModified: dayjs('2023-10-01'),
+	dateModified: dayjs('2023-10-02'),
 	description: '漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
 	localNav: [
@@ -165,8 +165,9 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<H slot="heading">1992年</H>
 
-		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1992年7号" release="1992-01-22" tags={['カラー']}>
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1992年7号" release="1992-01-22" tags={['表紙', 'カラー']}>
 			<div class="p-text">
+				<p>表紙：真剣な表情でアイスホッケーする月斗（鼻の絆創膏なし）</p>
 				<p>pp.115–134: 『行け!!南国アイスホッケー部』第33話「かわいい雪だるまくん」、冒頭5ページ2色カラー</p>
 			</div>
 		</LibraryItemBook>
@@ -1016,6 +1017,12 @@ const slugger = new GithubSlugger();
 			<ul class="p-notes">
 				<li>話数表記が<q>File.56</q>になっているが、実際は55話目</li>
 			</ul>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年マガジン 2006年4・5号" release="2005-12-28" tags={['企画']}>
+			<div class="p-text">
+				<p>pp.6–8: 「愛読大感謝! オール連載作家直筆色紙プレゼント」に望と可符香（着物姿）のイラスト色紙</p>
+			</div>
 		</LibraryItemBook>
 	</Section>
 	<Section slugger={slugger}>
@@ -2370,7 +2377,7 @@ const slugger = new GithubSlugger();
 			</ul>
 		</LibraryItemBook>
 
-		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2023年39号" release="2023-08-23">
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2023年39号" release="2023-08-23" tags={['企画']}>
 			<div class="p-text">
 				<p>p.5: 「うる星やつら45周年記念特別企画」にラムちゃんイラスト色紙寄稿（カラー）</p>
 			</div>

--- a/astro/src/pages/kumeta/yomoyama/kuigaten.astro
+++ b/astro/src/pages/kumeta/yomoyama/kuigaten.astro
@@ -13,7 +13,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治画集「悔画展」収録イラスト一覧',
 	heading: '「悔画展」収録イラスト一覧',
-	dateModified: dayjs('2023-08-08'),
+	dateModified: dayjs('2023-10-02'),
 	description: '2016年に発売された久米田康治画集「悔画展」に収録されているイラストのリストです。',
 	image: 'https://m.media-amazon.com/images/I/51m9Oqxw9kL.jpg',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
@@ -1124,6 +1124,15 @@ const slugger = new GithubSlugger();
 					<td>正月晴着の月斗</td>
 					<td>週刊少年サンデー 1992年3・4号　表紙</td>
 					<td>1991年12月25日</td>
+					<td class="u-cell -center">✘</td>
+					<td></td>
+				</tr>
+				<tr>
+					<td>漫画</td>
+					<td>行け!!南国アイスホッケー部</td>
+					<td>真剣な表情でアイスホッケーする月斗（鼻の絆創膏なし）</td>
+					<td>週刊少年サンデー 1992年7号　表紙</td>
+					<td>1992年1月22日</td>
 					<td class="u-cell -center">✘</td>
 					<td></td>
 				</tr>


### PR DESCRIPTION
- [メディア紹介 — 漫画雑誌](https://w0s.jp/kumeta/library/manga)に「週刊少年マガジン 2006年4・5号」（『さよなら絶望先生』イラスト色紙）を追加
- [「悔画展」収録イラスト一覧](https://w0s.jp/kumeta/yomoyama/kuigaten)に「週刊少年サンデー 1992年7号」表紙情報を追加