### PR TITLE
インデックスページのリンクリストのフォントサイズが小さくなっていたバグを修正

### DIFF
--- a/astro/src/pages/tokyu/an/index.astro
+++ b/astro/src/pages/tokyu/an/index.astro
@@ -948,7 +948,7 @@ const slugger = new GithubSlugger();
 	<Section id="etc">
 		<H slot="heading">その他の自動放送関連コンテンツ</H>
 
-		<ul class="p-links">
+		<ul class="p-links -index">
 			<li><a href="/tokyu/an/menu">メニュー放送一覧</a></li>
 			<li><a href="/tokyu/an/iketama_compare">池上、多摩川線 車種別放送内容比較</a></li>
 			<li><a href="/tokyu/an/sound">自動放送音声</a></li>


### PR DESCRIPTION
#445 の修正漏れ対応