### PR TITLE
智田うに代原に関する記述ミス修正

### DIFF
--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -415,7 +415,7 @@ const slugger = new GithubSlugger();
 
 			<ul class="p-notes">
 				<li>「智田うに」は久米田先生の元アシスタントである熊澤智道のペンネーム（『行け!!南国アイスホッケー部』1巻カバーそでで登場）。空中浮遊をネタにした原稿がボツになり（<LinkExternal href="https://www.amazon.co.jp/dp/B00A765C6O/">『さよなら絶望先生』一四集</LinkExternal>の「紙ブログ」で紹介）、急遽代原で掲載されたことが<LinkExternal href="http://tukigamiteta.blog43.fc2.com/blog-entry-69.html#comment_list">本人の発言</LinkExternal>で明かされている。なお、この号の『行け!!南国アイスホッケー部』の休載理由は<q>久米田先生急病のため</q>となっていた。</li>
-				<li>余談だが、次号（1995年44号）掲載の『行け!!南国アイスホッケー部』第207話「幸せのペンダント!?」（<LinkExternal href="https://www.amazon.co.jp/dp/B009JZH02S/">単行本20巻</LinkExternal>収録）では漫画家志望の「くまさわくん」が原稿採用されるエピソードが（必然性なく）挟まれている。</li>
+				<li>余談だが、次号（1995年44号）掲載の『行け!!南国アイスホッケー部』第207話「幸せのペンダント!?」（<LinkExternal href="https://www.amazon.co.jp/dp/B00DE1QOYI/">単行本20巻</LinkExternal>収録）では漫画家志望の「くまさわくん」が原稿採用されるエピソードが（必然性なく）挟まれている。</li>
 			</ul>
 		</LibraryItemBook>
 

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -415,7 +415,7 @@ const slugger = new GithubSlugger();
 
 			<ul class="p-notes">
 				<li>「智田うに」は久米田先生の元アシスタントである熊澤智道のペンネーム（『行け!!南国アイスホッケー部』1巻カバーそでで登場）。空中浮遊をネタにした原稿がボツになり（<LinkExternal href="https://www.amazon.co.jp/dp/B00A765C6O/">『さよなら絶望先生』一四集</LinkExternal>の「紙ブログ」で紹介）、急遽代原で掲載されたことが<LinkExternal href="http://tukigamiteta.blog43.fc2.com/blog-entry-69.html#comment_list">本人の発言</LinkExternal>で明かされている。なお、この号の『行け!!南国アイスホッケー部』の休載理由は<q>久米田先生急病のため</q>となっていた。</li>
-				<li>余談だが、次号（1995年44号）掲載の『行け!!南国アイスホッケー部』第207話「幸せのペンダント!?」（<LinkExternal href="https://www.amazon.co.jp/dp/B009JZH02S/">単行本20巻</LinkExternal>収録）では漫画家志望の「くまざわくん」が原稿採用されるエピソードが（必然性なく）挟まれている。</li>
+				<li>余談だが、次号（1995年44号）掲載の『行け!!南国アイスホッケー部』第207話「幸せのペンダント!?」（<LinkExternal href="https://www.amazon.co.jp/dp/B009JZH02S/">単行本20巻</LinkExternal>収録）では漫画家志望の「くまさわくん」が原稿採用されるエピソードが（必然性なく）挟まれている。</li>
 			</ul>
 		</LibraryItemBook>
 


### PR DESCRIPTION
- 登場キャラ名「くまさわくん」が「くまざわくん」になっていた
- 南国20巻のAmazonリンク先が改蔵20巻になっていた