### PR TITLE
オートフォーカスでのスクロール位置調整

### DIFF
--- a/astro/script/w0s.ts
+++ b/astro/script/w0s.ts
@@ -104,6 +104,7 @@ if (autoFocusElement !== null) {
 		autoFocusElement.tabIndex = -1;
 	}
 	autoFocusElement.focus();
+	autoFocusElement.scrollIntoView();
 }
 
 /* 入力値の変換 */


### PR DESCRIPTION
Firefox, Chrome ともに、`focus()` 処理だけでは変なところにスクロールしてしまうため、`scrollIntoView()` にてスクロール位置を調整する。