### PR TITLE
パンくずの最上位階層のページ名は一律「ホーム」とする

### DIFF
--- a/astro/src/layouts/include/ContentHeader.astro
+++ b/astro/src/layouts/include/ContentHeader.astro
@@ -17,8 +17,13 @@ const { pagePath, structuredData, tocData } = Astro.props;
 			<p class="p-topic-path">
 				{structuredData.breadcrumb.map((breadcrumbItem, index) => (
 					<Fragment>
-						{index > 0 && <span class="p-topic-path__separator">&gt;</span>}
-						<a href={breadcrumbItem.path}>{breadcrumbItem.name}</a>
+						{index === 0 && <a href={breadcrumbItem.path}>ホーム</a>}
+						{index >= 1 && (
+							<Fragment>
+								<span class="p-topic-path__separator">&gt;</span>
+								<a href={breadcrumbItem.path}>{breadcrumbItem.name}</a>
+							</Fragment>
+						)}
 					</Fragment>
 				))}
 				<span class="p-topic-path__separator">&gt;</span>

--- a/astro/src/pages/tokyu/machine/cont_fcc.astro
+++ b/astro/src/pages/tokyu/machine/cont_fcc.astro
@@ -16,7 +16,7 @@ const structuredData: StructuredData = {
 	description: '8000系グループの界磁チョッパ制御車に搭載された制御装置を紹介します。',
 	image: 'https://media.w0s.jp/image/tokyu/machine/cont/MMC-HTR-20A_8117.jpg',
 	breadcrumb: [
-		{ path: '/tokyu/', name: 'ホーム' },
+		{ path: '/tokyu/', name: '東急電車資料室' },
 		{ path: '/tokyu/machine/', name: '車両機器' },
 	],
 	localNav: [

--- a/astro/src/pages/tokyu/machine/cont_gto.astro
+++ b/astro/src/pages/tokyu/machine/cont_gto.astro
@@ -19,7 +19,7 @@ const structuredData: StructuredData = {
 	description: '9000系から2000系までの VVVF インバーター制御車（GTO サイリスタ 素子使用）に搭載された制御装置を紹介します。',
 	image: 'https://media.w0s.jp/image/tokyu/machine/cont/VF-HR107_9301.jpg',
 	breadcrumb: [
-		{ path: '/tokyu/', name: 'ホーム' },
+		{ path: '/tokyu/', name: '東急電車資料室' },
 		{ path: '/tokyu/machine/', name: '車両機器' },
 	],
 	localNav: [

--- a/astro/src/pages/tokyu/machine/cont_high.astro
+++ b/astro/src/pages/tokyu/machine/cont_high.astro
@@ -19,7 +19,7 @@ const structuredData: StructuredData = {
 	description: '旧5000系から7200系までの高性能車に搭載された制御装置を紹介します。',
 	image: 'https://media.w0s.jp/image/tokyu/machine/cont/PE11B_kumamoto5102A.jpg',
 	breadcrumb: [
-		{ path: '/tokyu/', name: 'ホーム' },
+		{ path: '/tokyu/', name: '東急電車資料室' },
 		{ path: '/tokyu/machine/', name: '車両機器' },
 	],
 	localNav: [

--- a/astro/src/pages/tokyu/machine/cont_igbt.astro
+++ b/astro/src/pages/tokyu/machine/cont_igbt.astro
@@ -17,7 +17,7 @@ const structuredData: StructuredData = {
 	description: 'デハ7815 から新3000系、300系、Y000系までの VVVF インバーター制御車（IGBT 素子使用）車両に搭載された制御装置を紹介します。',
 	image: 'https://media.w0s.jp/image/tokyu/machine/cont/VFI-HR4820E_3403_12.jpg',
 	breadcrumb: [
-		{ path: '/tokyu/', name: 'ホーム' },
+		{ path: '/tokyu/', name: '東急電車資料室' },
 		{ path: '/tokyu/machine/', name: '車両機器' },
 	],
 	localNav: [

--- a/astro/src/pages/tokyu/machine/cont_old.astro
+++ b/astro/src/pages/tokyu/machine/cont_old.astro
@@ -19,7 +19,7 @@ const structuredData: StructuredData = {
 	description: 'デハ1形からデハ3800形までの旧性能車（鉄道線の電動客車、電動貨車に限る）に搭載された制御装置を紹介します。',
 	image: 'https://media.w0s.jp/image/tokyu/machine/cont/MMC-H-10K_towada3603.jpg',
 	breadcrumb: [
-		{ path: '/tokyu/', name: 'ホーム' },
+		{ path: '/tokyu/', name: '東急電車資料室' },
 		{ path: '/tokyu/machine/', name: '車両機器' },
 	],
 	localNav: [


### PR DESCRIPTION
#431 で JSON-LD の最上位階層のページ名を変更した。
しかしページヘッダーのパンくずは一律「ホーム」で問題ない。