### PR TITLE
メディア紹介 2023年12月29日更新分

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -121,6 +121,10 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2023-12-29">
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「コミックビーム 2010年10月号」「月刊少年マガジン 2018年3月号」「ハルタ 2021-October Volume 88」を追加</p>
+					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「プレイボーイ 2011年No.48」を追加</p>
+				</TopUpdate>
 				<TopUpdate date="2023-12-24">
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年マガジン 2014年32号」の赤松健コメントを追加</p>
 				</TopUpdate>
@@ -132,9 +136,6 @@ const slugger = new GithubSlugger();
 				</TopUpdate>
 				<TopUpdate date="2023-11-24">
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「インモラル壱号」（1998年）、「制服大征服」（1999年）を追加。</p>
-				</TopUpdate>
-				<TopUpdate date="2023-11-23">
-					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「EGAKU —draw the song— 展図録」（2023年）を追加。</p>
 				</TopUpdate>
 			</ul>
 		</div>

--- a/astro/src/pages/kumeta/library/book.astro
+++ b/astro/src/pages/kumeta/library/book.astro
@@ -11,7 +11,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の図書、一般雑誌での紹介例',
 	heading: 'メディア紹介 — 図書、一般雑誌',
-	dateModified: dayjs('2023-12-16'),
+	dateModified: dayjs('2023-12-29'),
 	description: '本や雑誌（漫画雑誌を除く）において久米田先生のインタビューや描き下ろしイラストが掲載された事例、また久米田作品が紹介された事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
 	localNav: [
@@ -1228,6 +1228,12 @@ const slugger = new GithubSlugger();
 			<ul class="p-notes">
 				<li>Amazon の表紙画像は実際のものとは異なる</li>
 			</ul>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="プレイボーイ 2011年No.48" release="2011-11">
+			<div class="p-text">
+				<p>p.109: 「この漫画がパネェ!!」で『じょしらく』紹介</p>
+			</div>
 		</LibraryItemBook>
 
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="月刊アニメスタイル 第5号（2011年12月）" release="2011-12-23" tags={['アニメ']} isbn="978-4-902948-11-0" amazonAsin="4902948117" amazonImageId="51wvWHNn1jL" amazonImageWidth={114} amazonImageHeight={160}>

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -11,7 +11,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の漫画雑誌での紹介例',
 	heading: 'メディア紹介 — 漫画雑誌',
-	dateModified: dayjs('2023-12-24'),
+	dateModified: dayjs('2023-12-29'),
 	description: '漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: 'ホーム' }],
 	localNav: [
@@ -1275,7 +1275,7 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<H slot="heading">2009年</H>
 
-		<LibraryItemBook slugger={slugger} headingLevel={3} title="マガジンドラゴン 2009年新春" release="2009-01-07" tags={['表紙', '読み切り', '企画']} amazonAsin="B001O5OGU0" amazonImageId="61xfpxd0SjL" amazonImageWidth={110} amazonImageHeight={160}>
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="マガジンドラゴン 2009年新春" release="2009-01-07" tags={['表紙', '読切', '企画']} amazonAsin="B001O5OGU0" amazonImageId="61xfpxd0SjL" amazonImageWidth={110} amazonImageHeight={160}>
 			<div class="p-text">
 				<p>表紙: 望&amp;可符香</p>
 				<p>p.10: さよなら絶望先生特製Tシャツ応募者全員サービス（カラー）</p>
@@ -1428,13 +1428,19 @@ const slugger = new GithubSlugger();
 
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="月刊少年シリウス 2010年8月号　付録「私立シリウス学園　学校案内」" release="2010-06-26" tags={['描き下ろし']}>
 			<div class="p-text">
-				<p>pp.3–4: 制服デザインイラストとコメント</p>
+				<p>pp.4–5: 制服デザインイラストとコメント</p>
 			</div>
 		</LibraryItemBook>
 
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年マガジン 2010年35号" release="2010-07-28" tags={['企画', '描き下ろし']}>
 			<div class="p-text">
 				<p>p.15: 「『ヒックとドラゴン』の漫画を描いてと言われたが著作権の関係でヒックとドラゴンは描いちゃ駄目よと言われたので。」（望&amp;可符香による『ヒックとドラゴン』宣伝漫画、カラー）</p>
+			</div>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="コミックビーム 2010年10月号" release="2010-09-12">
+			<div class="p-text">
+				<p>pp.305–306: 『夜は千の眼を持つ』第133回にてショート漫画「さよなら絶望頓知」掲載（『さよなら絶望先生』のあからさまなパロディ）</p>
 			</div>
 		</LibraryItemBook>
 
@@ -1806,7 +1812,7 @@ const slugger = new GithubSlugger();
 			</div>
 		</LibraryItemBook>
 
-		<LibraryItemBook slugger={slugger} headingLevel={3} title="ヤングマガジンサード 2014年 Vol.3" release="2014-11-06" tags={['読み切り']}>
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="ヤングマガジンサード 2014年 Vol.3" release="2014-11-06" tags={['読切']}>
 			<div class="p-text">
 				<p>p.2: イラストギャラリー「Out Of Ordinary!」に1ページのカラー漫画『おわり人間ギャルとルーズ』掲載</p>
 			</div>
@@ -1830,7 +1836,7 @@ const slugger = new GithubSlugger();
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="ヤングマガジン 2015年6号" release="2015-01-05" tags={['表紙', '読切']} amazonAsin="B00R3BMQKQ" amazonImageId="61K6W2O9nYL" amazonImageWidth={110} amazonImageHeight={160}>
 			<div class="p-text">
 				<p>表紙: 嘉手納千代<small>（他作品と混じっての掲載）</small></p>
-				<p>pp.119–128: 読切『オフサイドトラップ』</p>
+				<p>pp.119–128: 妄想読み切りシリーズ「俺の100話目!!」企画第1弾　読切『オフサイドトラップ』</p>
 			</div>
 		</LibraryItemBook>
 
@@ -2111,6 +2117,12 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<H slot="heading">2018年</H>
 
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="月刊少年マガジン 2018年3月号" release="2020-02-06">
+			<div class="p-text">
+				<p>pp.744-746: 「第40回月マガ新人賞グランドチャレンジ」の特別審査委員に参加（久米田康治、松本明澄）、入賞作品へのコメントと総評</p>
+			</div>
+		</LibraryItemBook>
+
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2018年12号" release="2018-02-14" tags={['読切', '畑健二郎']}>
 			<div class="p-text">
 				<p>pp.81–94: 乱入読切・かってに改蔵特別編『新しい恥図』（『トニカクカワイイ』新連載祝い）</p>
@@ -2230,7 +2242,7 @@ const slugger = new GithubSlugger();
 				<p>
 					pp.3–36: 『かくしごと』扉ページカラー<small>（<LinkExternal href="https://www.amazon.co.jp/dp/B085L7QSHK/">単行本11巻</LinkExternal>表紙で採用）</small>
 				</p>
-				<p>pp:4-5: 『かくしごと』TV アニメ特集、大槻ケンヂコメント</p>
+				<p>pp.4-5: 『かくしごと』TV アニメ特集、大槻ケンヂコメント</p>
 			</div>
 		</LibraryItemBook>
 
@@ -2239,7 +2251,7 @@ const slugger = new GithubSlugger();
 				<p>
 					表紙: 可久士&amp;姫<small>（『ましろのおと』など他作品と混じっての掲載、イラストは<LinkExternal href="https://www.amazon.co.jp/dp/B01N3CRBG8/">単行本3巻</LinkExternal>表紙の流用）</small>
 				</p>
-				<p>pp:231-232: 『かくしごと』TV アニメ特集、高橋李依インタビュー（カラー）</p>
+				<p>pp.231-232: 『かくしごと』TV アニメ特集、高橋李依インタビュー（カラー）</p>
 			</div>
 		</LibraryItemBook>
 
@@ -2277,6 +2289,12 @@ const slugger = new GithubSlugger();
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2021年32号" release="2021-07-07" tags={['イベント']}>
 			<div class="p-text">
 				<p>p.14: NEWS Sunday「全曝し展」広告（カラー）</p>
+			</div>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="ハルタ 2021-October Volume 88" release="2021-10">
+			<div class="p-text">
+				<p>p.900: 読者コーナー内「ハルタ・マイク・リレー　第7回」での宇島葉（『猫のまにまに』連載中）インタビュー内で漫画家の描き方に久米田先生の影響があると発言</p>
 			</div>
 		</LibraryItemBook>
 


### PR DESCRIPTION
- 漫画雑誌に「コミックビーム 2010年10月号」「月刊少年マガジン 2018年3月号」「ハルタ 2021-October Volume 88」を追加
- 図書、一般雑誌に「プレイボーイ 2011年No.48」を追加
- タグの「読み切り」「読切」を後者に統一
- ページ数のミス修正（私立シリウス学園　学校案内）