### PR TITLE
`<cite>` と `<caption>` のマークアップ、スタイルを変更

### DIFF
--- a/astro/src/components/CodeBlock.astro
+++ b/astro/src/components/CodeBlock.astro
@@ -45,9 +45,7 @@ const highlighted = registLanguageName !== undefined ? hljs.highlight(code, { la
 <figure>
 	{
 		caption !== undefined && (
-			<figcaption class="c-caption">
-				<span class="c-caption__title">{caption}</span>
-			</figcaption>
+			<figcaption class="c-caption">{caption}</figcaption>
 		)
 	}
 	<div class="p-code">

--- a/astro/src/pages/kumeta/kumeta/media.astro
+++ b/astro/src/pages/kumeta/kumeta/media.astro
@@ -263,7 +263,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed">
 				<Image path="kumeta/kumeta/media/jyoshiraku_oad.jpg" width={480} height={270} quality={60} />
 			</div>
-			<figcaption class="c-caption"><cite>『じょしらく』OAD Aパート</cite>（近所の漫画家と山下が出演するシーン）</figcaption>
+			<figcaption class="c-caption"><cite class="c-cite -work">じょしらく</cite>OAD Aパート（近所の漫画家と山下が出演するシーン）</figcaption>
 		</figure>
 
 		<p>動画形式での出演は TV アニメ『有頂天家族』が初の事例であり、 Blu-ray&amp;DVD の映像特典として森見登美彦先生との対談が収録されました。久米田先生からはキャラクター原案の話にとどまらず、普段ギャグ作品を作るうえで重視していることや、原作者としての立ち位置から『じょしらく』の話に至るまで幅広い話題がありました。</p>
@@ -272,7 +272,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed">
 				<Image path="kumeta/kumeta/media/uchoten_bd2_talk.jpg" width={720} height={405} quality={90} />
 			</div>
-			<figcaption class="c-caption"><cite>『有頂天家族』Blu-ray 第二巻の作家対談</cite>（左から久米田康治、森見登美彦）</figcaption>
+			<figcaption class="c-caption"><cite class="c-cite -work">有頂天家族</cite>Blu-ray 第二巻の作家対談（左から久米田康治、森見登美彦）</figcaption>
 		</figure>
 
 		<p>2020年3月には『かくしごと』アニメ放送の一環で神谷浩史さんとの対談動画が<LinkExternal href="https://www.youtube.com/user/avexpictures">エイベックス・ピクチャーズの YouTube アカウント</LinkExternal>で公開されました。神谷さんといえば『さよなら絶望先生』からの付き合いですが、その放送当時は久米田先生と制作スタッフ陣との対談は複数回行われていたものの、キャスト陣とはアニカン Vol.43（フリーペーパー）での対談が1回あったのみであり、動画で神谷さんと対談を行うのはこれが初めてのことです。</p>
@@ -290,7 +290,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed">
 				<Image path="kumeta/kumeta/media/nakushigoto_1.jpg" width={720} height={405} quality={90} />
 			</div>
-			<figcaption class="c-caption"><cite>「久米田康治画業30周年記念トークショー」第1部　漫画家対談</cite>（左から久米田康治、藤田和日郎、畑健二郎）</figcaption>
+			<figcaption class="c-caption"><cite>久米田康治画業30周年記念トークショー</cite>第1部　漫画家対談（左から久米田康治、藤田和日郎、畑健二郎）</figcaption>
 		</figure>
 
 		<p>2020年12月に埼玉県川越で行われた『かくしごと』スペシャルイベントでは、夜の部の最後に久米田先生が登壇し、その御前で劇場編集版の制作発表が行われました。このイベントは会場に客を入れるリアルイベントでしたが、インターネット配信および後日発売された <LinkExternal href="https://www.amazon.co.jp/dp/B08KTV4QG9/">Blu-ray&amp;DVD</LinkExternal>にも収録されています。</p>
@@ -299,7 +299,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed">
 				<Image path="kumeta/kumeta/media/kakushigoto_event_night.jpg" width={720} height={405} quality={90} />
 			</div>
-			<figcaption class="c-caption"><cite>「TVアニメ『かくしごと』スペシャルイベント」夜の部</cite>（左から神谷浩史、久米田康治、大槻ケンヂ、高橋李依）</figcaption>
+			<figcaption class="c-caption"><cite>TVアニメ『かくしごと』スペシャルイベント</cite>夜の部（左から神谷浩史、久米田康治、大槻ケンヂ、高橋李依）</figcaption>
 		</figure>
 
 		<p>2021年7月に『かくしごと』の劇場編集版が公開されましたが、公開と同時に Blu-ray が発売、また週末の土日には3週連続でインターネット配信が行われ、<LinkExternal href="https://kakushigoto-anime.com/topics/96/">1週目</LinkExternal>は神谷浩史さん、<LinkExternal href="https://kakushigoto-anime.com/topics/127/">2週目</LinkExternal>は高橋李依さん、そして<LinkExternal href="https://kakushigoto-anime.com/topics/135/">3週目</LinkExternal>には久米田先生&amp;村野監督によるコメント映像が収録されました。</p>
@@ -308,7 +308,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed">
 				<Image path="kumeta/kumeta/media/kakushigoto_haishin_3.jpg" width={720} height={405} quality={90} />
 			</div>
-			<figcaption class="c-caption"><cite>『劇場編集版　かくしごと』週末配信チケット　第3弾　コメント映像</cite>（左から村野佑太、久米田康治）</figcaption>
+			<figcaption class="c-caption"><cite class="c-cite -work">劇場編集版　かくしごと</cite>週末配信チケット　第3弾　コメント映像（左から村野佑太、久米田康治）</figcaption>
 		</figure>
 
 		<p>2021年10月には『劇場編集版　かくしごと』の Blu-ray 全国発売に関連した特典映像の配信が行われました。これは楽天チケットでの Blu-ray 購入者を対象に配信されたもので、10月2日に行われたオンラインサイン会の前後に収録されています。インタビュアーは舞台挨拶での司会を5回とも務められ、青春時代が『かってに改蔵』で成り立っていたという松澤千晶さんで、「久米田康治先生へ10の質問」と題して劇場編集版を受けての感想やキービジュアル制作のエピソード、「全曝し展」の話などで盛り上がりました。</p>
@@ -317,7 +317,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed">
 				<Image path="kumeta/kumeta/media/kakushigoto_sign_interview.jpg" width={720} height={405} quality={90} />
 			</div>
-			<figcaption class="c-caption"><cite>『劇場編集版　かくしごと』Blu-ray 発売記念オンラインサイン会　特別インタビュー</cite>（左から松澤千晶、久米田康治）</figcaption>
+			<figcaption class="c-caption"><cite class="c-cite -work">劇場編集版　かくしごと</cite>Blu-ray 発売記念オンラインサイン会　特別インタビュー（左から松澤千晶、久米田康治）</figcaption>
 		</figure>
 	</Section>
 </Layout>

--- a/astro/src/pages/kumeta/yomoyama/mangaka.astro
+++ b/astro/src/pages/kumeta/yomoyama/mangaka.astro
@@ -31,7 +31,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/nangoku_2_p109.jpg" alt="1コマ目: レストランのテーブルから立ち上がる男性2人組「そ…そうだったのか!」「少しくらいキザな方がいいのか!」、2コマ目: その男性ら「いやぁ　どーりでちっともモテないと思いましたよ。」「これで我々がモテない原因がはっきりしましたな。」、3コマ目: 男性「これからはキザにいきましょう。」、そあら「な…何、今の人たち?」、月斗「どっかのくされたまんが家とその担当だろ。」" width={371} height={400} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『行け!!南国アイスホッケー部』</cite>2巻 p.109</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">行け!!南国アイスホッケー部</cite>2巻 p.109</figcaption>
 			</figure>
 		</div>
 
@@ -45,7 +45,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/nangoku_4_p184.jpg" alt="ナレーション「その後彼がどーしたかというと…」「某シモネタマンガ家のもとでアシスタントしていた!」、シーモネーター「先生、チンポはこんなもんで。」、携帯電話を片手に持った全裸のまんが家「いやぁあ! 彼は使えますよ!」" width={371} height={270} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『行け!!南国アイスホッケー部』</cite>4巻 p.184</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">行け!!南国アイスホッケー部</cite>4巻 p.184</figcaption>
 			</figure>
 		</div>
 
@@ -58,7 +58,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/nangoku_5_p119.jpg" alt="シーモネーター「主人公が死んでしまったら、このまんがが終わってしまって…　さるお方が路頭に迷ってしまうからだ。」" width={371} height={180} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『行け!!南国アイスホッケー部』</cite>5巻 p.119</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">行け!!南国アイスホッケー部</cite>5巻 p.119</figcaption>
 			</figure>
 		</div>
 
@@ -71,7 +71,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/nangoku_6_p29.jpg" alt="そあら「そう…それなら信ぴょう性があるわね…」、まんが家「あっかよ! ボケーー!!」" width={371} height={240} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『行け!!南国アイスホッケー部』</cite>6巻 p.29</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">行け!!南国アイスホッケー部</cite>6巻 p.29</figcaption>
 			</figure>
 		</div>
 
@@ -85,7 +85,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/nangoku_23_p185.jpg" alt="「もう下ネタはやりません」漫画家久米田氏　下ネタ帽をぬぎすてる久米田氏（ややうつむき加減に帽子を下ろすまんが家の後ろ姿のイラスト）　南国終了時、そう声高に宣言した漫画家久米田康治氏。満を期して始まった新連載「太陽の戦士ポカポカ」は、少年誌らしい活発な少年が元気に大活躍する大河古代ロマンとして始まったはずだったが、第二話において早くも主人公が下着ドロをやらかし、その後も「チンチン大蛇」など南国テイストなギャグを連発している。このことから「実はタイトルを変えて周囲をあざむいただけではないのか?」と疑惑と疑念の声があがっている。　【パソ通でもすばやいツッコミ】某大手通信ネットのマンガフォーラムでもこの2話の話題がとりあげられ「下ネタ大王改め夢大将96」じゃなかったの? ととまどいの声があがっている。" width={371} height={300} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『行け!!南国アイスホッケー部』</cite>23巻 p.185</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">行け!!南国アイスホッケー部</cite>23巻 p.185</figcaption>
 			</figure>
 		</div>
 
@@ -590,7 +590,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/darling_1_p198.jpg" alt="ある日の「ダーリン」の打ち合わせ　前担当Y氏「ここでそあらは冬馬を…」「もっとそあらと冬馬のカンケーをさ明確に…」「そあらのかわいい部分を出そうよ」、まんが家「…あの…そあらじゃないんスケド」" width={375} height={300} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『育ってダーリン!!』</cite>1巻 p.198</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">育ってダーリン!!</cite>1巻 p.198</figcaption>
 			</figure>
 		</div>
 	</Section>
@@ -608,7 +608,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/pokapoka_4_p172.jpg" alt="1コマ目: ブラックドリル「そのすきに愚かな国民を支配するのじゃ!!」「OH! なんて恐ろしい計画!!」、2コマ目: 「さー、こいつでT大生の偏差値を吸いまくるのじゃ!!」（掃除機の吸込口のイラスト）、3コマ目: 掃除機を持つブラックドリル「ムッ…もー一杯になってしまったか!!」（掃除機のメーターが満杯になっている）" width={375} height={200} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『太陽の戦士ポカポカ』</cite>4巻 p.172</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">太陽の戦士ポカポカ</cite>4巻 p.172</figcaption>
 			</figure>
 		</div>
 
@@ -621,7 +621,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/pokapoka_5_p82.jpg" alt="1コマ目: りく「考えられるもっとも無責任な職業であるまんが家は…この世界では存在しえないんだ!!」、ゲームをしながら電話するまんが家「やってまーす　はーいやってまーす」、2コマ目: こよみ「と、同時にもっとも無責任な職業として肩を並べる…編集者も存在しえないのよ!!」、両側を女の子に囲まれて酔いながら電話する編集者「やってるー?」" width={375} height={200} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『太陽の戦士ポカポカ』</cite>5巻 p.82</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">太陽の戦士ポカポカ</cite>5巻 p.82</figcaption>
 			</figure>
 		</div>
 
@@ -635,13 +635,13 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/pokapoka_1_p186.jpg" alt="南国スポーツ「キャバクラであのA・S氏とニアミス」、日の丸扇子を持ちながら泣き顔をしているまんが家のイラスト" width={270} height={270} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『太陽の戦士ポカポカ』</cite>1巻 p.186</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">太陽の戦士ポカポカ</cite>1巻 p.186</figcaption>
 			</figure>
 			<figure class="c-flex__item">
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/pokapoka_2_p189.jpg" alt="南スポ「クメタ氏　ド×え×んと接近遭…」、目線が入ったドラえもんを見つめるまんが家のイラスト" width={270} height={270} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『太陽の戦士ポカポカ』</cite>2巻 p.189</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">太陽の戦士ポカポカ</cite>2巻 p.189</figcaption>
 			</figure>
 		</div>
 	</Section>
@@ -658,13 +658,13 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kaizo_1_p102.jpg" alt="1コマ目: 「いやー、やっと終わったよ。」（机の上に漫画原稿が置かれている）、2コマ目: まんが家「3日ぶりに寝られるよ。」「ん?」（窓の外からボールが飛んでくる）、3コマ目: ボールが製図用インクケースに当たり、原稿にインクが掛かる、4コマ目: 唖然とした表情の漫画家（帽子に“米”マーク）" width={382} height={300} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『かってに改蔵』</cite>1巻 p.102</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">かってに改蔵</cite>1巻 p.102</figcaption>
 			</figure>
 			<figure class="c-flex__item">
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kaizo_ova_1_32m39s.jpg" alt="原稿にインクが掛かったのを見て唖然とする漫画家（帽子に“米”マーク）" width={382} height={215} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>OVA『かってに改蔵』</cite>上巻　第2話</figcaption>
+				<figcaption class="c-caption -meta">OVA<cite class="c-cite -work">かってに改蔵</cite>上巻　第2話</figcaption>
 			</figure>
 		</div>
 
@@ -677,13 +677,13 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kaizo_ova_1_09m39s.jpg" alt="朝顔が咲く狭い道に立つYシャツ姿の青年（目元は髪で隠れている）" width={382} height={215} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>OVA『かってに改蔵』</cite>上巻　第1話（康治13歳）</figcaption>
+				<figcaption class="c-caption -meta">OVA<cite class="c-cite -work">かってに改蔵</cite>上巻　第1話（康治13歳）</figcaption>
 			</figure>
 			<figure class="c-flex__item">
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kaizo_ova_1_10m44s.jpg" alt="椅子の背にもたれ、窓の外を見上げる男性（後ろ姿）" width={382} height={215} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>OVA『かってに改蔵』</cite>上巻　第1話（康治最近）</figcaption>
+				<figcaption class="c-caption -meta">OVA<cite class="c-cite -work">かってに改蔵</cite>上巻　第1話（康治最近）</figcaption>
 			</figure>
 		</div>
 
@@ -697,13 +697,13 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kaizo_5_p120.jpg" alt="1コマ目: 「町立祝日研究所」建物の外観が描かれている、2コマ目: PC の置かれた机の前に座るまんが家（写真ハメコミ）「どーも。」、3コマ目: 改蔵「この方が日本屈指の祝日研究家の…」、羽美「なんかすりへりきったまんが家みたいな顔してるけど…」、まんが家「まずこれをごらんください。」" width={382} height={270} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『かってに改蔵』</cite>5巻 p.120</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">かってに改蔵</cite>5巻 p.120</figcaption>
 			</figure>
 			<figure class="c-flex__item">
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kaizo_5_p20.jpg" alt="1コマ目: タクシー運転手「あれ? お客さんもうお帰りで? 花火大会これからですよ」（後部座席に男性2人が座っている）、2コマ目: 後部座席のまんが家「いいのです　我々のフェスタは終わったのです」（隣のメガネ男性は表紙に「瀬葵」の文字が書かれた本を読んでいる）" width={382} height={270} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『かってに改蔵』</cite>5巻 p.20</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">かってに改蔵</cite>5巻 p.20</figcaption>
 			</figure>
 		</div>
 
@@ -716,7 +716,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kaizo_13_p117.jpg" alt="1コマ目: メガネ男性「やりましたよ!!! 『改蔵』アニメ化ですよ!!!」、執筆中のまんが家「本当ですか!!」、2コマ目: 電話をするまんが家「なんだかさぁアニメになるんだって」、3コマ目: 電話をするまんが家「そうそうアニメにね。まいったよ…」、4コマ目: 日めくりカレンダーが4枚剥がれ落ちる、5コマ目: メガネ男性「いやあなんというか…　やっぱりあの話はなかった事に……」（やっぱイロイロ版権とかの問題とかイロイロとね…）、6コマ目: まんが家が無言で口をあんぐり開けている" width={382} height={300} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『かってに改蔵』</cite>13巻 p.117</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">かってに改蔵</cite>13巻 p.117</figcaption>
 			</figure>
 		</div>
 
@@ -730,7 +730,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kaizo_26_p200.jpg" alt="1コマ目: 病室の別途で原稿を描くまんが家「ふーー。」、2コマ目: まんが家「今週もなんとかあがったよ。第300話「文化人ぶっちゃってますか」の巻。」、3コマ目: 女性看護師が無言で見ている、4コマ目: 原稿を手にした女性看護師「はいはい。今週も面白いですね。」" width={382} height={360} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『かってに改蔵』</cite>26巻 p.200</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">かってに改蔵</cite>26巻 p.200</figcaption>
 			</figure>
 		</div>
 
@@ -1146,7 +1146,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/darling_b_p220.jpg" alt="1コマ目: まんが家「これは何かの罰ですか?」、うらら「ん?」、2コマ目: まんが家「これはなにかの罰ですか!!」、うらら「ひいい…」、3コマ目: ナレーション「某まんが家。（現在三十路）」「本編の作者である。」、まんが家「眠っていてくれればいいものを!!」「なぜ20代の過ちを掘り返さにゃいかんのだ!!」、うらら「ひいいい…」" width={371} height={270} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『育ってダーリン!!』</cite>B巻 p.220</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">育ってダーリン!!</cite>B巻 p.220</figcaption>
 			</figure>
 		</div>
 
@@ -1176,13 +1176,13 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/jyoshiraku_4_p39.jpg" alt="1コマ目: まんが家「私も言わせてもらってもいいですか…」、苦来「近所の漫画家」、2コマ目: 魔梨威がマガジンを読みながら爆笑している様子をまんが家が引戸越しに見ている、3コマ目: 爆笑している魔梨威「は……はかまが…　はかまがしましま!」、4コマ目: 唖然とするまんが家、5コマ目: まんが家「笑うタイミングが変なんですよ」「ぜんぜん笑う所じゃないし!!」、6コマ目: まんが家「そのくせ笑って欲しいところは」、7コマ目: 魔梨威がマガジンのページを無表情でめくる" width={423} height={360} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『じょしらく』</cite>四巻 p.39</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">じょしらく</cite>四巻 p.39</figcaption>
 			</figure>
 			<figure class="c-flex__item">
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/jyoshiraku_oad_04m54s.jpg" alt="爆笑する魔梨威をバックにまんが家が必死に訴えている" width={423} height={238} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『じょしらく』</cite>OAD　Aパート</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">じょしらく</cite>OAD　Aパート</figcaption>
 			</figure>
 		</div>
 
@@ -1195,7 +1195,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/jyoshiraku_oad_09m41s.jpg" alt="まんが家が山下とともに引戸越しにこちらを覗いており、その脇に『行け!!南国アイスホッケー部』と『かってに改蔵』の単行本が浮かんでいる" width={423} height={238} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『じょしらく』</cite>OAD　Bパート</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">じょしらく</cite>OAD　Bパート</figcaption>
 			</figure>
 		</div>
 
@@ -1271,19 +1271,19 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/sekadoro_1_p77.jpg" alt="1コマ目: 真心「底辺‥って　「伯爵」だから偉いんじゃないの?」、ホムンクルス「蔑称ですよ　あるでしょそんな使い方」、2コマ目: 真心「ああ‥あるね」、背景画像にロリ“将軍”（少女フィギュアを持っている男性）、風俗“王”（麦わら帽子）、アニメ“様”（短髪で丸い大きな顔）、ハンケツ“王子”（尻を半分出した男性）" width={403} height={160} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『せっかち伯爵と時間どろぼう』</cite>1巻 p.77</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">せっかち伯爵と時間どろぼう</cite>1巻 p.77</figcaption>
 			</figure>
 			<figure class="c-flex__item">
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/sekadoro_3_p35.jpg" alt="まんが家「漫画家とかプレッシャーハンパないっすよ」、編集「編集とかプレッシャーハンパないっすよ」" width={403} height={160} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『せっかち伯爵と時間どろぼう』</cite>3巻 p.35</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">せっかち伯爵と時間どろぼう</cite>3巻 p.35</figcaption>
 			</figure>
 			<figure class="c-flex__item">
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/sekadoro_5_p121.jpg" alt="1コマ目: ナレーション「消費税はまだ5%で」、2コマ目: ナレーション「新連載始めた漫画家は希望にあふれ」、まんが家「大ヒットだ」" width={403} height={160} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『せっかち伯爵と時間どろぼう』</cite>5巻 p.121</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">せっかち伯爵と時間どろぼう</cite>5巻 p.121</figcaption>
 			</figure>
 		</div>
 
@@ -1296,7 +1296,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/sekadoro_2_p156.jpg" alt="1コマ目: 伯爵「なんで40巻もでているのに　まだ続けようとするのですか」、2コマ目: 真心「そ　それは」、3コマ目: まんが家「それはね」、4コマ目: まんが家「次も売れるかわかんねーからだよ　バカ」、5コマ目: 「次も売れるかわかんねーからだよ　オマエらのバカ」、枠外の手書き文字「せおこーじシステム　サイコー」" width={403} height={240} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『せっかち伯爵と時間どろぼう』</cite>2巻 p.156</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">せっかち伯爵と時間どろぼう</cite>2巻 p.156</figcaption>
 			</figure>
 		</div>
 
@@ -1309,7 +1309,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/sekadoro_1_p155.jpg" alt="「エセエヌエス（仮）　そー　おっしゃる　ねっと　枠」の手書きタイトルロゴ" width={403} height={240} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『せっかち伯爵と時間どろぼう』</cite>1巻 p.155</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">せっかち伯爵と時間どろぼう</cite>1巻 p.155</figcaption>
 			</figure>
 		</div>
 	</Section>
@@ -1326,7 +1326,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/pulp_1_p16.jpg" alt="1コマ目: 部長「ま 三流がウォルト気取りすると　痛々しいのよ」、2コマ目: 「そんなBC級の雑多なキャラが　雑多な物語を繰り広げる　スタジオスタジオパルプへようこそ」、2コマ目の脇にぶち抜きで役者丸ひろ子がブロンズ像（左手を挙げたまんが家と手を繋いだ下っぱスーツ地丹）を見上げている" width={422} height={400} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『スタジオパルプ』</cite>1巻 p.16</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">スタジオパルプ</cite>1巻 p.16</figcaption>
 			</figure>
 		</div>
 
@@ -1339,7 +1339,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/pulp_1_p45.jpg" alt="所属タレントの顔写真　小林（名取羽美）、佐藤（坪内地丹）、山田（サンジェルマン伯爵）、斉藤（一旧）、中村（木津千里）、高橋（勝改蔵）、久保田（まんが家）、海老名（モブおっさん）、内田（モブおばさん）、ローラ（日塔奈美）、近藤（風間圭介）、石川（万世橋わたる）、佐々木（糸色望）" width={422} height={600} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『スタジオパルプ』</cite>1巻 p.45</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">スタジオパルプ</cite>1巻 p.45</figcaption>
 			</figure>
 		</div>
 	</Section>
@@ -1356,7 +1356,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kakushigoto_6_p34.jpg" alt="新企画　うろ覚え「漫画家仕事場遍歴」　1コマ目: 椅子に座って腕組みしている久米田康治「描く仕事（漫画家）に興味ある人の中には漫画家の仕事場に興味のある人も多いだろう　ここでは過去に私が渡り歩いた仕事場を紹介したいと思う」、2コマ目: 久米田「なにぶん昔の事なのでうろ覚えかつ　妄想や虚構　嘘　大げさが混じってるかもしれないがあしからず」" width={422} height={306} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>『かくしごと』</cite>6巻 p.34</figcaption>
+				<figcaption class="c-caption -meta"><cite class="c-cite -work">かくしごと</cite>6巻 p.34</figcaption>
 			</figure>
 		</div>
 
@@ -1369,7 +1369,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/kakushigoto_tv_10_04m12s.jpg" alt="笑顔の姫、やや驚き顔の可久士の後ろに「米」マークのTシャツを着たまんが家が立ち止まってガン見しており、またマスクをした風留、初老夫婦の通行人も歩きながらこちらを見ている" width={422} height={237} quality={80} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>TV アニメ『かくしごと』</cite>10号 Aパート</figcaption>
+				<figcaption class="c-caption -meta">TV アニメ<cite class="c-cite -work">かくしごと</cite>10号 Aパート</figcaption>
 			</figure>
 		</div>
 	</Section>
@@ -1388,7 +1388,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/sunday_1992_1&2_p438.jpg" alt="連載作家の一言コメントが書かれたコーナー: （平安貴族のような自画像）久米田　打ち合わせの時喫茶店で○ンポ○ンポと大声でいえる(編)さんはすごい。" width={480} height={360} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>「週刊少年サンデー」</cite>1992年1・2号 p.438</figcaption>
+				<figcaption class="c-caption -meta"><cite>週刊少年サンデー</cite>1992年1・2号 p.438</figcaption>
 			</figure>
 		</div>
 
@@ -1401,7 +1401,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/youngsunday_1993_15_p324.jpg" alt="受験&フーゾク欲望克服新連載（参考書を読む春平のイラスト）　√P ルートパラダイス　久米田康治（下ネタ帽の自画像）" width={480} height={360} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>「ヤングサンデー」</cite>1993年No.15 p.324</figcaption>
+				<figcaption class="c-caption -meta"><cite>ヤングサンデー</cite>1993年No.15 p.324</figcaption>
 			</figure>
 		</div>
 
@@ -1414,7 +1414,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/sunday_2003_1_p114.jpg" alt="久米田康治先生　発つ鳥後をにごさず。老兵は死なず、ただ消えゆくのみ。（改蔵のイラストに「あけましておめでとう　今年でさようなら」の直筆コメントとサイン）" width={480} height={360} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>「週刊少年サンデー」</cite>2003年1号 p.114</figcaption>
+				<figcaption class="c-caption -meta"><cite>週刊少年サンデー</cite>2003年1号 p.114</figcaption>
 			</figure>
 		</div>
 
@@ -1443,7 +1443,7 @@ const structuredData: StructuredData = {
 				<div class="p-embed">
 					<Image path="kumeta/yomoyama/mangaka/sunday_2021_48_toc.jpg" alt="シブヤニアファミリー　久米田康治（ランドセルを背負った振り向きイッコちゃんのイラスト）　シルバー人材センターの方から来ました。あの方らの繋ぎとして短い間ですが頑張ります。（ボサボサ頭に無精ヒゲ、目線の入った自画像）" width={480} height={360} quality={60} />
 				</div>
-				<figcaption class="c-caption -meta"><cite>「週刊少年サンデー」</cite>2021年48号　目次ページ</figcaption>
+				<figcaption class="c-caption -meta"><cite>週刊少年サンデー</cite>2021年48号　目次ページ</figcaption>
 			</figure>
 		</div>
 	</Section>

--- a/astro/src/pages/kumeta/yomoyama/pulp_daidanen.astro
+++ b/astro/src/pages/kumeta/yomoyama/pulp_daidanen.astro
@@ -29,7 +29,7 @@ const slugger = new GithubSlugger();
 					<div class="p-embed -border">
 						<Image path="kumeta/yomoyama/pulp15_daidanen.jpg" alt="大画像" width={1022} height={734} quality={60} link={true} />
 					</div>
-					<figcaption class="c-caption -meta"><span class="c-caption__title">見開きの大団円イラスト</span>（「楽園」32号 pp.360–361 を加工）</figcaption>
+					<figcaption class="c-caption">見開きの大団円イラスト（<cite>楽園</cite>32号 pp.360–361 を加工）</figcaption>
 				</figure>
 			</div>
 		</details>

--- a/astro/src/pages/kumeta/yomoyama/zensarashi_slideshow.astro
+++ b/astro/src/pages/kumeta/yomoyama/zensarashi_slideshow.astro
@@ -19,9 +19,7 @@ const structuredData: StructuredData = {
 		<div class="p-embed -border">
 			<iframe src="https://www.youtube-nocookie.com/embed/Dtb8tbftKsc?cc_load_policy=1" allow="accelerometer;autoplay;clipboard-write;encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="560" height="315" style="--aspect-ratio: 560/315"></iframe>
 		</div>
-		<figcaption class="c-caption -meta">
-			<LinkExternal href="https://www.youtube.com/watch?v=Dtb8tbftKsc" class="c-caption__title">久米田康治「全曝し展」の様子</LinkExternal>
-		</figcaption>
+		<figcaption class="c-caption -meta"><LinkExternal href="https://www.youtube.com/watch?v=Dtb8tbftKsc">久米田康治「全曝し展」の様子</LinkExternal></figcaption>
 	</figure>
 
 	<ul class="p-notes">

--- a/astro/src/pages/kumeta/yomoyama/zetsubou_web.astro
+++ b/astro/src/pages/kumeta/yomoyama/zetsubou_web.astro
@@ -86,9 +86,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed -border">
 				<iframe src="https://www.youtube-nocookie.com/embed/J3J4b_wuxsM" allow="accelerometer;autoplay;clipboard-write;encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="560" height="315" style="--aspect-ratio: 560/315"></iframe>
 			</div>
-			<figcaption class="c-caption -meta">
-				<LinkExternal href="https://www.youtube.com/watch?v=J3J4b_wuxsM" class="c-caption__title">『さよなら絶望先生』公式サイト閲覧の様子</LinkExternal>
-			</figcaption>
+			<figcaption class="c-caption -meta"><LinkExternal href="https://www.youtube.com/watch?v=J3J4b_wuxsM">『さよなら絶望先生』公式サイト閲覧の様子</LinkExternal></figcaption>
 		</figure>
 	</Section>
 	<Section slugger={slugger}>
@@ -98,9 +96,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed -border">
 				<iframe src="https://www.youtube-nocookie.com/embed/kDSBb4UD5CQ" allow="accelerometer;autoplay;clipboard-write;encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="560" height="315" style="--aspect-ratio: 560/315"></iframe>
 			</div>
-			<figcaption class="c-caption -meta">
-				<LinkExternal href="https://www.youtube.com/watch?v=kDSBb4UD5CQ" class="c-caption__title">『俗・さよなら絶望先生』公式サイト閲覧の様子</LinkExternal>
-			</figcaption>
+			<figcaption class="c-caption -meta"><LinkExternal href="https://www.youtube.com/watch?v=kDSBb4UD5CQ">『俗・さよなら絶望先生』公式サイト閲覧の様子</LinkExternal></figcaption>
 		</figure>
 
 		<ul class="p-notes">
@@ -114,9 +110,7 @@ const slugger = new GithubSlugger();
 			<div class="p-embed -border">
 				<iframe src="https://www.youtube-nocookie.com/embed/t4j7jg8_GZQ" allow="accelerometer;autoplay;clipboard-write;encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="560" height="315" style="--aspect-ratio: 560/315"></iframe>
 			</div>
-			<figcaption class="c-caption -meta">
-				<LinkExternal href="https://www.youtube.com/watch?v=t4j7jg8_GZQ" class="c-caption__title">『懺・さよなら絶望先生』公式サイト閲覧の様子</LinkExternal>
-			</figcaption>
+			<figcaption class="c-caption -meta"><LinkExternal href="https://www.youtube.com/watch?v=t4j7jg8_GZQ">『懺・さよなら絶望先生』公式サイト閲覧の様子</LinkExternal></figcaption>
 		</figure>
 
 		<ul class="p-notes">

--- a/astro/src/pages/madoka/yomoyama/monoga-modoka.astro
+++ b/astro/src/pages/madoka/yomoyama/monoga-modoka.astro
@@ -194,9 +194,7 @@ const structuredData: StructuredData = {
 							<Image path="madoka/yomoyama/monoga-modoka_kanazawa1.jpg" alt="写真拡大" width={306} height={306} quality={60} link={true} />
 							<!-- 2016-12-22 IMG_5289 -->
 						</div>
-						<figcaption class="c-caption">
-							<span class="c-caption__title">MADOGATARI GALLERY でのキャラクターボード展示</span>
-						</figcaption>
+						<figcaption class="c-caption">MADOGATARI GALLERY でのキャラクターボード展示</figcaption>
 					</figure>
 				</div>
 				<div class="c-grid__item">
@@ -205,9 +203,7 @@ const structuredData: StructuredData = {
 							<Image path="madoka/yomoyama/monoga-modoka_kanazawa2.jpg" alt="写真拡大" width={306} height={204} quality={60} link={true} />
 							<!-- 2016-12-22 IMG_5296 -->
 						</div>
-						<figcaption class="c-caption">
-							<span class="c-caption__title">キャラクターボードが展示されていたエリアの様子</span>
-						</figcaption>
+						<figcaption class="c-caption">キャラクターボードが展示されていたエリアの様子</figcaption>
 					</figure>
 				</div>
 			</div>

--- a/astro/src/pages/tokyu/data/preservation.astro
+++ b/astro/src/pages/tokyu/data/preservation.astro
@@ -299,9 +299,7 @@ const structuredData: StructuredData = {
 			<div class="p-embed -border">
 				<iframe src="https://www.google.com/maps/d/embed?mid=1wcErO5GFrxTDWgFmFvooaScjytnyRnSy&hl=ja" title="保存車両マップ" style="height: min(100vh, 720px)"></iframe>
 			</div>
-			<figcaption class="c-caption -meta">
-				<LinkExternal href="https://www.google.com/maps/d/viewer?mid=1wcErO5GFrxTDWgFmFvooaScjytnyRnSy&hl=ja&usp=sharing" class="c-link" icon={false}>Google マップ</LinkExternal>
-			</figcaption>
+			<figcaption class="c-caption -meta"><LinkExternal href="https://www.google.com/maps/d/viewer?mid=1wcErO5GFrxTDWgFmFvooaScjytnyRnSy&hl=ja&usp=sharing" class="c-link" icon={false}>Google マップ</LinkExternal></figcaption>
 		</figure>
 	</Section>
 </Layout>

--- a/astro/src/pages/tokyu/sty/aci.astro
+++ b/astro/src/pages/tokyu/sty/aci.astro
@@ -33,9 +33,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aci/INV049.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-07-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1022（5次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1022（5次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -53,9 +51,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aci/INV088.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-02-14 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ2251（1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ2251（1次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -80,9 +76,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aci/TCE220.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2019-04-26 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9021（1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9021（1次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/amp_8000.astro
+++ b/astro/src/pages/tokyu/sty/amp_8000.astro
@@ -36,9 +36,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-1_1.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-07 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8004（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8004（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -56,9 +54,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-1_2.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-07 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8006（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8006（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -75,9 +71,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-3.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2002-05-23 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8051（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8051（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -101,9 +95,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-6.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-25 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8515（7次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8515（7次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -120,9 +112,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-9.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8629（9-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8629（9-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -139,9 +129,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-10.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ8931（10-1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ8931（10-1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -158,9 +146,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-11.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-07 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8409（13次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8409（13次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -184,9 +170,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-15.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-07 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ0807（18-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ0807（18-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -203,9 +187,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-21.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-11 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ0718（21次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ0718（21次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -229,9 +211,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8500-ir.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8629（9-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8629（9-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -248,9 +228,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/amp/8000-tr.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2005-07-14 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8248（12-3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8248（12-3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/aps.astro
+++ b/astro/src/pages/tokyu/sty/aps.astro
@@ -416,9 +416,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/CLG107_matsumoto5005.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2010-06-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">松本電気鉄道モハ5005（東急デハ5055）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">松本電気鉄道モハ5005（東急デハ5055）</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -427,9 +425,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/CLG107_3043.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2006-03-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デワ3043 海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デワ3043 海側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -492,9 +488,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/TDK381_konan6007.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2006-09-03 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">弘南鉄道デハ6007（東急デハ6007）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">弘南鉄道デハ6007（東急デハ6007）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -537,9 +531,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/HG533_konan7031.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-05-05 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">弘南鉄道デハ7031（東急デハ7031）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">弘南鉄道デハ7031（東急デハ7031）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -560,9 +552,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/CLG339_7290.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7290 山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7290 山側</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -571,9 +561,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/SC102_toyohashi1809.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2023-03-03 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title"><b>【自動調整器】</b>豊橋鉄道モ1809（東急デハ7256）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta"><b>【自動調整器】</b>豊橋鉄道モ1809（東急デハ7256）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -599,9 +587,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/CLG319_7290.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-12 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7290 山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7290 山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -626,9 +612,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/CLG333_hakone107.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2011-06-26 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">箱根登山鉄道モハ107</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">箱根登山鉄道モハ107</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -650,9 +634,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/TDK359_kumamoto5102.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-01-02 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">熊本電気鉄道モハ5102A（東急デハ5032）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">熊本電気鉄道モハ5102A（東急デハ5032）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -674,9 +656,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/TDK366_hokuriku7112.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2006-11-04 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">北陸鉄道モハ7112（東急デハ7055）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">北陸鉄道モハ7112（東急デハ7055）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -703,9 +683,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/BS33_8201.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2006-12-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8201（1次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8201（1次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -734,9 +712,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV009_8641.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-03-22 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8641（18-2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8641（18-2次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -762,9 +738,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/S11_konan7031.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-08-05 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">弘南鉄道デハ7031（東急デハ7031）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">弘南鉄道デハ7031（東急デハ7031）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -790,9 +764,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/CLG350_8015.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2006-07-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8015（2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8015（2次車）海側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -814,9 +786,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/HG554_toyohashi2807.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-11-25 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">豊橋鉄道ク2807（東急クハ7554）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">豊橋鉄道ク2807（東急クハ7554）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -837,9 +807,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/TDK3725_mizuma1002.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2015-04-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">水間鉄道デハ1002（東急デハ7009）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">水間鉄道デハ1002（東急デハ7009）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -887,9 +855,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/BS477_7200.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7200 山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7200 山側</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -898,9 +864,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/BS477_mizuma1004.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-10-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">水間鉄道デハ1004（東急デハ7007）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">水間鉄道デハ1004（東急デハ7007）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -928,9 +892,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/BS482_8097.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-03-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8097（16-2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8097（16-2次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -973,9 +935,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV006_7602.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-09-04 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7602（1次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7602（1次車）山側</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -984,9 +944,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV006_toyohashi2806.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-01-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">豊橋鉄道ク2806（東急クハ7505）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">豊橋鉄道ク2806（東急クハ7505）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1008,9 +966,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV008_8977.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-02-11 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ8977（18-2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ8977（18-2次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1031,9 +987,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV020_9310.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-03-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ9310（3次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ9310（3次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1054,9 +1008,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/SVH120_7914.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-09-02 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7914（5次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7914（5次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1081,9 +1033,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV029_8398.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-01-31 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ8398（16-2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ8398（16-2次車）山側</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -1092,9 +1042,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV029_toyama17482.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2013-11-04 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">富山地方鉄道モハ17482（東急デハ8692）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">富山地方鉄道モハ17482（東急デハ8692）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1118,9 +1066,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV095_8932.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2006-09-05 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ8932（10-1次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ8932（10-1次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1141,9 +1087,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV127_3262.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-05-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ3262（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ3262（2次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1164,9 +1108,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV104_8296.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-27 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8296（13次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8296（13次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1187,9 +1129,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV146_8031.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2005-01-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8031（4次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8031（4次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1210,9 +1150,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV153_8290.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-22 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8290（17-1次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8290（17-1次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1234,9 +1172,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV205_9322_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2023-01-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ9322 海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ9322 海側</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -1245,9 +1181,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/INV205_9322_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2019-05-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ9322 山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ9322 山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1269,9 +1203,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/CDA021_towada7204.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-04-30 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">十和田観光電鉄デハ7204（東急デハ7211）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">十和田観光電鉄デハ7204（東急デハ7211）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1293,9 +1225,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/BS483_toyohashi2810.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-04-04 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">豊橋鉄道ク2810（東急クハ7551）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">豊橋鉄道ク2810（東急クハ7551）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1316,9 +1246,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/RG5096_yoro7914.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2022-10-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">養老鉄道ク7914（東急クハ7914）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">養老鉄道ク7914（東急クハ7914）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1371,9 +1299,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/RG660_7715.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-12 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7715（5次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7715（5次車）山側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1395,9 +1321,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/SVF041_Y012.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2006-07-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハY012 海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハY012 海側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1418,9 +1342,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/SVF091_1602.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2016-10-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1602 海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1602 海側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -1445,9 +1367,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/aps/DA61T_306B.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2013-09-07 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ306B（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ306B（2次車）</figcaption>
 					</figure>
 				</div>
 			</div>

--- a/astro/src/pages/tokyu/sty/atc.astro
+++ b/astro/src/pages/tokyu/sty/atc.astro
@@ -34,9 +34,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/atc/CMR-DC-129.jpg" alt="写真拡大" width={485} height={244} quality={60} link={true} />
 							<!-- 撮影日: 2009-02-28 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8695（20次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8695（20次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -54,9 +52,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/atc/AT-CS21TK16.jpg" alt="写真拡大" width={485} height={244} quality={60} link={true} />
 							<!-- 撮影日: 2007-10-02 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハY001（1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハY001（1次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -80,9 +76,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/atc/toyoko_ATS-P_1.jpg" alt="写真拡大" width={485} height={244} quality={60} link={true} />
 							<!-- 撮影日: 2006-03-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8024（3-1次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8024（3-1次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -100,9 +94,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/atc/AT-CS21TK11.jpg" alt="写真拡大" width={485} height={244} quality={60} link={true} />
 							<!-- 撮影日: 2009-02-28 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9101（1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9101（1次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -126,9 +118,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/atc/CMR-DC-117.jpg" alt="写真拡大" width={485} height={244} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-05 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ3010（2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ3010（2次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -154,9 +144,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/atc/AT-CS21TK5.jpg" alt="写真拡大" width={485} height={244} quality={60} link={true} />
 							<!-- 撮影日: 2007-09-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8098（16-2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8098（16-2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -181,9 +169,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/atc/AT-CS21TK17.jpg" alt="写真拡大" width={485} height={244} quality={60} link={true} />
 							<!-- 撮影日: 2008-04-27 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8085（16-2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8085（16-2次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/bce.astro
+++ b/astro/src/pages/tokyu/sty/bce.astro
@@ -34,9 +34,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/bce/HD23.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-12 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7200（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7200（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -61,9 +59,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/bce/E6-M.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2005-12-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8115（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8115（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -83,9 +79,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/bce/E30-A.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-04-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ9311（3次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ9311（3次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -106,9 +100,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/bce/E53.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-08-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7713（5次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7713（5次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -128,9 +120,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/bce/E78-M1.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-05-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ3212（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ3212（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -150,9 +140,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/bce/E80.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2005-11-30 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ304A（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ304A（2次車）山側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -160,9 +148,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/bce/BSR70.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-10-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ309A（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ309A（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/bt.astro
+++ b/astro/src/pages/tokyu/sty/bt.astro
@@ -36,9 +36,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/7200_100V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-09-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7290（2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7290（2次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -58,9 +56,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/8000_100V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2005-11-14 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8232（6次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8232（6次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -73,9 +69,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/8500_100V-40Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-09-28 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8281（16-2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8281（16-2次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -88,9 +82,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/7800_100V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7801（1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7801（1次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -103,9 +95,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/8500_24V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2005-11-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ8977（18-2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ8977（18-2次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -118,9 +108,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/7600_24V-20Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-08-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7714（5次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7714（5次車）山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -140,9 +128,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/9000_100V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2005-11-14 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ9810（3次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ9810（3次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -155,9 +141,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/9000_100V-30Ah_24V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2005-11-14 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9010（3次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9010（3次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -177,9 +161,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/1000_100V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-07-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1024（5次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1024（5次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -192,9 +174,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/1000_100V-30Ah_24V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-04-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1223（4次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1223（4次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -214,9 +194,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/3000_100V-60Ah_24V-30Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-08-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ3510（2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ3510（2次車）海側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -236,9 +214,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/bt/300_100V-20Ah_24V-80Ah.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-09-23 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ305B（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ305B（2次車）山側</figcaption>
 					</figure>
 				</Section>
 			</div>

--- a/astro/src/pages/tokyu/sty/cp.astro
+++ b/astro/src/pages/tokyu/sty/cp.astro
@@ -156,9 +156,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/D2N_510.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2009-05-19 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">モハ510 復元車</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">モハ510 復元車</figcaption>
 				</figure>
 			</div>
 			<div class="c-flex__item">
@@ -167,9 +165,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/D2N_kumamoto5102A.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2006-05-06 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">熊本電気鉄道モハ5102A（東急デハ5032）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">熊本電気鉄道モハ5102A（東急デハ5032）</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -191,9 +187,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/3YS_matsumoto5005.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2010-03-21 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">松本電気鉄道モハ5005（東急デハ5055）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">松本電気鉄道モハ5005（東急デハ5055）</figcaption>
 				</figure>
 			</div>
 			<div class="c-flex__item">
@@ -202,9 +196,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/3YS_nagano2510.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2007-05-05 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">長野電鉄モハ2510（東急デハ5015）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">長野電鉄モハ2510（東急デハ5015）</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -230,9 +222,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/C1000_konan6005.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2006-09-03 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">弘南鉄道デハ6005（東急デハ6005）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">弘南鉄道デハ6005（東急デハ6005）</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -253,9 +243,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/HB1500_ueda7255.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2005-03-29 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title"><b>【7200系タイプ】</b>上田交通モハ7255（東急デハ7258）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta"><b>【7200系タイプ】</b>上田交通モハ7255（東急デハ7258）</figcaption>
 				</figure>
 			</div>
 			<div class="c-flex__item">
@@ -264,9 +252,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/HB1500_fukushima7202.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2013-07-07 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title"><b>【7000系タイプ】</b>福島交通デハ7202（東急デハ7125）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta"><b>【7000系タイプ】</b>福島交通デハ7202（東急デハ7125）</figcaption>
 				</figure>
 			</div>
 			<div class="c-flex__item">
@@ -275,9 +261,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/HB1500_hokuriku7211.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2008-04-13 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title"><b>【京阪タイプ】</b>北陸鉄道クハ7211（東急デハ7137）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta"><b>【京阪タイプ】</b>北陸鉄道クハ7211（東急デハ7137）</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -300,9 +284,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/HB2000_8879.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2009-04-05 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title"><b>【神鋼電機】</b>デハ8879（15次車）海側</span>
-					</figcaption>
+					<figcaption class="c-caption -meta"><b>【神鋼電機】</b>デハ8879（15次車）海側</figcaption>
 				</figure>
 			</div>
 			<div class="c-flex__item">
@@ -311,9 +293,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/HB2000_8281.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2008-09-06 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title"><b>【日立製作所】</b>デハ8281（16-2次車）海側 #1</span>
-					</figcaption>
+					<figcaption class="c-caption -meta"><b>【日立製作所】</b>デハ8281（16-2次車）海側 #1</figcaption>
 				</figure>
 			</div>
 			<div class="c-flex__item">
@@ -322,9 +302,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/HB2000_izukyu8252.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2006-05-28 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title"><b>【神鋼電機、反転】</b>伊豆急行クモハ8252（東急デハ8049）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta"><b>【神鋼電機、反転】</b>伊豆急行クモハ8252（東急デハ8049）</figcaption>
 				</figure>
 			</div>
 			<div class="c-flex__item">
@@ -333,9 +311,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/HB2000_8881_frame.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2009-05-22 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">デハ8881（15次車）海側</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">デハ8881（15次車）海側</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -361,9 +337,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS20_9101.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-01-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9101（1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9101（1次車）海側</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -372,9 +346,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS20_9010.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2013-06-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9010（3次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9010（3次車）海側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -401,9 +373,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS20_8641.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-12-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8641（18-2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8641（18-2次車）海側</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -428,9 +398,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS10_1223.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-04-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1223（4次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1223（4次車）海側</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -439,9 +407,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS10_iga101.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-12-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">伊賀鉄道ク101（東急クハ1010）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">伊賀鉄道ク101（東急クハ1010）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -463,9 +429,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS10_fukushima1208.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-04-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">福島交通クハ1208（東急デハ1257）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">福島交通クハ1208（東急デハ1257）</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -489,9 +453,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS5_310B.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-02-22 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ310B（2次車）山側 #2</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ310B（2次車）山側 #2</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -512,9 +474,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS5_Y001.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-04-06 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハY001（1次車）海側 #1</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハY001（1次車）海側 #1</figcaption>
 					</figure>
 				</div>
 				<div class="c-flex__item">
@@ -523,9 +483,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/cp/HS5_Y002.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-03-22 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハY002（2次車）海側 #1</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハY002（2次車）海側 #1</figcaption>
 					</figure>
 				</div>
 			</div>
@@ -547,9 +505,7 @@ const slugger = new GithubSlugger();
 				<Image path="tokyu/sty/cp/C2500L_3510.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 				<!-- 撮影日: 2007-08-19 -->
 			</div>
-			<figcaption class="c-caption -meta">
-				<span class="c-caption__title">サハ3510（2次車）海側</span>
-			</figcaption>
+			<figcaption class="c-caption -meta">サハ3510（2次車）海側</figcaption>
 		</figure>
 
 		<div class="p-text">
@@ -570,9 +526,7 @@ const slugger = new GithubSlugger();
 						<Image path="tokyu/sty/cp/C2000M_toyama17482.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 						<!-- 撮影日: 2013-11-03 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">富山地方鉄道モハ17482</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">富山地方鉄道モハ17482</figcaption>
 				</figure>
 			</div>
 		</div>

--- a/astro/src/pages/tokyu/sty/nosmoking.astro
+++ b/astro/src/pages/tokyu/sty/nosmoking.astro
@@ -33,9 +33,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/bold_purple.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-07-30 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8218（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8218（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -52,9 +50,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/bold_black.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-07-30 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8040（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8040（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -71,9 +67,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/bold_blue.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-06-25 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1312（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1312（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -90,9 +84,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/thin_black.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-06-25 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7908（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7908（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -116,9 +108,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/pic_str.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-06-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7653（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7653（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -135,9 +125,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/pic_only.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-06-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8001（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8001（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -161,9 +149,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/3000.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-06-25 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ3013（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ3013（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -180,9 +166,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/Y000.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-06-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハY011（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハY011（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -199,9 +183,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/300.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-06-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ301A（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ301A（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -218,9 +200,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/nosmoking/9000_renewal.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-07-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9011（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9011（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/pt_7000.astro
+++ b/astro/src/pages/tokyu/sty/pt_7000.astro
@@ -34,9 +34,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/pt/PT43.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2010-06-30 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7701（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7701（1次車）</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -44,9 +42,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/pt/PT43_side.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2007-03-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7701（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7701（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -64,9 +60,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/pt/PT44.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2010-06-30 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7801（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7801（1次車）</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -74,9 +68,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/pt/PT44_side.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2007-02-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7810（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7810（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -99,18 +91,14 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/pt/PT44S-C.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2010-08-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7705（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7705（2次車）</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/pt/PT44S-C_side.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2007-02-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7805（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7805（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -132,18 +120,14 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/pt/PT44S.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2010-07-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7682（1次車）下り方</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7682（1次車）下り方</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/pt/PT44S_side.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2007-03-03 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7681（1次車）下り方</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7681（1次車）下り方</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -161,18 +145,14 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/pt/PT4309.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2005-05-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7290（2次車）下り方</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7290（2次車）下り方</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/pt/PT4309_side.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2007-03-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7290（2次車）下り方</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7290（2次車）下り方</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -196,27 +176,21 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/pt/PT7108-A.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2010-06-07 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7715（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7715（5次車）</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/pt/PT7108-B.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2010-06-07 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7815（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7815（4次車）</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/pt/PT7108_side.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2007-04-22 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7815（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7815（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/rec.astro
+++ b/astro/src/pages/tokyu/sty/rec.astro
@@ -42,9 +42,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RS120.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-10-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7290（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7290（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -68,9 +66,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RS175.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-06-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8692（20次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8692（20次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -87,9 +83,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RS180.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-06-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8091（12-1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8091（12-1次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -113,9 +107,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE001-A.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-02-11 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9001（1次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9001（1次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -132,9 +124,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE001-C.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-03-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9006（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9006（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -152,9 +142,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE001-E.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-09-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1213（3次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1213（3次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -172,9 +160,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE001-G.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-07-14 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1222（4次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1222（4次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -198,9 +184,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE005.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-08-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7601（1次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7601（1次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -224,9 +208,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE007.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-08-12 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ8975（18-1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ8975（18-1次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -250,9 +232,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE013.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-08-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7905（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7905（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -269,9 +249,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/S4341.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-08-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7910（3次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7910（3次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -295,9 +273,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/CG316.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-08-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ3510（2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ3510（2次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -321,9 +297,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE059.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-09-25 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハY001（1次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハY001（1次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -347,9 +321,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RFE068.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-09-28 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8282（16-2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8282（16-2次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -373,9 +345,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/rec/RS157.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2007-09-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ8975（18-1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ8975（18-1次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/roof_1000n.astro
+++ b/astro/src/pages/tokyu/sty/roof_1000n.astro
@@ -40,9 +40,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/1000N2.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-11 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1017（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1017（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -67,9 +65,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/1200N.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-11 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1213（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1213（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -87,9 +83,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/1200N2.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-11 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1221（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1221（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -113,9 +107,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/1300N2.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-27 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1323（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1323（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/roof_7200.astro
+++ b/astro/src/pages/tokyu/sty/roof_7200.astro
@@ -40,9 +40,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7200.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2011-11-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7200（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7200（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -67,9 +65,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7290.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-07-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7290（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7290（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -88,9 +84,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7290_PT7108.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2011-11-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7290（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7290（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -116,9 +110,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7590.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2011-11-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サヤ7590（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サヤ7590（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/roof_7600.astro
+++ b/astro/src/pages/tokyu/sty/roof_7600.astro
@@ -40,9 +40,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7600.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7602（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7602（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -67,9 +65,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7653.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-27 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7653（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7653（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -88,9 +84,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7650.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7662（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7662（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -115,9 +109,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7673.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-27 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7673（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7673（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -135,9 +127,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7670.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7682（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7682（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/roof_7700.astro
+++ b/astro/src/pages/tokyu/sty/roof_7700.astro
@@ -40,9 +40,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7701.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7702（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7702（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -61,9 +59,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7700.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-12 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7707（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7707（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -80,9 +76,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7710.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7710（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7710（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -106,9 +100,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7801.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-06-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7801（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7801（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -126,9 +118,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7800.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7802（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7802（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -145,9 +135,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7810.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7810（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7810（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -171,9 +159,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7901.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-06-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7901（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7901（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -191,9 +177,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7900.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7910（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7910（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/roof_7700n.astro
+++ b/astro/src/pages/tokyu/sty/roof_7700n.astro
@@ -40,9 +40,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7700N.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7715（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7715（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -68,9 +66,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7800N.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7815（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7815（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -95,9 +91,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/roof/7900N.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2009-05-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7915（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7915（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/tra.astro
+++ b/astro/src/pages/tokyu/sty/tra.astro
@@ -36,9 +36,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/tra/dnt_oimachi.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2008-06-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ8091（12-1次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ8091（12-1次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -55,18 +53,14 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/tra/dnt_ikegami.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2009-01-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7912（4次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7912（4次車）山側</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/tra/dnt_ikegami_7600.jpg" alt="写真拡大" width={485} height={397} quality={60} link={true} />
 							<!-- 撮影日: 2009-03-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7601（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7601（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -90,9 +84,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/tra/atc_toyoko.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2009-01-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ9013（3次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ9013（3次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -109,9 +101,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/tra/atc_meguro.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2008-12-06 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ3004（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ3004（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -129,9 +119,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/tra/atc_oimachi.jpg" alt="写真拡大" width={485} height={324} quality={60} link={true} />
 							<!-- 撮影日: 2008-06-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8641（18-2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8641（18-2次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/truck_etc.astro
+++ b/astro/src/pages/tokyu/sty/truck_etc.astro
@@ -157,9 +157,7 @@ const structuredData: StructuredData = {
 				<Image path="tokyu/sty/truck/nsk-A1_hossyoji203.jpg" alt="写真拡大" width={1022} height={409} quality={80} link={true} />
 				<!-- 撮影日: 2010-03-08 -->
 			</div>
-			<figcaption class="c-caption -meta">
-				<span class="c-caption__title">日ノ丸自動車デハ203 米子市方</span>
-			</figcaption>
+			<figcaption class="c-caption -meta">日ノ丸自動車デハ203 米子市方</figcaption>
 		</figure>
 
 		<div class="p-text">
@@ -177,9 +175,7 @@ const structuredData: StructuredData = {
 				<Image path="tokyu/sty/truck/3100_kaya3104.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 				<!-- 撮影日: 2010-07-21 -->
 			</div>
-			<figcaption class="c-caption -meta">
-				<span class="c-caption__title">加悦鉄道サハ3104</span>
-			</figcaption>
+			<figcaption class="c-caption -meta">加悦鉄道サハ3104</figcaption>
 		</figure>
 
 		<div class="p-text">
@@ -202,9 +198,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/KS33E_oigawa821.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2010-05-25 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">大井川鐵道スイテ82 1 金谷方</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">大井川鐵道スイテ82 1 金谷方</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -222,9 +216,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/sty/truck/DT21B_hokuriku7112.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 						<!-- 撮影日: 2007-03-31 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">北陸鉄道クハ7112 野町方</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">北陸鉄道クハ7112 野町方</figcaption>
 				</figure>
 
 				<div class="p-text">
@@ -240,9 +232,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/truck/FS342_hokuriku7102.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 							<!-- 撮影日: 2007-03-31 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">北陸鉄道モハ7102 鶴来方</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">北陸鉄道モハ7102 鶴来方</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -257,9 +247,7 @@ const structuredData: StructuredData = {
 								<Image path="tokyu/sty/truck/FS097_iyotetsu502.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 								<!-- 撮影日: 2008-10-19 -->
 							</div>
-							<figcaption class="c-caption -meta">
-								<span class="c-caption__title">伊予鉄道サハ502 横河原方</span>
-							</figcaption>
+							<figcaption class="c-caption -meta">伊予鉄道サハ502 横河原方</figcaption>
 						</figure>
 
 						<div class="p-text">
@@ -277,9 +265,7 @@ const structuredData: StructuredData = {
 									<Image path="tokyu/sty/truck/TR230_mani50-2186.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 									<!-- 撮影日: 2019-07-03 -->
 								</div>
-								<figcaption class="c-caption -meta">
-									<span class="c-caption__title">マニ50 2186</span>
-								</figcaption>
+								<figcaption class="c-caption -meta">マニ50 2186</figcaption>
 							</figure>
 
 							<div class="p-text">

--- a/astro/src/pages/tokyu/sty/truck_ts1000.astro
+++ b/astro/src/pages/tokyu/sty/truck_ts1000.astro
@@ -166,9 +166,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS1004_9208.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2016-10-23 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">デハ9208（3次車）上り方山側</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">デハ9208（3次車）上り方山側</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -193,9 +191,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS1005_9007.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2009-02-14 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">クハ9007（2次車）上り方山側</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">クハ9007（2次車）上り方山側</figcaption>
 			</figure>
 
 			<figure class="c-fit">
@@ -203,9 +199,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS1005_9109.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2011-10-09 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">クハ9109（3次車）上り方山側</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">クハ9109（3次車）上り方山側</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -227,9 +221,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/sty/truck/TS1006_1223.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 						<!-- 撮影日: 2009-06-17 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">デハ1223（4次車）上り方山側</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">デハ1223（4次車）上り方山側</figcaption>
 				</figure>
 
 				<div class="p-text">
@@ -245,9 +237,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/sty/truck/TS1006A_1362.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 						<!-- 撮影日: 2006-04-09 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">デハ1362（3次車）上り方山側</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">デハ1362（3次車）上り方山側</figcaption>
 				</figure>
 
 				<div class="p-text">
@@ -265,18 +255,14 @@ const structuredData: StructuredData = {
 								<Image path="tokyu/sty/truck/TS1007_1101.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 								<!-- 撮影日: 2009-03-01 -->
 							</div>
-							<figcaption class="c-caption -meta">
-								<span class="c-caption__title">クハ1101（1次車）上り方山側</span>
-							</figcaption>
+							<figcaption class="c-caption -meta">クハ1101（1次車）上り方山側</figcaption>
 						</figure>
 						<figure class="c-fit">
 							<div class="p-embed -border">
 								<Image path="tokyu/sty/truck/TS1007_1015.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 								<!-- 撮影日: 2006-03-03 -->
 							</div>
-							<figcaption class="c-caption -meta">
-								<span class="c-caption__title">クハ1015（4次車）上り方海側</span>
-							</figcaption>
+							<figcaption class="c-caption -meta">クハ1015（4次車）上り方海側</figcaption>
 						</figure>
 
 						<div class="p-text">
@@ -299,9 +285,7 @@ const structuredData: StructuredData = {
 									<Image path="tokyu/sty/truck/TS1010_2453.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 									<!-- 撮影日: 2009-06-18 -->
 								</div>
-								<figcaption class="c-caption -meta">
-									<span class="c-caption__title">デハ2453（2次車）上り方山側</span>
-								</figcaption>
+								<figcaption class="c-caption -meta">デハ2453（2次車）上り方山側</figcaption>
 							</figure>
 
 							<div class="p-text">
@@ -322,9 +306,7 @@ const structuredData: StructuredData = {
 										<Image path="tokyu/sty/truck/TS1011_2101.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 										<!-- 撮影日: 2009-03-01 -->
 									</div>
-									<figcaption class="c-caption -meta">
-										<span class="c-caption__title">クハ2101（1次車）下り方海側</span>
-									</figcaption>
+									<figcaption class="c-caption -meta">クハ2101（1次車）下り方海側</figcaption>
 								</figure>
 
 								<figure class="c-fit">
@@ -332,9 +314,7 @@ const structuredData: StructuredData = {
 										<Image path="tokyu/sty/truck/TS1011_9022.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 										<!-- 撮影日: 2019-05-19 -->
 									</div>
-									<figcaption class="c-caption -meta">
-										<span class="c-caption__title">クハ9022（1次車）下り方山側</span>
-									</figcaption>
+									<figcaption class="c-caption -meta">クハ9022（1次車）下り方山側</figcaption>
 								</figure>
 
 								<div class="p-text">
@@ -355,9 +335,7 @@ const structuredData: StructuredData = {
 											<Image path="tokyu/sty/truck/TS1019_3404.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 											<!-- 撮影日: 2009-01-31 -->
 										</div>
-										<figcaption class="c-caption -meta">
-											<span class="c-caption__title">デハ3404（2次車）下り方海側</span>
-										</figcaption>
+										<figcaption class="c-caption -meta">デハ3404（2次車）下り方海側</figcaption>
 									</figure>
 
 									<div class="p-text">
@@ -381,9 +359,7 @@ const structuredData: StructuredData = {
 												<Image path="tokyu/sty/truck/TS1020_3104.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 												<!-- 撮影日: 2009-01-31 -->
 											</div>
-											<figcaption class="c-caption -meta">
-												<span class="c-caption__title">クハ3104（2次車）下り方海側</span>
-											</figcaption>
+											<figcaption class="c-caption -meta">クハ3104（2次車）下り方海側</figcaption>
 										</figure>
 
 										<div class="p-text">

--- a/astro/src/pages/tokyu/sty/truck_ts300.astro
+++ b/astro/src/pages/tokyu/sty/truck_ts300.astro
@@ -164,9 +164,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS301_kumamoto5102A.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2007-01-02 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">熊本電気鉄道モハ5102A 上熊本方（東急デハ5032 上り方）</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">熊本電気鉄道モハ5102A 上熊本方（東急デハ5032 上り方）</figcaption>
 			</figure>
 
 			<figure class="c-fit">
@@ -174,9 +172,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS301_kumamoto5101A.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2007-01-02 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">熊本電気鉄道モハ5101A 上熊本方（東急デハ5031 上り方）</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">熊本電気鉄道モハ5101A 上熊本方（東急デハ5031 上り方）</figcaption>
 			</figure>
 
 			<figure class="c-fit">
@@ -184,9 +180,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS301_gakunan5002.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2005-11-15 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">岳南鉄道モハ5002 岳南江尾方（東急デハ5028 下り方）</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">岳南鉄道モハ5002 岳南江尾方（東急デハ5028 下り方）</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -208,9 +202,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS301_ueda5251.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2007-05-05 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">上田交通クハ5251 別所温泉方（東急デハ5202 下り方）</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">上田交通クハ5251 別所温泉方（東急デハ5202 下り方）</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -279,9 +271,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/sty/truck/TS302_204.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 						<!-- 撮影日: 2009-02-01 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">デハ204 海側</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">デハ204 海側</figcaption>
 				</figure>
 
 				<div class="p-text">
@@ -305,18 +295,14 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/truck/TS315_konan6007_motor.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 							<!-- 撮影日: 2007-05-26 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">弘南鉄道デハ6007 大鰐温泉方（東急デハ6007 上り方）モーター側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">弘南鉄道デハ6007 大鰐温泉方（東急デハ6007 上り方）モーター側</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/truck/TS315_konan6007_gear.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 							<!-- 撮影日: 2007-05-26 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">弘南鉄道デハ6007 中央弘前方（東急デハ6007 下り方）・第1段歯車装置側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">弘南鉄道デハ6007 中央弘前方（東急デハ6007 下り方）・第1段歯車装置側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -336,9 +322,7 @@ const structuredData: StructuredData = {
 								<Image path="tokyu/sty/truck/TS332_307B.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 								<!-- 撮影日: 2009-02-28 -->
 							</div>
-							<figcaption class="c-caption -meta">
-								<span class="c-caption__title">デハ307B（2次車）上り方山側</span>
-							</figcaption>
+							<figcaption class="c-caption -meta">デハ307B（2次車）上り方山側</figcaption>
 						</figure>
 
 						<div class="p-text">
@@ -358,9 +342,7 @@ const structuredData: StructuredData = {
 								<Image path="tokyu/sty/truck/TS332T_305.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 								<!-- 撮影日: 2009-02-28 -->
 							</div>
-							<figcaption class="c-caption -meta">
-								<span class="c-caption__title">デハ305B―デハ305A（2次車）連接部山側</span>
-							</figcaption>
+							<figcaption class="c-caption -meta">デハ305B―デハ305A（2次車）連接部山側</figcaption>
 						</figure>
 
 						<div class="p-text">
@@ -384,9 +366,7 @@ const structuredData: StructuredData = {
 										<Image path="tokyu/sty/truck/TS333_7590.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 										<!-- 撮影日: 2009-01-20 -->
 									</div>
-									<figcaption class="c-caption -meta">
-										<span class="c-caption__title">サヤ7590 上り方山側</span>
-									</figcaption>
+									<figcaption class="c-caption -meta">サヤ7590 上り方山側</figcaption>
 								</figure>
 
 								<div class="p-text">
@@ -406,9 +386,7 @@ const structuredData: StructuredData = {
 											<Image path="tokyu/sty/truck/TS334_7590.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 											<!-- 撮影日: 2009-01-20 -->
 										</div>
-										<figcaption class="c-caption -meta">
-											<span class="c-caption__title">サヤ7590 車央部山側</span>
-										</figcaption>
+										<figcaption class="c-caption -meta">サヤ7590 車央部山側</figcaption>
 									</figure>
 
 									<div class="p-text">

--- a/astro/src/pages/tokyu/sty/truck_ts700.astro
+++ b/astro/src/pages/tokyu/sty/truck_ts700.astro
@@ -99,9 +99,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS701_mizuma7003.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2006-09-02 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">水間鉄道デハ7003 貝塚方（東急デハ7012 下り方）</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">水間鉄道デハ7003 貝塚方（東急デハ7012 下り方）</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -121,9 +119,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS701_fukushima7315.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2017-08-26 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">福島交通サハ7315 飯坂温泉方（東急デハ7134 上り方）</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">福島交通サハ7315 飯坂温泉方（東急デハ7134 上り方）</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -142,9 +138,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/sty/truck/TS708_ueda7551.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 						<!-- 撮影日: 2005-04-16 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">上田交通クハ7551 別所温泉方（東急クハ7551 下り方）</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">上田交通クハ7551 別所温泉方（東急クハ7551 下り方）</figcaption>
 				</figure>
 
 				<div class="p-text">

--- a/astro/src/pages/tokyu/sty/truck_ts800.astro
+++ b/astro/src/pages/tokyu/sty/truck_ts800.astro
@@ -212,18 +212,14 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS802_7200.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2009-01-20 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">デヤ7200（2次車）上り方山側</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">デヤ7200（2次車）上り方山側</figcaption>
 			</figure>
 			<figure class="c-fit">
 				<div class="p-embed -border">
 					<Image path="tokyu/sty/truck/TS802_toyohashi1856.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2009-01-10 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">豊橋鉄道モ1856 新豊橋方（東急デハ7401 下り方）</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">豊橋鉄道モ1856 新豊橋方（東急デハ7401 下り方）</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -243,9 +239,7 @@ const structuredData: StructuredData = {
 					<Image path="tokyu/sty/truck/TS802A_7290.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 					<!-- 撮影日: 2009-01-20 -->
 				</div>
-				<figcaption class="c-caption -meta">
-					<span class="c-caption__title">デヤ7290（2次車）上り方山側</span>
-				</figcaption>
+				<figcaption class="c-caption -meta">デヤ7290（2次車）上り方山側</figcaption>
 			</figure>
 
 			<div class="p-text">
@@ -473,9 +467,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/sty/truck/TS807M_8728.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 						<!-- 撮影日: 2009-10-23 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">デハ8728（8次車）上り方山側</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">デハ8728（8次車）上り方山側</figcaption>
 				</figure>
 
 				<div class="p-text">
@@ -492,9 +484,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/sty/truck/TS807A_8791.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 						<!-- 撮影日: 2009-10-23 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">デハ8791（18-1次車）上り方山側</span>
-					</figcaption>
+					<figcaption class="c-caption -meta">デハ8791（18-1次車）上り方山側</figcaption>
 				</figure>
 
 				<div class="p-text">
@@ -511,9 +501,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/truck/TS807B_8492.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 							<!-- 撮影日: 2008-09-06 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8492（13次車）下り方海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8492（13次車）下り方海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -534,9 +522,7 @@ const structuredData: StructuredData = {
 									<Image path="tokyu/sty/truck/TS815C-M_8918.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 									<!-- 撮影日: 2009-11-16 -->
 								</div>
-								<figcaption class="c-caption -meta">
-									<span class="c-caption__title">サハ8918（9-2次車）下り方山側</span>
-								</figcaption>
+								<figcaption class="c-caption -meta">サハ8918（9-2次車）下り方山側</figcaption>
 							</figure>
 
 							<figure class="c-fit">
@@ -544,9 +530,7 @@ const structuredData: StructuredData = {
 									<Image path="tokyu/sty/truck/TS815C-M_8904.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 									<!-- 撮影日: 2006-02-27 -->
 								</div>
-								<figcaption class="c-caption -meta">
-									<span class="c-caption__title">サハ8904（6次車）上り方山側</span>
-								</figcaption>
+								<figcaption class="c-caption -meta">サハ8904（6次車）上り方山側</figcaption>
 							</figure>
 
 							<div class="p-text">
@@ -564,9 +548,7 @@ const structuredData: StructuredData = {
 									<Image path="tokyu/sty/truck/TS815C-A_8935.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 									<!-- 撮影日: 2006-02-27 -->
 								</div>
-								<figcaption class="c-caption -meta">
-									<span class="c-caption__title">サハ8935（11-1次車）下り方山側</span>
-								</figcaption>
+								<figcaption class="c-caption -meta">サハ8935（11-1次車）下り方山側</figcaption>
 							</figure>
 
 							<div class="p-text">
@@ -582,9 +564,7 @@ const structuredData: StructuredData = {
 										<Image path="tokyu/sty/truck/TS815E_8093.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 										<!-- 撮影日: 2009-03-08 -->
 									</div>
-									<figcaption class="c-caption -meta">
-										<span class="c-caption__title">クハ8093（13次車）下り方山側</span>
-									</figcaption>
+									<figcaption class="c-caption -meta">クハ8093（13次車）下り方山側</figcaption>
 								</figure>
 
 								<div class="p-text">
@@ -599,9 +579,7 @@ const structuredData: StructuredData = {
 											<Image path="tokyu/sty/truck/TS815C_8978.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 											<!-- 撮影日: 2008-12-23 -->
 										</div>
-										<figcaption class="c-caption -meta">
-											<span class="c-caption__title">サハ8978（18-2次車）下り方海側</span>
-										</figcaption>
+										<figcaption class="c-caption -meta">サハ8978（18-2次車）下り方海側</figcaption>
 									</figure>
 
 									<div class="p-text">
@@ -617,9 +595,7 @@ const structuredData: StructuredData = {
 												<Image path="tokyu/sty/truck/TS815D_8097.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 												<!-- 撮影日: 2009-03-01 -->
 											</div>
-											<figcaption class="c-caption -meta">
-												<span class="c-caption__title">クハ8097（16-2次車）下り方山側</span>
-											</figcaption>
+											<figcaption class="c-caption -meta">クハ8097（16-2次車）下り方山側</figcaption>
 										</figure>
 
 										<div class="p-text">
@@ -637,9 +613,7 @@ const structuredData: StructuredData = {
 													<Image path="tokyu/sty/truck/TS815F_8020.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 													<!-- 撮影日: 2007-09-11 -->
 												</div>
-												<figcaption class="c-caption -meta">
-													<span class="c-caption__title">クハ8020（2次車）下り方山側</span>
-												</figcaption>
+												<figcaption class="c-caption -meta">クハ8020（2次車）下り方山側</figcaption>
 											</figure>
 
 											<div class="p-text">
@@ -659,9 +633,7 @@ const structuredData: StructuredData = {
 															<Image path="tokyu/sty/truck/TS831_7681.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 															<!-- 撮影日: 2010-05-07 -->
 														</div>
-														<figcaption class="c-caption -meta">
-															<span class="c-caption__title">デハ7681（1次車）上り方山側</span>
-														</figcaption>
+														<figcaption class="c-caption -meta">デハ7681（1次車）上り方山側</figcaption>
 													</figure>
 
 													<figure class="c-fit">
@@ -669,9 +641,7 @@ const structuredData: StructuredData = {
 															<Image path="tokyu/sty/truck/TS831_7673.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 															<!-- 撮影日: 2009-04-21 -->
 														</div>
-														<figcaption class="c-caption -meta">
-															<span class="c-caption__title">デハ7673（3次車）下り方海側</span>
-														</figcaption>
+														<figcaption class="c-caption -meta">デハ7673（3次車）下り方海側</figcaption>
 													</figure>
 
 													<div class="p-text">
@@ -691,9 +661,7 @@ const structuredData: StructuredData = {
 																<Image path="tokyu/sty/truck/TS832_7810.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 																<!-- 撮影日: 2006-03-03 -->
 															</div>
-															<figcaption class="c-caption -meta">
-																<span class="c-caption__title">デハ7810（3次車）下り方海側</span>
-															</figcaption>
+															<figcaption class="c-caption -meta">デハ7810（3次車）下り方海側</figcaption>
 														</figure>
 
 														<figure class="c-fit">
@@ -701,9 +669,7 @@ const structuredData: StructuredData = {
 																<Image path="tokyu/sty/truck/TS832_towada7703.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 																<!-- 撮影日: 2009-04-23 -->
 															</div>
-															<figcaption class="c-caption -meta">
-																<span class="c-caption__title">十和田観光電鉄モハ7703 三沢方（東急デハ7711 下り方）</span>
-															</figcaption>
+															<figcaption class="c-caption -meta">十和田観光電鉄モハ7703 三沢方（東急デハ7711 下り方）</figcaption>
 														</figure>
 
 														<div class="p-text">
@@ -726,9 +692,7 @@ const structuredData: StructuredData = {
 																	<Image path="tokyu/sty/truck/TS835_7907.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 																	<!-- 撮影日: 2009-07-09 -->
 																</div>
-																<figcaption class="c-caption -meta">
-																	<span class="c-caption__title">クハ7907（3次車）下り方山側</span>
-																</figcaption>
+																<figcaption class="c-caption -meta">クハ7907（3次車）下り方山側</figcaption>
 															</figure>
 
 															<figure class="c-fit">
@@ -736,9 +700,7 @@ const structuredData: StructuredData = {
 																	<Image path="tokyu/sty/truck/TS835_7915.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 																	<!-- 撮影日: 2008-02-26 -->
 																</div>
-																<figcaption class="c-caption -meta">
-																	<span class="c-caption__title">クハ7915（5次車）上り方海側</span>
-																</figcaption>
+																<figcaption class="c-caption -meta">クハ7915（5次車）上り方海側</figcaption>
 															</figure>
 
 															<div class="p-text">
@@ -763,9 +725,7 @@ const structuredData: StructuredData = {
 																		<Image path="tokyu/sty/truck/TS839_7601.jpg" alt="写真拡大" width={1022} height={341} quality={80} link={true} />
 																		<!-- 撮影日: 2009-08-19 -->
 																	</div>
-																	<figcaption class="c-caption -meta">
-																		<span class="c-caption__title">クハ7601（1次車）下り方山側</span>
-																	</figcaption>
+																	<figcaption class="c-caption -meta">クハ7601（1次車）下り方山側</figcaption>
 																</figure>
 
 																<div class="p-text">

--- a/astro/src/pages/tokyu/sty/ub_1000n.astro
+++ b/astro/src/pages/tokyu/sty/ub_1000n.astro
@@ -42,9 +42,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1200Ns.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1212海側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1212海側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -61,9 +59,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1200Nm.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-02 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1213山側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1213山側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -87,9 +83,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1310Ns.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1313海側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1313海側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -106,9 +100,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1310Nm.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1313山側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1313山側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -132,9 +124,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1000Ns.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1012海側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1012海側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -151,9 +141,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1000Nm.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1013山側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1013山側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -177,9 +165,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1200N-1000N_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1213 ｰ クハ1013海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1213 ｰ クハ1013海側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -187,9 +173,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1000N-1200N_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1013 ｰ デハ1213山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1013 ｰ デハ1213山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -202,18 +186,14 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1310N-1200N_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1313 ｰ デハ1212海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1313 ｰ デハ1212海側</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/ub/1200N-1310N_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1212 ｰ デハ1313山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1212 ｰ デハ1313山側</figcaption>
 					</figure>
 				</Section>
 			</div>

--- a/astro/src/pages/tokyu/sty/ub_1000n2.astro
+++ b/astro/src/pages/tokyu/sty/ub_1000n2.astro
@@ -41,9 +41,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1200N2s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1217海側（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1217海側（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -60,9 +58,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1200N2m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1217山側（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1217山側（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -86,9 +82,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1310N2s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1317海側（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1317海側（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -105,9 +99,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1310N2m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1317山側（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1317山側（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -131,9 +123,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1000N2s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1017海側（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1017海側（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -150,9 +140,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1000N2m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1017山側（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1017山側（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -176,9 +164,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1200N2-1000N2_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1223 ｰ クハ1023海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1223 ｰ クハ1023海側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -186,9 +172,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1000N2-1200N2_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1014 ｰ デハ1214山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1014 ｰ デハ1214山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -201,9 +185,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1310N2-1200N2_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1322 ｰ デハ1222海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1322 ｰ デハ1222海側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -211,9 +193,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1200N2-1310N2_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-02 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1222 ｰ デハ1322山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1222 ｰ デハ1322山側</figcaption>
 					</figure>
 				</Section>
 			</div>

--- a/astro/src/pages/tokyu/sty/ub_1500.astro
+++ b/astro/src/pages/tokyu/sty/ub_1500.astro
@@ -41,9 +41,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1500_sea.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1501海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1501海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -60,9 +58,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1500_mount.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1501山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1501山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -86,9 +82,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1600_sea.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1601海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1601海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -105,9 +99,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1600_mount.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1601山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1601山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -131,9 +123,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1724_sea.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1724海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1724海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -150,9 +140,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1724_mount.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1724山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1724山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -176,9 +164,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1524_sea.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1524海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1524海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -195,9 +181,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1524_mount.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1524山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1524山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -221,9 +205,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1700_sea.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1701海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1701海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -240,9 +222,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/1700_mount.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 2019-04-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ1701山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ1701山側</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/ub_7600.astro
+++ b/astro/src/pages/tokyu/sty/ub_7600.astro
@@ -41,9 +41,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7650s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7662海側（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7662海側（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -60,9 +58,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7650m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7662山側（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7662山側（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -86,9 +82,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7670s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7682海側（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7682海側（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -105,9 +99,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7670m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7682山側（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7682山側（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -131,9 +123,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7600s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7602海側（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7602海側（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -150,9 +140,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7600m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7602山側（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7602山側（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -176,9 +164,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7670-7600_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7681 ｰ クハ7601海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7681 ｰ クハ7601海側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -186,9 +172,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7600-7670_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7601 ｰ デハ7681山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7601 ｰ デハ7681山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -201,9 +185,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7673-7603_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7673 ｰ クハ7603海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7673 ｰ クハ7603海側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -211,9 +193,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7603-7673_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7603 ｰ デハ7673山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7603 ｰ デハ7673山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -226,18 +206,14 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7650-7670_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7662 ｰ デハ7682海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7662 ｰ デハ7682海側</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/ub/7670-7650_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7681 ｰ デハ7661山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7681 ｰ デハ7661山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -250,18 +226,14 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7653-7673_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7653 ｰ デハ7673海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7653 ｰ デハ7673海側</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/ub/7673-7653_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7673 ｰ デハ7653山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7673 ｰ デハ7653山側</figcaption>
 					</figure>
 				</Section>
 			</div>

--- a/astro/src/pages/tokyu/sty/ub_7700.astro
+++ b/astro/src/pages/tokyu/sty/ub_7700.astro
@@ -41,9 +41,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7700s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7710海側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7710海側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -61,9 +59,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7700m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7706山側（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7706山側（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -88,9 +84,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7800s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7806海側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7806海側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -108,9 +102,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7800m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7810山側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7810山側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -135,9 +127,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7900s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7906海側（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7906海側（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -156,9 +146,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7900m.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7906山側（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7906山側（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -182,9 +170,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7900TDKs.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7910海側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7910海側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -202,9 +188,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7900TDKm.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7910山側（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7910山側（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -228,9 +212,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7700-7800_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7701 ｰ デハ7801海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7701 ｰ デハ7801海側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -238,9 +220,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7800-7700_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-09 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7807 ｰ デハ7707山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7807 ｰ デハ7707山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -253,9 +233,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7800-7900_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-02 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7806 ｰ クハ7906海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7806 ｰ クハ7906海側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -263,9 +241,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7900-7800_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-02 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7906 ｰ デハ7806山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7906 ｰ デハ7806山側</figcaption>
 					</figure>
 				</Section>
 			</div>

--- a/astro/src/pages/tokyu/sty/ub_7700n.astro
+++ b/astro/src/pages/tokyu/sty/ub_7700n.astro
@@ -41,9 +41,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7700Ns.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7715海側（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7715海側（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -60,9 +58,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7700Nm.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7715山側（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7715山側（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -86,9 +82,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7800Ns.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7815海側（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7815海側（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -105,9 +99,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7800Nm.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7815山側（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7815山側（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -131,9 +123,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7900Ns.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7915海側（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7915海側（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -150,9 +140,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7900Nm.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2008-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7915山側（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7915山側（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -176,9 +164,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7700N-7800N_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-04-12 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7715 ｰ デハ7815海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7715 ｰ デハ7815海側</figcaption>
 					</figure>
 
 					<figure class="c-fit">
@@ -186,9 +172,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7800N-7700N_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7815 ｰ デハ7715山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7815 ｰ デハ7715山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -201,18 +185,14 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7800N-7900N_sea.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-04-12 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7815 ｰ クハ7915海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7815 ｰ クハ7915海側</figcaption>
 					</figure>
 					<figure class="c-fit">
 						<div class="p-embed -border">
 							<Image path="tokyu/sty/ub/7900N-7800N_mount.jpg" alt="写真拡大" width={485} height={243} quality={60} link={true} />
 							<!-- 撮影日: 2008-02-17 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7915 ｰ デハ7815山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7915 ｰ デハ7815山側</figcaption>
 					</figure>
 				</Section>
 			</div>

--- a/astro/src/pages/tokyu/sty/ub_7900_m.astro
+++ b/astro/src/pages/tokyu/sty/ub_7900_m.astro
@@ -43,9 +43,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7901m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7901（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7901（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -62,9 +60,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7902m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7902（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7902（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -81,9 +77,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7903m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7903（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7903（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -100,9 +94,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7905m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-04-12 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7905（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7905（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -119,9 +111,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7906m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7906（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7906（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -138,9 +128,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7907m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7907（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7907（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -157,9 +145,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7908m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-04-05 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7908（2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7908（2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -176,9 +162,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7910m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7910（3次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7910（3次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -202,9 +186,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7912m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7912（4次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7912（4次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -221,9 +203,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7913m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-23 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7913（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7913（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -240,9 +220,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7914m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-08 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7914（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7914（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -266,9 +244,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/7915m.jpg" alt="写真拡大" width={485} height={122} quality={60} link={true} />
 							<!-- 撮影日: 2008-03-23 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">クハ7915（5次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">クハ7915（5次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/ub_8290.astro
+++ b/astro/src/pages/tokyu/sty/ub_8290.astro
@@ -42,9 +42,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8290s-BS33.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2005-05-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8294海側（13次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8294海側（13次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -61,9 +59,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8290m-BS33.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2007-09-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8284山側（16-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8284山側（16-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -80,9 +76,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/IC3C.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2007-08-18 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8495 ｰ デハ8280山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8495 ｰ デハ8280山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -106,9 +100,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8290s-INV104.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2005-05-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8282海側（16-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8282海側（16-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -125,9 +117,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8290m-INV104.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2007-10-13 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8296山側（13次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8296山側（13次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -144,9 +134,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/IC3C-fo.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2007-04-15 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8496 ｰ デハ8282山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8496 ｰ デハ8282山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -170,9 +158,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8290s-INV153.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2005-05-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8298海側（16-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8298海側（16-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -190,9 +176,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/IC3C-rem.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2007-05-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8494 ｰ デハ8298山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8494 ｰ デハ8298山側</figcaption>
 					</figure>
 				</Section>
 			</div>
@@ -212,9 +196,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8200s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2005-05-01 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8203海側（1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8203海側（1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/ub_8800.astro
+++ b/astro/src/pages/tokyu/sty/ub_8800.astro
@@ -42,9 +42,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8800s-7.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2010-01-11 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8816海側（7-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8816海側（7-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -62,9 +60,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8800s-14.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2010-01-11 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8862海側（14-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8862海側（14-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -89,9 +85,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8800s-cpremove10.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2009-10-23 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8835海側（10-1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8835海側（10-1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -109,9 +103,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8800s-cpremove13.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2010-01-20 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8850海側（14-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8850海側（14-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -128,9 +120,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8800s-BTtransfer.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2009-11-24 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8897海側（18-1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8897海側（18-1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -148,9 +138,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8800s-frame.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2009-11-27 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8849海側（14-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8849海側（14-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -174,9 +162,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8800s-20G.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2009-12-10 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ0808海側（19-1次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ0808海側（19-1次車）</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -201,9 +187,7 @@ const structuredData: StructuredData = {
 							<Image path="tokyu/sty/ub/8290s.jpg" alt="写真拡大" width={485} height={152} quality={60} link={true} />
 							<!-- 撮影日: 2009-11-29 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8283海側（16-2次車）</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8283海側（16-2次車）</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/sty/usl.astro
+++ b/astro/src/pages/tokyu/sty/usl.astro
@@ -37,9 +37,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/usl/7200_OLR1.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-09-16 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ7662（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ7662（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -56,9 +54,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/usl/7200_OLR2.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-09-07 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デヤ7200（2次車）海側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デヤ7200（2次車）海側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -82,9 +78,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/usl/8500_side-lamp.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-08-13 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ8591（20次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ8591（20次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -111,9 +105,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/usl/9000_side-lamp-4.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-10-21 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">デハ1218（4次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">デハ1218（4次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">
@@ -130,9 +122,7 @@ const slugger = new GithubSlugger();
 							<Image path="tokyu/sty/usl/9000_side-lamp-3.jpg" alt="写真拡大" width={485} height={364} quality={60} link={true} />
 							<!-- 撮影日: 2006-08-19 -->
 						</div>
-						<figcaption class="c-caption -meta">
-							<span class="c-caption__title">サハ9706（2次車）山側</span>
-						</figcaption>
+						<figcaption class="c-caption -meta">サハ9706（2次車）山側</figcaption>
 					</figure>
 
 					<div class="p-text">

--- a/astro/src/pages/tokyu/yomoyama/ca105.astro
+++ b/astro/src/pages/tokyu/yomoyama/ca105.astro
@@ -34,9 +34,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/ca105/CA105_kumamoto.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2009-05-30 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">CA-105 （熊本電気鉄道モハ5101A）</span>
-					</figcaption>
+					<figcaption class="c-caption">CA-105（熊本電気鉄道モハ5101A）</figcaption>
 				</figure>
 			</div>
 			<div class="c-grid__item">
@@ -45,9 +43,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/ca105/CA105_mizuma.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2007-06-24 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">CA-105 （水間鉄道デハ7003）</span>
-					</figcaption>
+					<figcaption class="c-caption">CA-105（水間鉄道デハ7003）</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -68,9 +64,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/ca105/mizuma_7003.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2007-10-20 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">水間鉄道デハ7003</span>
-					</figcaption>
+					<figcaption class="c-caption">水間鉄道デハ7003</figcaption>
 				</figure>
 			</div>
 		</div>

--- a/astro/src/pages/tokyu/yomoyama/echizen_mc1101.astro
+++ b/astro/src/pages/tokyu/yomoyama/echizen_mc1101.astro
@@ -38,9 +38,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/echizen_mc1101/MC1102.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2009-07-20 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">えちぜん鉄道MC1102</span>
-					</figcaption>
+					<figcaption class="c-caption">えちぜん鉄道MC1102</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -54,9 +52,7 @@ const structuredData: StructuredData = {
 			<blockquote class="p-quote">
 				<p>車両近代化の一環として，1500V昇圧によって廃車となった豊橋鉄道モハ1900形から発生したDT-21中空カルダン式台車と，クーラー3基（合計10,500Kcal）を利用して新性能化が計画され，2000年(平成12年)4月11日深夜に川崎重工へ陸送．改造工事終了後の同年7月2日早朝に福井へ帰着した．</p>
 			</blockquote>
-			<figcaption class="c-caption -meta">
-				<cite>【現有私鉄概説】京福電気鉄道福井鉄道部</cite>（岡本英志）<br />鉄道ピクトリアルNo.701・2001年5月臨時増刊号
-			</figcaption>
+			<figcaption class="c-caption -meta">鉄道ピクトリアル 2001年5月臨時増刊号（No.701）<cite>【現有私鉄概説】京福電気鉄道福井鉄道部</cite>（岡本英志）</figcaption>
 		</figure>
 
 		<ul class="p-notes">
@@ -71,9 +67,7 @@ const structuredData: StructuredData = {
 			<blockquote class="p-quote">
 				<p>新製・廃車はないが，改造ではモハ1101形1101・1102の冷房化，高性能化が施工され1998年7月17日に竣功している．これに伴い台車は日車D-18から川車DT-21に，電動機はTDK-528/9-HMから東洋MT-46Aに，制御器は東洋ES-519Bから日立MMC-H-10Kに変更された．</p>
 			</blockquote>
-			<figcaption class="c-caption -meta">
-				<cite>各社別車両情勢</cite>（藤井信夫・大幡哲海・岸上明彦）<br />鉄道ピクトリアルNo.676・1999年10月臨時増刊号
-			</figcaption>
+			<figcaption class="c-caption -meta">鉄道ピクトリアル 1999年10月臨時増刊号（No.676）<cite>各社別車両情勢</cite>（藤井信夫・大幡哲海・岸上明彦）</figcaption>
 		</figure>
 
 		<div class="p-text">
@@ -92,9 +86,7 @@ const structuredData: StructuredData = {
 			<blockquote class="p-quote">
 				<p>この車は，本年3月に新車5300系に台車・モータを譲って廃車になった名鉄モ5205・5206の車体を購入し，自社高師工場で国鉄101系の台車・モータ（DT21・MT42），名鉄3880系〔元東急3600系〕の制御器・パンタグラフ（MMC-H-10・PT42）と南海の600V時代のMG，他予備品の床下機器に三菱電機製の架線電源（DC600V）を，三相交流（AC200V）に変えるインバータとクーラを組み合わせた，DA空調システムにより，冷房車化したものである．</p>
 			</blockquote>
-			<figcaption class="c-caption -meta">
-				<cite>豊橋鉄道に冷房車登場</cite>（神沢順）<br />鉄道ファンNo.307・1986年11月号
-			</figcaption>
+			<figcaption class="c-caption -meta">鉄道ファン 1986年11月号（No.307）<cite>豊橋鉄道に冷房車登場</cite>（神沢順）</figcaption>
 		</figure>
 
 		<ul class="p-notes">
@@ -105,9 +97,7 @@ const structuredData: StructuredData = {
 			<blockquote class="p-quote">
 				<p>制御装置は従来の釣掛車との総括制御を考慮し，名鉄3880系（元東急3700系）に使用されていた電動カム軸式MMC-H-10Gが採用されている。</p>
 			</blockquote>
-			<figcaption class="c-caption -meta">
-				<cite>豊橋鉄道1900系</cite>（鉄道ピクトリアル編集部）<br />鉄道ピクトリアルNo.480・1987年5月臨時増刊号
-			</figcaption>
+			<figcaption class="c-caption -meta">鉄道ピクトリアル 1987年5月臨時増刊号（No.480）<cite>豊橋鉄道1900系</cite>（鉄道ピクトリアル編集部）</figcaption>
 		</figure>
 
 		<div class="p-text">
@@ -120,15 +110,13 @@ const structuredData: StructuredData = {
 					<div class="p-embed -border">
 						<Image path="tokyu/yomoyama/echizen_mc1101/toyohashi_1956.jpg" width={500} height={356} quality={60} />
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">豊橋鉄道モ1956</span>
-					</figcaption>
+					<figcaption class="c-caption">豊橋鉄道モ1956</figcaption>
 				</figure>
 			</div>
 		</div>
 
 		<ul class="p-notes">
-			<li>豊橋鉄道モ1956の写真は<LinkExternal href="http://js3vxw.cocolog-nifty.com/photos/toyohashi__600v/">JS3VXWの鉄道管理局</LinkExternal>より許可を得て転載。</li>
+			<li>豊橋鉄道モ1956の写真は <LinkExternal href="http://js3vxw.cocolog-nifty.com/photos/toyohashi__600v/">JS3VXWの鉄道管理局</LinkExternal>より許可を得て転載。</li>
 		</ul>
 	</Section>
 
@@ -146,9 +134,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/echizen_mc1101/ttm_MMC-H-10G.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2006-04-23 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">MMC-H-10G （電車とバスの博物館展示品）</span>
-					</figcaption>
+					<figcaption class="c-caption">MMC-H-10G（電車とバスの博物館展示品）</figcaption>
 				</figure>
 			</div>
 			<div class="c-grid__item">
@@ -157,9 +143,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/echizen_mc1101/MC1102_MMC-H-10K.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2009-07-20 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">MMC-H-10K （えちぜん鉄道MC1102）</span>
-					</figcaption>
+					<figcaption class="c-caption">MMC-H-10K（えちぜん鉄道MC1102）</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -172,9 +156,7 @@ const structuredData: StructuredData = {
 			<blockquote class="p-quote">
 				<p>主制御器はMMC-H-10G化，電動発電機もCLG-107形となって活躍したが，昭50〜55に全車両を名古屋鉄道へ譲渡した．</p>
 			</blockquote>
-			<figcaption class="c-caption -meta">
-				<cite>私鉄車両めぐり〔127〕</cite>（荻原俊夫）<br />鉄道ピクトリアルNo.442・1985年1月臨時増刊号
-			</figcaption>
+			<figcaption class="c-caption -meta">鉄道ピクトリアル 1985年1月臨時増刊号（No.442）<cite>私鉄車両めぐり〔127〕</cite>（荻原俊夫）</figcaption>
 		</figure>
 
 		<div class="p-text">
@@ -327,9 +309,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/echizen_mc1101/MC1102_MMC-H-10K_magnify.jpg" alt="写真拡大" width={500} height={375} quality={60} link={true} />
 						<!-- 撮影日: 2009-07-20 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">MC1102の主制御器、MCOS蓋拡大</span>
-					</figcaption>
+					<figcaption class="c-caption">MC1102の主制御器、MCOS蓋拡大</figcaption>
 				</figure>
 			</div>
 		</div>

--- a/astro/src/pages/tokyu/yomoyama/hsc.astro
+++ b/astro/src/pages/tokyu/yomoyama/hsc.astro
@@ -35,9 +35,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/hsc/HD23.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2009-05-12 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">HD23型ブレーキ制御装置（デヤ7200）</span>
-					</figcaption>
+					<figcaption class="c-caption">HD23型ブレーキ制御装置（デヤ7200）</figcaption>
 				</figure>
 			</div>
 			<div class="c-grid__item">
@@ -46,9 +44,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/hsc/GR3.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2009-06-09 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">参考比較: 旧7000系のブレーキ制御装置（福島交通デハ7111）</span>
-					</figcaption>
+					<figcaption class="c-caption">参考比較: 旧7000系のブレーキ制御装置（福島交通デハ7111）</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -73,9 +69,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/hsc/cocks.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2009-05-14 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">3本の空気管（デヤ7200）</span>
-					</figcaption>
+					<figcaption class="c-caption">3本の空気管（デヤ7200）</figcaption>
 				</figure>
 			</div>
 			<div class="c-grid__item">
@@ -84,9 +78,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/hsc/connect.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2008-01-04 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">空気管がすべて連結された様子（デヤ7200+デヤ7290）</span>
-					</figcaption>
+					<figcaption class="c-caption">空気管がすべて連結された様子（デヤ7200+デヤ7290）</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -110,9 +102,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/hsc/sakusei.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2003-02-23 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">デヤ7290+デハ7706-デハ7806-クハ7906+デヤ7200</span>
-					</figcaption>
+					<figcaption class="c-caption">デヤ7290+デハ7706-デハ7806-クハ7906+デヤ7200</figcaption>
 				</figure>
 			</div>
 		</div>
@@ -136,9 +126,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/hsc/konan_connect_m.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2009-09-07 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">空気管側連結部（弘南鉄道デハ7152+デハ7011）</span>
-					</figcaption>
+					<figcaption class="c-caption">空気管側連結部（弘南鉄道デハ7152+デハ7011）</figcaption>
 				</figure>
 			</div>
 			<div class="c-grid__item">
@@ -147,9 +135,7 @@ const structuredData: StructuredData = {
 						<Image path="tokyu/yomoyama/hsc/konan_connect_s.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 						<!-- 撮影日: 2009-04-24 -->
 					</div>
-					<figcaption class="c-caption -meta">
-						<span class="c-caption__title">電気栓側連結部（弘南鉄道デハ7011+デハ7153）</span>
-					</figcaption>
+					<figcaption class="c-caption">電気栓側連結部（弘南鉄道デハ7011+デハ7153）</figcaption>
 				</figure>
 			</div>
 		</div>

--- a/astro/src/pages/tokyu/yomoyama/ibaraki_6000.astro
+++ b/astro/src/pages/tokyu/yomoyama/ibaraki_6000.astro
@@ -38,7 +38,7 @@ const structuredData: StructuredData = {
 					<div class="p-embed -border">
 						<Image path="tokyu/yomoyama/ibaraki_6000/6201.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 					</div>
-					<figcaption class="c-caption -meta">
+					<figcaption class="c-caption">
 						デハ6201（撮影: 2009年5月<!-- 2009-05-03 -->）
 					</figcaption>
 				</figure>
@@ -48,7 +48,7 @@ const structuredData: StructuredData = {
 					<div class="p-embed -border">
 						<Image path="tokyu/yomoyama/ibaraki_6000/6201_surroundings.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 					</div>
-					<figcaption class="c-caption -meta">
+					<figcaption class="c-caption">
 						デハ6201が置かれている周辺（撮影: 2017年4月<!-- 2017-04-22 -->）
 					</figcaption>
 				</figure>
@@ -86,7 +86,7 @@ const structuredData: StructuredData = {
 					<div class="p-embed -border">
 						<Image path="tokyu/yomoyama/ibaraki_6000/6202.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 					</div>
-					<figcaption class="c-caption -meta">
+					<figcaption class="c-caption">
 						デハ6202（撮影: 2009年5月<!-- 2009-05-03 -->）
 					</figcaption>
 				</figure>
@@ -96,7 +96,7 @@ const structuredData: StructuredData = {
 					<div class="p-embed -border">
 						<Image path="tokyu/yomoyama/ibaraki_6000/6202_trace.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 					</div>
-					<figcaption class="c-caption -meta">
+					<figcaption class="c-caption">
 						デハ6202が置かれていた跡地（撮影: 2017年4月<!-- 2017-04-22 -->）
 					</figcaption>
 				</figure>
@@ -145,7 +145,7 @@ const structuredData: StructuredData = {
 					<div class="p-embed -border">
 						<Image path="tokyu/yomoyama/ibaraki_6000/6302_1.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 					</div>
-					<figcaption class="c-caption -meta">
+					<figcaption class="c-caption">
 						デハ6302 （1位側）（撮影: 2009年5月<!-- 2009-05-03 -->）
 					</figcaption>
 				</figure>
@@ -155,7 +155,7 @@ const structuredData: StructuredData = {
 					<div class="p-embed -border">
 						<Image path="tokyu/yomoyama/ibaraki_6000/6302_2.jpg" alt="写真拡大" width={500} height={333} quality={60} link={true} />
 					</div>
-					<figcaption class="c-caption -meta">
+					<figcaption class="c-caption">
 						デハ6302 （2位側）（撮影: 2009年5月<!-- 2009-05-03 -->）
 					</figcaption>
 				</figure>

--- a/astro/style/foundation/_elements.css
+++ b/astro/style/foundation/_elements.css
@@ -56,7 +56,7 @@ pre {
 	tab-size: 2;
 }
 
-:is(cite, em) {
+em {
 	&:lang(ja) {
 		font-weight: var(--font-weight-bold);
 	}
@@ -67,18 +67,18 @@ small {
 	font-weight: var(--font-weight-normal);
 }
 
-dfn {
+:is(cite, dfn) {
 	&::before {
-		content: var(--_dfn-open, "“");
+		content: var(--_open, "“");
 	}
 
 	&::after {
-		content: var(--_dfn-close, "”");
+		content: var(--_close, "”");
 	}
 
 	&:lang(ja) {
-		--_dfn-open: "「";
-		--_dfn-close: "」";
+		--_open: "「";
+		--_close: "」";
 	}
 }
 

--- a/astro/style/object/component/_grouping.css
+++ b/astro/style/object/component/_grouping.css
@@ -27,6 +27,7 @@ Styleguide 1.1.1
 
 	:is(figure)/* is() は PostCSS のビルドの都合 */ > &:first-child {
 		margin-block-end: 0.5em;
+		font-weight: var(--font-weight-bold);
 	}
 
 	:is(figure)/* is() は PostCSS のビルドの都合 */ > &:last-child {
@@ -38,8 +39,4 @@ Styleguide 1.1.1
 		margin-inline-start: auto;
 		padding-inline-start: 10%;
 	}
-}
-
-.c-caption__title {
-	font-weight: var(--font-weight-bold);
 }

--- a/astro/style/object/component/_text.css
+++ b/astro/style/object/component/_text.css
@@ -154,6 +154,24 @@ Styleguide 1.2.3
 }
 
 /*
+<cite> 要素のバリエーション
+
+Markup:
+<cite class="c-cite {{modifier_class}}"></cite>
+
+Styleguide 1.2.4
+*/
+.c-cite {
+	/* 作品名 */
+	&.-work {
+		&:lang(ja) {
+			--_open: "『";
+			--_close: "』";
+		}
+	}
+}
+
+/*
 コードハイライト
 
 <a href="https://github.com/highlightjs/highlight.js/blob/main/src/styles/github.css">Style Sample (github.css)</a>
@@ -161,7 +179,7 @@ Styleguide 1.2.3
 Markup:
 <span class="c-code-highlight {{modifier_class}}">&lt;a href=&quot;https://example.com/&quot;&gt;Link&lt;/a&gt;</span>
 
-Styleguide 1.2.4
+Styleguide 1.2.5
 */
 .c-code-highlight {
 	/* stylelint-disable selector-class-pattern */
@@ -281,7 +299,7 @@ Styleguide 1.2.4
 Markup:
 <sup class="c-footnote-ref"><a href="#fn1" id="nt1">[1]</a></sup>
 
-Styleguide 1.2.5
+Styleguide 1.2.6
 */
 .c-footnote-ref {
 	vertical-align: super;
@@ -321,7 +339,7 @@ Styleguide 1.2.5
 Markup:
 <a href="https://example.com/">リンク</a><small class="c-domain">(<code>example.com</code>)</small>
 
-Styleguide 1.2.6
+Styleguide 1.2.7
 */
 .c-domain {
 	--_font-size: calc(100% / var(--font-ratio-1));
@@ -354,7 +372,7 @@ Markup:
 .-tick - 肯定
 .-cross - 否定
 
-Styleguide 1.2.7
+Styleguide 1.2.8
 */
 .c-tac {
 	white-space: nowrap;


### PR DESCRIPTION
- `<cite>` 要素の中身に直接 「」 や 『』 を書くのを止め、CSS による表現とする
  - 太字表現は取り止め
  - `.c-cite.-work` を追加
- `.c-caption__title` を廃止し、`figure > .c-caption:first-child` を太字にすることで代用する
- メタ情報でもないのに `.-caption.-meta` としていた箇所を `.-caption` に変更
- `.-caption` 内で `<br/>` 改行していた箇所を除去
