### PR TITLE
グローバルナビのスタイル変更

### DIFF
--- a/astro/style/object/project/_header.css
+++ b/astro/style/object/project/_header.css
@@ -99,15 +99,18 @@
 }
 
 .p-header-gnav__link {
+	--_border-color: transparent;
+	--_border-width: 0px;
 	--_color: var(--color-darkgray);
-	--_background: var(--color-bg-light);
+	--_background: var(--color-white);
 
 	flex: 100%;
 	contain: content;
 	outline-offset: calc(1px - var(--outline-width-bold));
 	outline-width: var(--outline-width-bold);
+	border-block-end: var(--_border-width) solid var(--_border-color);
 	background: var(--_background);
-	padding: 0.5em 0.25em;
+	padding: 0.5em 0.25em calc(0.5em - var(--_border-width));
 	text-align: center;
 	text-decoration: none;
 	color: var(--_color);
@@ -124,6 +127,14 @@
 	}
 
 	&.-my-category {
-		--_background: linear-gradient(var(--color-white), var(--color-bg-verydark));
+	}
+
+	&:is(:not(:any-link), .-my-category) {
+		--_border-width: 2px;
+		--_border-color: var(--color-red);
+
+		&:focus {
+			--_border-width: 3px; /* フォーカスリングとの関係 */
+		}
 	}
 }


### PR DESCRIPTION
- 左上：旧デザイン、自身のページ（リンク設定なし）
- 左下：旧デザイン、自カテゴリのページ（リンク設定あり）
- 右上：新デザイン、自身のページ（リンク設定なし）
- 右下：新デザイン、自カテゴリのページ（リンク設定あり）**背景色は通常パターンと同様とし、赤線の有無でのみ区別**

![gnav](https://github.com/SaekiTominaga/w0s.jp/assets/4138486/9c3d3b92-ab11-457b-8b11-6901ccf13a9f)
