### PR TITLE
「東急電車よもやま話」のインデックスページ改修

### DIFF
--- a/astro/src/layouts/include/PageHeaderTokyu.astro
+++ b/astro/src/layouts/include/PageHeaderTokyu.astro
@@ -51,7 +51,7 @@ const { pagePath, top = false } = Astro.props;
 					[
 						{ path: '/tokyu/data/', name: '車両データ' },
 						{ path: '/tokyu/sty/', name: '車両形態' },
-						{ path: '/tokyu/yomoyama/', name: '車両よもやま' },
+						{ path: '/tokyu/yomoyama/', name: 'よもやま話' },
 						{ path: '/tokyu/an/', name: '自動放送' },
 						{ path: '/tokyu/set/', name: '設定器' },
 						{ path: '/tokyu/book/', name: '鉄道本執筆' },

--- a/astro/src/pages/tokyu/yomoyama/index.astro
+++ b/astro/src/pages/tokyu/yomoyama/index.astro
@@ -2,8 +2,6 @@
 import dayjs from 'dayjs';
 import Layout from '@layouts/Tokyu.astro';
 import Image from '@components/Image.astro';
-import H from '@components/H.astro';
-import Section from '@components/Section.astro';
 import type { StructuredData } from '@type/types.js';
 
 const structuredData: StructuredData = {
@@ -11,83 +9,67 @@ const structuredData: StructuredData = {
 	title: '東急電車よもやま話',
 	heading: 'よもやま話',
 	dateModified: dayjs('2018-12-23'),
-	description: '東急電鉄の車両や車両機器に関するよもやま話です。',
+	description: '東急電鉄の車両に関するよもやま話です。',
 	breadcrumb: [{ path: '/tokyu/', name: '東急電車資料室' }],
 };
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData} toc={false}>
-	<Section id="yomoyama">
-		<H slot="heading">車両よもやま</H>
-
-		<ul class="c-grid -wide">
-			<li class="c-grid__item">
-				<div class="p-item">
-					<a href="8637">
-						<Image path="tokyu/yomoyama/8637/1998_balloon.jpg" width={180} height={126} quality={60} class="p-item__image" />
-						<span class="p-item__title">8637F の装飾移り変わり</span>
-					</a>
-					<div class="p-item__text">
-						<p>装飾の変遷や編成替えの記録を紹介します。</p>
-					</div>
+	<ul class="c-grid">
+		<li class="c-grid__item">
+			<div class="p-item">
+				<a href="8637">
+					<Image path="tokyu/yomoyama/8637/1998_balloon.jpg" width={180} height={126} quality={60} class="p-item__image" />
+					<span class="p-item__title">8637F の装飾移り変わり</span>
+				</a>
+				<div class="p-item__text">
+					<p>装飾の変遷や編成替えの記録を紹介します。</p>
 				</div>
-			</li>
-			<li class="c-grid__item">
-				<div class="p-item">
-					<a href="echizen_mc1101">
-						<Image path="tokyu/yomoyama/echizen_mc1101/MC1102.jpg" width={180} height={126} quality={60} class="p-item__image" />
-						<span class="p-item__title">えちぜん鉄道MC1101形の主制御器<small>（MMC-H-10K 型）</small></span>
-					</a>
-					<div class="p-item__text">
-						<p>えちぜん鉄道MC1101形の主制御器は、元をたどれば東急・旧3000系グループで使われていたものです。</p>
-					</div>
+			</div>
+		</li>
+		<li class="c-grid__item">
+			<div class="p-item">
+				<a href="echizen_mc1101">
+					<Image path="tokyu/yomoyama/echizen_mc1101/MC1102.jpg" width={180} height={126} quality={60} class="p-item__image" />
+					<span class="p-item__title">えちぜん鉄道MC1101形の主制御器<small>（MMC-H-10K 型）</small></span>
+				</a>
+				<div class="p-item__text">
+					<p>えちぜん鉄道MC1101形の主制御器は、元をたどれば東急・旧3000系グループで使われていたものです。</p>
 				</div>
-			</li>
-		</ul>
-	</Section>
-	<Section id="imanao">
-		<H slot="heading">“今なお現役” 的なもの</H>
-
-		<ul class="c-grid -wide">
-			<li class="c-grid__item">
-				<div class="p-item">
-					<a href="hsc">
-						<Image path="tokyu/yomoyama/hsc/sakusei.jpg" width={180} height={126} quality={60} class="p-item__image" />
-						<span class="p-item__title">HSC 電磁直通ブレーキ</span>
-					</a>
-					<div class="p-item__text">
-						<p>東急では最後のHSCブレーキ搭載車となったデヤ7200、デヤ7290と、弘南鉄道黒石駅で平日朝に行われている増解結作業を紹介します。</p>
-					</div>
+			</div>
+		</li>
+		<li class="c-grid__item">
+			<div class="p-item">
+				<a href="ibaraki_6000">
+					<Image path="tokyu/yomoyama/ibaraki_6000/6201.jpg" width={180} height={126} quality={60} class="p-item__image" />
+					<span class="p-item__title">茨城県の旧6000系廃車体</span>
+				</a>
+				<div class="p-item__text">
+					<p>茨城県各所で倉庫や店舗などに活用されていた旧6000系を訪ねました。</p>
 				</div>
-			</li>
-			<li class="c-grid__item">
-				<div class="p-item">
-					<a href="ca105">
-						<Image path="tokyu/yomoyama/ca105/mizuma_7003.jpg" width={180} height={126} quality={60} class="p-item__image" />
-						<span class="p-item__title">CA-105 型　放送装置</span>
-					</a>
-					<div class="p-item__text">
-						<p>水間鉄道と熊本電気鉄道に残るテープ式の放送装置を紹介します。</p>
-					</div>
+			</div>
+		</li>
+		<li class="c-grid__item">
+			<div class="p-item">
+				<a href="hsc">
+					<Image path="tokyu/yomoyama/hsc/sakusei.jpg" width={180} height={126} quality={60} class="p-item__image" />
+					<span class="p-item__title">HSC 電磁直通ブレーキ</span>
+				</a>
+				<div class="p-item__text">
+					<p>東急では最後のHSCブレーキ搭載車となったデヤ7200、デヤ7290と、弘南鉄道黒石駅で平日朝に行われている増解結作業を紹介します。</p>
 				</div>
-			</li>
-		</ul>
-	</Section>
-	<Section id="preserve">
-		<H slot="heading">保存車</H>
-
-		<ul class="c-grid -wide">
-			<li class="c-grid__item">
-				<div class="p-item">
-					<a href="ibaraki_6000">
-						<Image path="tokyu/yomoyama/ibaraki_6000/6201.jpg" width={180} height={126} quality={60} class="p-item__image" />
-						<span class="p-item__title">茨城県の旧6000系廃車体</span>
-					</a>
-					<div class="p-item__text">
-						<p>茨城県各所で倉庫や店舗などに活用されていた旧6000系を訪ねました。</p>
-					</div>
+			</div>
+		</li>
+		<li class="c-grid__item">
+			<div class="p-item">
+				<a href="ca105">
+					<Image path="tokyu/yomoyama/ca105/mizuma_7003.jpg" width={180} height={126} quality={60} class="p-item__image" />
+					<span class="p-item__title">CA-105 型　放送装置</span>
+				</a>
+				<div class="p-item__text">
+					<p>水間鉄道と熊本電気鉄道に残るテープ式の放送装置を紹介します。</p>
 				</div>
-			</li>
-		</ul>
-	</Section>
+			</div>
+		</li>
+	</ul>
 </Layout>


### PR DESCRIPTION
- グロナビのページ名表記変更
- ページ数減少に伴い `<h2>` セクション廃止