### PR TITLE
メディア紹介 2023年12月29日更新分（追加）

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -122,7 +122,7 @@ const slugger = new GithubSlugger();
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
 				<TopUpdate date="2023-12-29">
-					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「コミックビーム 2010年10月号」「月刊少年マガジン 2018年3月号」「ハルタ 2021-October Volume 88」を追加</p>
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「コミックビーム 2010年10月号」「月刊少年マガジン 2018年3月号」「ハルタ 2021-October Volume 88」および「月刊少年マガジン 2016年9月号」の新人賞コメントを追加</p>
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「プレイボーイ 2011年No.48」を追加</p>
 				</TopUpdate>
 				<TopUpdate date="2023-12-24">

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -2117,7 +2117,7 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<H slot="heading">2018年</H>
 
-		<LibraryItemBook slugger={slugger} headingLevel={3} title="月刊少年マガジン 2018年3月号" release="2020-02-06">
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="月刊少年マガジン 2018年3月号" release="2018-02-06">
 			<div class="p-text">
 				<p>pp.744-746: 「第40回月マガ新人賞グランドチャレンジ」の特別審査委員に参加（久米田康治、松本明澄）、入賞作品へのコメントと総評</p>
 			</div>

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -2025,6 +2025,7 @@ const slugger = new GithubSlugger();
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="月刊少年マガジン 2016年9月号" release="2016-08-06" tags={['イベント']}>
 			<div class="p-text">
 				<p>p.695: 『かくしごと』1巻発売記念サイン会、原画展「一挙後悔中」レポート</p>
+				<p>pp.761–763: 「第34回月マガ新人賞グランドチャレンジ」の特別審査委員に参加（村枝賢一、久米田康治）、入賞作品へのコメントと総評</p>
 			</div>
 		</LibraryItemBook>
 


### PR DESCRIPTION
- 月刊少年マガジン 2016年9月号の新人賞コメントを追加
- 月刊少年マガジン 2018年3月号の日付ミスを修正