### PR TITLE
JSON-LD の日付に時刻を追加

### DIFF
--- a/astro/src/+util/StructuredData.ts
+++ b/astro/src/+util/StructuredData.ts
@@ -52,7 +52,7 @@ export default class StructuredDataUtil {
 			webPage.set('breadcrumb', breadcrumbList);
 		}
 		if (structuredData.dateModified !== undefined) {
-			webPage.set('dateModified', structuredData.dateModified.format('YYYY-MM-DD'));
+			webPage.set('dateModified', structuredData.dateModified.format('YYYYMMDDTHHmm'));
 		}
 		webPage.set('headline', structuredData.title);
 		if (structuredData.description !== undefined) {


### PR DESCRIPTION
ISO 8601 では日付のみで問題ないが、Google Search Console では時刻を含めないと「重大ではない問題」として警告される。

[リッチリザルト テスト](https://search.google.com/test/rich-results)での結果は以下のとおり。

- 🆖 `20240101`
- 🆖 `2024-01-01`
- 🆗 `20240101T0000`
- 🆗 `2024-01-01T00:00`