### PR TITLE
Basic 認証の対象 URL を任意に指定できるように変更

### DIFF
--- a/configure/schema/express.json
+++ b/configure/schema/express.json
@@ -206,14 +206,14 @@
 					"type": "array",
 					"items": {
 						"type": "object",
-						"required": ["directory", "realm", "htpasswd"],
+						"required": ["urls", "realm", "htpasswd"],
 						"properties": {
-							"directory": {
+							"urls": {
 								"type": "array",
 								"items": {
 									"type": "string"
 								},
-								"title": "directory"
+								"title": "対象 URL"
 							},
 							"realm": {
 								"type": "string",

--- a/express/package.json
+++ b/express/package.json
@@ -14,7 +14,8 @@
 		"basic-auth": "^2.0.1",
 		"compression": "^1.7.4",
 		"express": "^4.18.2",
-		"htpasswd-js": "^1.0.2"
+		"htpasswd-js": "^1.0.2",
+		"matcher": "^5.0.0"
 	},
 	"devDependencies": {
 		"@types/basic-auth": "^1.1.8",

--- a/express/src/app.ts
+++ b/express/src/app.ts
@@ -5,6 +5,7 @@ import compression from 'compression';
 import express, { type NextFunction, type Request, type Response } from 'express';
 // @ts-expect-error: ts(7016)
 import htpasswd from 'htpasswd-js';
+import { isMatch } from 'matcher';
 import HtmlEscape from '@w0s/html-escape';
 // @ts-expect-error: ts(7016)
 import { handler as ssrHandler } from '@w0s.jp/astro/dist/server/entry.mjs';
@@ -63,7 +64,7 @@ app.use(
 	}),
 	async (req, res, next) => {
 		/* Basic Authentication */
-		const basic = config.static.auth_basic?.find((auth) => auth.directory.find((urlPath) => req.url.startsWith(urlPath)));
+		const basic = config.static.auth_basic?.find((auth) => isMatch(req.url, auth.urls));
 		if (basic !== undefined) {
 			const credentials = basicAuth(req);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -791,7 +791,8 @@
 				"basic-auth": "^2.0.1",
 				"compression": "^1.7.4",
 				"express": "^4.18.2",
-				"htpasswd-js": "^1.0.2"
+				"htpasswd-js": "^1.0.2",
+				"matcher": "^5.0.0"
 			},
 			"devDependencies": {
 				"@types/basic-auth": "^1.1.8",
@@ -9355,6 +9356,31 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/matcher": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-5.0.0.tgz",
+			"integrity": "sha512-s2EMBOWtXFc8dgqvoAzKJXxNHibcdJMV0gwqKUaw9E2JBJuGUK7DrNKrA6g/i+v72TT16+6sVm5mS3thaMLQUw==",
+			"dependencies": {
+				"escape-string-regexp": "^5.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/matcher/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mathml-tag-names": {


### PR DESCRIPTION
従来は対象の祖先ディレクトリしか指定できなかったため、任意の URL を指定できるようにした。