### PR TITLE
リンクリストのコンポーネントでフォントサイズを大きくしているのを止める

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -28,7 +28,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">漫画</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/kumeta/manga/list">作品リスト</a><small>（1988年〜）</small></li>
 							<li><a href="/kumeta/manga/subtitle">連載作品サブタイトル</a><small>（1991年〜）</small></li>
 							<li><a href="/kumeta/manga/color">本誌カラー掲載回</a><small>（1991年〜）</small></li>
@@ -42,7 +42,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">メディア紹介</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/kumeta/library/manga">漫画雑誌</a><small>（1979年〜）</small></li>
 							<li><a href="/kumeta/library/book">図書、一般雑誌</a><small>（1993年〜）</small></li>
 							<li><a href="/kumeta/library/newspaper">新聞</a><small>（2006年〜）</small></li>
@@ -54,7 +54,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">アニメ</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/kumeta/anime/zetsubou/diff">『さよなら絶望先生』放送版とパッケージ版の比較</a></li>
 							<li><a>『かくしごと』放送版とパッケージ版の比較</a></li>
 							<li><a href="/kumeta/anime/kakushigoto/storyboard">『劇場編集版　かくしごと』絵コンテ検証</a></li>
@@ -65,7 +65,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">久米田先生</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a>年表</a><small>（1988年〜）</small></li>
 							<li><a>イベント登壇、サイン会</a><small>（1992年〜）</small></li>
 							<li><a href="/kumeta/kumeta/interview">インタビュー</a><small>（1996年〜）</small></li>
@@ -78,7 +78,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">よもやま</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/kumeta/yomoyama/mangaka">“近所の売れないまんが家” 登場履歴</a><small>（1991年〜）</small></li>
 							<li><a href="/kumeta/yomoyama/kuigaten">「悔画展」収録イラスト一覧</a><small>（2016年）</small></li>
 							<li><a href="/kumeta/yomoyama/zensarashi_slideshow">「全曝し展」の様子</a><small>（2021年）</small></li>
@@ -91,7 +91,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">最新ニュース</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="https://calendar.google.com/calendar/u/0/embed?src=udi6d8s0b41c10iesq8iovb2c8@group.calendar.google.com">久米田康治カレンダー</a><small>（Google カレンダー）</small></li>
 							<li><a href="https://discord.gg/3G4kchxRgk">久米田康治情報</a><small>（Discord）</small></li>
 						</ul>

--- a/astro/src/pages/madoka/index.astro
+++ b/astro/src/pages/madoka/index.astro
@@ -28,7 +28,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">映像</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/madoka/video/connect">「コネクト」映像バリエーション</a></li>
 							<li><a href="/madoka/video/zenpen">[前編] 始まりの物語　上映版とパッケージ版の比較</a></li>
 							<li><a href="/madoka/video/kouhen">[後編] 永遠の物語　上映版とパッケージ版の比較</a></li>
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">メディア紹介</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/madoka/library/book">図書</a><small>（2011年〜2019年）</small></li>
 							<li><a href="/madoka/library/magazine">雑誌</a><small>（2010年〜2021年）</small></li>
 							<li><a href="/madoka/library/newspaper">新聞</a><small>（2011年〜2019年）</small></li>
@@ -53,7 +53,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">イベント</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/madoka/event/event">まどか☆マギカ展</a><small>（2011年〜2014年）</small></li>
 							<li><a href="/madoka/event/genga">まどか☆マギカ複製原画展</a><small>（2013年）</small></li>
 							<li><a href="/madoka/event/shop">まどか☆マギカショップ</a><small>（2012年〜2015年）</small></li>
@@ -69,7 +69,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">よもやま</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/madoka/yomoyama/official_news">公式サイトニュース一覧</a></li>
 							<li><a href="/madoka/yomoyama/commentary">オーディオコメンタリー</a></li>
 							<li><a href="/madoka/yomoyama/umeten_guide">蒼樹うめ展　音声ガイド</a></li>
@@ -84,7 +84,7 @@ const slugger = new GithubSlugger();
 					<Section slugger={slugger} depth={2} headingType="b">
 						<H slot="heading">同人誌</H>
 
-						<ul class="p-links">
+						<ul class="p-links -index">
 							<li><a href="/madoka/dojin/pictorial6">[新編]叛逆の物語　上映版とパッケージ版の比較</a></li>
 							<li><a href="/madoka/dojin/pictorial7">TVシリーズ　放送版とパッケージ版の比較</a></li>
 							<li><a href="/madoka/dojin/pictorial8">まどか☆マギカ映像比較講義録</a></li>

--- a/astro/src/pages/madoka/yomoyama/commentary.astro
+++ b/astro/src/pages/madoka/yomoyama/commentary.astro
@@ -14,7 +14,7 @@ const structuredData: StructuredData = {
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<ul class="p-links">
+	<ul class="p-links -index">
 		<li><a href="commentary_tv">TV シリーズ</a>（悠木碧、斎藤千和 ほか）</li>
 		<li><a href="commentary_zenpen">[前編]始まりの物語</a>（悠木碧、斎藤千和、水橋かおり、喜多村英梨）</li>
 		<li><a href="commentary_kouhen">[後編]永遠の物語</a>（悠木碧、斎藤千和、野中藍、加藤英美里）</li>

--- a/astro/src/pages/madoka/yomoyama/kumeta.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta.astro
@@ -13,7 +13,7 @@ const structuredData: StructuredData = {
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<ul class="p-links">
+	<ul class="p-links -index">
 		<li><a href="kumeta_kaizo">かってに改蔵</a>（漫画、ラジオ）</li>
 		<li><a href="kumeta_zetsubou">さよなら絶望先生</a>（漫画、ラジオ）</li>
 		<li><a href="kumeta_joshiraku">じょしらく</a>（漫画、TVアニメ、ラジオ）</li>

--- a/astro/src/pages/madoka/yomoyama/official_news.astro
+++ b/astro/src/pages/madoka/yomoyama/official_news.astro
@@ -22,7 +22,7 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<H slot="heading">TV シリーズ</H>
 
-		<ul class="p-links">
+		<ul class="p-links -index">
 			<li><LinkExternal href="https://www.madoka-magica.com/tv/news/#n234575" icon={false}>発売中の『ニュータイプ5月号』『アニメージュ5月号』『アニメディア5月号』に情報掲載中</LinkExternal> （2011年4月11日）</li>
 			<li><LinkExternal href="https://www.madoka-magica.com/tv/news/#n234594" icon={false}>発売中の『オトナアニメvol.20』大特集中</LinkExternal> （2011年4月11日）</li>
 			<li><LinkExternal href="https://www.madoka-magica.com/tv/news/#n234613" icon={false}>公式HPリニューアル</LinkExternal> （2011年4月12日）</li>
@@ -107,7 +107,7 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<H slot="heading">劇場版</H>
 
-		<ul class="p-links">
+		<ul class="p-links -index">
 			<li><LinkExternal href="https://www.madoka-magica.com/rebellion/news/?id=14354" icon={false}>【限定特典付き】 劇場窓口販売前売券第1弾7月7日(土)発売</LinkExternal>（2012年6月8日）</li>
 			<li><LinkExternal href="https://www.madoka-magica.com/rebellion/news/?id=14355" icon={false}>前編＆後編公開日決定！！</LinkExternal>（2012年6月8日）</li>
 			<li><LinkExternal href="https://www.madoka-magica.com/rebellion/news/?id=14356" icon={false}>劇場版前編＆後編公開館追加情報公開！！</LinkExternal>（2012年6月8日）</li>

--- a/astro/src/pages/tokyu/data/index.astro
+++ b/astro/src/pages/tokyu/data/index.astro
@@ -21,7 +21,7 @@ const structuredData: StructuredData = {
 			<Section id="car">
 				<H slot="heading">車両</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="history/">車歴表</a>（2010年3月）</li>
 					<li><a href="preservation">保存車両リスト</a>（2019年10月）</li>
 				</ul>
@@ -31,7 +31,7 @@ const structuredData: StructuredData = {
 			<Section id="form">
 				<H slot="heading">編成表</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="form_car">主要機器搭載表（車種別）</a>（2009年3月）</li>
 					<li><a href="form_line">主要機器搭載表（路線別）</a>（2009年3月）</li>
 					<li><a href="form_local">譲渡車両編成表</a>（2020年2月）</li>
@@ -42,7 +42,7 @@ const structuredData: StructuredData = {
 			<Section id="list">
 				<H slot="heading">機器一覧</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="siv_8500">8500系　大容量 SIV 形式一覧</a>（2005年2月）</li>
 					<li><a href="acu_8500">8500系後期車　冷房配置バリエーション</a>（2022年7月）</li>
 					<li><a href="acu_9000">9000系　冷房配置バリエーション</a>（2018年12月）</li>

--- a/astro/src/pages/tokyu/sty/index.astro
+++ b/astro/src/pages/tokyu/sty/index.astro
@@ -21,7 +21,7 @@ const structuredData: StructuredData = {
 			<Section id="truck">
 				<H slot="heading">台車</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="truck_ts300">TS-300 系台車</a></li>
 					<li><a href="truck_ts700">TS-700 系台車（パイオニアⅢ）</a></li>
 					<li><a href="truck_ts800">TS-800 系台車</a></li>
@@ -34,7 +34,7 @@ const structuredData: StructuredData = {
 			<Section id="sty">
 				<H slot="heading">車両機器</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="aps">補助電源装置</a></li>
 					<li><a href="cp">空気圧縮機</a></li>
 					<li><a href="bce">ブレーキ制御装置</a></li>
@@ -52,7 +52,7 @@ const structuredData: StructuredData = {
 			<Section id="ub">
 				<H slot="heading">床下機器配置</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="ub_7600">7600系</a></li>
 					<li><a href="ub_7700">7700系</a></li>
 					<li><a href="ub_7700n">7700系（7915F）</a></li>
@@ -69,7 +69,7 @@ const structuredData: StructuredData = {
 			<Section id="roof">
 				<H slot="heading">屋根上機器配置</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="roof_7200">7200系（デヤ7200、デヤ7290、サヤ7590）</a></li>
 					<li><a href="roof_7600">7600系</a></li>
 					<li><a href="roof_7700">7700系</a></li>
@@ -82,7 +82,7 @@ const structuredData: StructuredData = {
 			<Section id="etc">
 				<H slot="heading">室外その他</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="front_7700">7700系　先頭車正面バリエーション</a></li>
 				</ul>
 			</Section>
@@ -91,7 +91,7 @@ const structuredData: StructuredData = {
 			<Section id="indoors">
 				<H slot="heading">室内</H>
 
-				<ul class="p-links">
+				<ul class="p-links -index">
 					<li><a href="nosmoking">禁煙標記</a></li>
 					<li><a href="amp_8000">8000系グループ　客室内スピーカ</a></li>
 				</ul>

--- a/astro/style/object/project/_main-list.css
+++ b/astro/style/object/project/_main-list.css
@@ -181,6 +181,8 @@ Markup:
 	</ul></li>
 </ul>
 
+.-index - インデックスページにおける下層ページのリンク
+
 Styleguide 2.3.6
 */
 .p-links {
@@ -224,10 +226,6 @@ Styleguide 2.3.6
 			}
 		}
 
-		& > a {
-			font-size: calc(100% * var(--font-ratio-2));
-		}
-
 		& > :any-link {
 			--_icon-color: var(--link-color-bullet);
 
@@ -237,9 +235,11 @@ Styleguide 2.3.6
 				--_icon-color: var(--link-color-hover);
 			}
 		}
+	}
 
-		& > ul > li > a {
-			font-size: calc(100% * var(--font-ratio-1));
+	&.-index {
+		& a {
+			font-size: calc(100% * var(--font-ratio-2));
 		}
 	}
 }


### PR DESCRIPTION
従来スタイルは `-index` オプションを追加することで対応