### PR TITLE
テキストリンクにおいて自分自身のリンクの際はビュレットアイコンを付けない

### DIFF
--- a/astro/style/object/component/_text.css
+++ b/astro/style/object/component/_text.css
@@ -20,16 +20,16 @@ Styleguide 1.2.1
 	--_icon-block-size: 0.75em;
 	--_icon-color: var(--color-gray);
 
-	&::before {
-		display: inline flow-root;
-		clip-path: var(--_icon-clip-path);
-		margin-inline-end: 0.5em;
-		border-block-start: var(--_icon-block-size) solid var(--_icon-color);
-		inline-size: var(--_icon-inline-size);
-		content: "";
-	}
-
 	&:any-link {
+		&::before {
+			display: inline flow-root;
+			clip-path: var(--_icon-clip-path);
+			margin-inline-end: 0.5em;
+			border-block-start: var(--_icon-block-size) solid var(--_icon-color);
+			inline-size: var(--_icon-inline-size);
+			content: "";
+		}
+
 		/* 他ページ */
 		&:not([href^="#"]) {
 			--_icon-color: var(--link-color-bullet);


### PR DESCRIPTION
↓ 修正前
![横並びのナビゲーション、リンクには緑色のビュレットアイコン、現在地リンクには灰色のビュレットアイコン](https://github.com/SaekiTominaga/w0s.jp/assets/4138486/7fe87c1f-04db-4ac1-82ec-ae3780c61271)

↓ 修正後
![現在地リンクにはビュレットアイコンなし](https://github.com/SaekiTominaga/w0s.jp/assets/4138486/2cbfe04c-a628-499d-8081-2bb8f688fd82)
