### PR TITLE
サムネイル画像の `<img>` 要素に `crossorigin` 属性を付与

### DIFF
--- a/astro/src/components/Image.astro
+++ b/astro/src/components/Image.astro
@@ -72,7 +72,7 @@ const paramAvif2x = assembleUrlSearch('avif', width2x, height2x, quality2x);
 			<picture>
 				<source type="image/avif" srcset={`https://media.w0s.jp/thumbimage/${filePath}${paramAvif}, https://media.w0s.jp/thumbimage/${filePath}${paramAvif2x} 2x`} />
 				<source type="image/webp" srcset={`https://media.w0s.jp/thumbimage/${filePath}${paramWebp}, https://media.w0s.jp/thumbimage/${filePath}${paramWebp2x} 2x`} />
-				<img src={`https://media.w0s.jp/thumbimage/${filePath}${param}`} alt={alt} width={width} height={height} class:list={className} style={style} />
+				<img src={`https://media.w0s.jp/thumbimage/${filePath}${param}`} alt={alt} width={width} height={height} crossorigin="" class:list={className} style={style} />
 			</picture>
 		</a>
 	)
@@ -82,7 +82,7 @@ const paramAvif2x = assembleUrlSearch('avif', width2x, height2x, quality2x);
 		<picture>
 			<source type="image/avif" srcset={`https://media.w0s.jp/thumbimage/${filePath}${paramAvif}, https://media.w0s.jp/thumbimage/${filePath}${paramAvif2x} 2x`} />
 			<source type="image/webp" srcset={`https://media.w0s.jp/thumbimage/${filePath}${paramWebp}, https://media.w0s.jp/thumbimage/${filePath}${paramWebp2x} 2x`} />
-			<img src={`https://media.w0s.jp/thumbimage/${filePath}${param}`} alt={alt} width={width} height={height} class:list={className} style={style} />
+			<img src={`https://media.w0s.jp/thumbimage/${filePath}${param}`} alt={alt} width={width} height={height} crossorigin="" class:list={className} style={style} />
 		</picture>
 	)
 }

--- a/astro/src/pages/madoka/video/connect.astro
+++ b/astro/src/pages/madoka/video/connect.astro
@@ -1290,7 +1290,7 @@ const slugger = new GithubSlugger();
 			<div class="c-grid__item">
 				<figure>
 					<div class="p-embed -border">
-						<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/connect_1994_tbs_1.jpg?type=webp;w=612;quality=30" width="306" height="172" id="video-c025-tbs-1">
+						<video controls="" width="306" height="172" id="video-c025-tbs-1">
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C025_tbs_1.webm" type="video/webm" />
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C025_tbs_1.mp4" type="video/mp4" />
 						</video>
@@ -1301,7 +1301,7 @@ const slugger = new GithubSlugger();
 			<div class="c-grid__item">
 				<figure>
 					<div class="p-embed -border">
-						<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/connect_1994_tbs_3.jpg?type=webp;w=612;quality=30" width="306" height="172" id="video-c025-tbs-3">
+						<video controls="" width="306" height="172" id="video-c025-tbs-3">
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C025_tbs_3.webm" type="video/webm" />
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C025_tbs_3.mp4" type="video/mp4" />
 						</video>
@@ -1618,7 +1618,7 @@ const slugger = new GithubSlugger();
 			<div class="c-grid__item">
 				<figure>
 					<div class="p-embed -border">
-						<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/connect_2528_tbs_1.jpg?type=webp;w=612;quality=30" width="306" height="172" id="video-c033-tbs-1">
+						<video controls="" width="306" height="172" id="video-c033-tbs-1">
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C033_tbs_1.webm" type="video/webm" />
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C033_tbs_1.mp4" type="video/mp4" />
 						</video>
@@ -1629,7 +1629,7 @@ const slugger = new GithubSlugger();
 			<div class="c-grid__item">
 				<figure>
 					<div class="p-embed -border">
-						<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/connect_2528_tbs_5.jpg?type=webp;w=612;quality=30" width="306" height="172" id="video-c033-tbs-5">
+						<video controls="" width="306" height="172" id="video-c033-tbs-5">
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C033_tbs_5.webm" type="video/webm" />
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C033_tbs_5.mp4" type="video/mp4" />
 						</video>
@@ -1692,7 +1692,7 @@ const slugger = new GithubSlugger();
 			<div class="c-grid__item">
 				<figure>
 					<div class="p-embed -border">
-						<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/connect_2553_tbs_1.jpg?type=webp;w=612;quality=30" width="306" height="172" id="video-c034-tbs-1">
+						<video controls="" width="306" height="172" id="video-c034-tbs-1">
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C034_tbs_1.webm" type="video/webm" />
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C034_tbs_1.mp4" type="video/mp4" />
 						</video>
@@ -1703,7 +1703,7 @@ const slugger = new GithubSlugger();
 			<div class="c-grid__item">
 				<figure>
 					<div class="p-embed -border">
-						<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/connect_2553_tbs_5.jpg?type=webp;w=612;quality=30" width="306" height="172" id="video-c034-tbs-5">
+						<video controls="" width="306" height="172" id="video-c034-tbs-5">
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C034_tbs_5.webm" type="video/webm" />
 							<source src="https://media.w0s.jp/video/madoka/video/connect_OP-C034_tbs_5.mp4" type="video/mp4" />
 						</video>

--- a/astro/src/pages/madoka/video/shinpen.astro
+++ b/astro/src/pages/madoka/video/shinpen.astro
@@ -193,7 +193,7 @@ const structuredData: StructuredData = {
 						<div class="c-grid__item">
 							<figure>
 								<div class="p-embed -border">
-									<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/shinpen_chapter1_00-04-20_tvtokyo.jpg?type=webp;w=588;quality=30" width="294" height="166" id="video-chapter1-000420-tvtokyo">
+									<video controls="" width="294" height="166" id="video-chapter1-000420-tvtokyo">
 										<source src="https://media.w0s.jp/video/madoka/video/shinpen_chapter1_00-04-19_tvtokyo.webm" type="video/webm" />
 										<source src="https://media.w0s.jp/video/madoka/video/shinpen_chapter1_00-04-19_tvtokyo.mp4" type="video/mp4" />
 									</video>
@@ -204,7 +204,7 @@ const structuredData: StructuredData = {
 						<div class="c-grid__item">
 							<figure>
 								<div class="p-embed -border">
-									<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/shinpen_chapter1_00-04-20_bd.jpg?type=webp;w=588;quality=30" width="294" height="166" id="video-chapter1-000420-bd">
+									<video controls="" width="294" height="166" id="video-chapter1-000420-bd">
 										<source src="https://media.w0s.jp/video/madoka/video/shinpen_chapter1_00-04-19_bd.webm" type="video/webm" />
 										<source src="https://media.w0s.jp/video/madoka/video/shinpen_chapter1_00-04-19_bd.mp4" type="video/mp4" />
 									</video>
@@ -420,7 +420,7 @@ const structuredData: StructuredData = {
 						<div class="c-grid__item">
 							<figure>
 								<div class="p-embed -border">
-									<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/shinpen_chapter6_00-18-17_bd.jpg?type=webp;w=588;quality=30" width="294" height="166">
+									<video controls="" width="294" height="166">
 										<source src="https://media.w0s.jp/video/madoka/video/shinpen_chapter6_00-18-11_bd.webm" type="video/webm" />
 										<source src="https://media.w0s.jp/video/madoka/video/shinpen_chapter6_00-18-11_bd.mp4" type="video/mp4" />
 									</video>
@@ -755,7 +755,7 @@ const structuredData: StructuredData = {
 						<div class="c-grid__item">
 							<figure>
 								<div class="p-embed -border">
-									<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/video/shinpen_chapter10_00-34-20_bd.jpg?type=webp;w=588;quality=30" width="294" height="166">
+									<video controls="" width="294" height="166">
 										<source src="https://media.w0s.jp/video/madoka/video/shinpen_chapter10_00-34-20_bd.webm" type="video/webm" />
 										<source src="https://media.w0s.jp/video/madoka/video/shinpen_chapter10_00-34-20_bd.mp4" type="video/mp4" />
 									</video>

--- a/astro/src/pages/madoka/yomoyama/aj2017_magireco_jiho.astro
+++ b/astro/src/pages/madoka/yomoyama/aj2017_magireco_jiho.astro
@@ -19,7 +19,7 @@ const slugger = new GithubSlugger();
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<figure class="c-fit">
 		<div class="p-embed -border">
-			<video controls="" poster="https://media.w0s.jp/thumbimage/madoka/yomoyama/index_aj2017_magireco_jiho.jpg?type=webp;w=1280;quality=30" width="640" height="360">
+			<video controls="" width="640" height="360">
 				<source src="https://media.w0s.jp/video/madoka/yomoyama/aj2017_magireco_jiho_1100.webm" type="video/webm" />
 				<source src="https://media.w0s.jp/video/madoka/yomoyama/aj2017_magireco_jiho_1100.mp4" type="video/mp4" />
 				<track kind="captions" label="セリフ字幕" src="/madoka/yomoyama/video/aj2017_magireco_jiho_1100.vtt" />


### PR DESCRIPTION
SaekiTominaga/media.w0s.jp/pull/50 に対応した修正

Firefox は `<video poster="..." crossorigin="">` で poster 画像が crossorigin 扱いにならないため（Firefox 125, Firefox 127 Nightly）、`poster` 属性は削除する。