### PR TITLE
メディア紹介 2024年5月29日更新分

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -123,6 +123,9 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2024-05-29">
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2023年30号」「週刊少年サンデー 2024年27号」を追加</p>
+				</TopUpdate>
 				<TopUpdate date="2024-05-03">
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2024年19号」を追加</p>
 					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に「朝日新聞 2024年4月30日 朝刊」を追加</p>

--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -139,10 +139,6 @@ const slugger = new GithubSlugger();
 				<TopUpdate date="2024-04-02">
 					<p><a href="/kumeta/library/web">メディア紹介 — Web</a> を新規作成</p>
 				</TopUpdate>
-				<TopUpdate date="2024-03-28">
-					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2024年16号」「週刊少年サンデー 2024年18号」を追加</p>
-					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「私は元気です　病める時も健やかなる時も腐る時もイキる時も泣いた時も病める時も。」（2023年）を追加</p>
-				</TopUpdate>
 			</ul>
 		</div>
 	</section>

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -11,7 +11,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の漫画雑誌での紹介例',
 	heading: 'メディア紹介 — 漫画雑誌',
-	dateModified: dayjs('2024-05-03'),
+	dateModified: dayjs('2024-05-29'),
 	description: '漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: '久米田康治データベース' }],
 	localNav: [
@@ -2432,6 +2432,12 @@ const slugger = new GithubSlugger();
 			</ul>
 		</LibraryItemBook>
 
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2023年30号" release="2023-06-21" tags={['表紙']}>
+			<div class="p-text">
+				<p>表紙: 制服姿の振り向き逸子<small>（『トニカクカワイイ』など他作品と混じっての掲載、イラストは<LinkExternal href="https://www.amazon.co.jp/dp/B0BC8JM421/">単行本1巻</LinkExternal>表紙の流用）</small></p>
+			</div>
+		</LibraryItemBook>
+
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2023年39号" release="2023-08-23" tags={['企画']}>
 			<div class="p-text">
 				<p>p.5: 「うる星やつら45周年記念特別企画」にラムちゃんイラスト色紙寄稿（カラー）<q>みんなのもとにラムちゃんが現れますように　今からでも</q></p>
@@ -2449,6 +2455,10 @@ const slugger = new GithubSlugger();
 			<div class="p-text">
 				<p>p.13: 「名探偵コナン30周年記念企画」に江戸川コナンのイラスト色紙寄稿（カラー）<q>30年続いた真実はひとつ!!</q></p>
 			</div>
+
+			<ul class="p-notes">
+				<li><LinkExternal href="https://www.conanten-30th.jp/">名探偵コナン展</LinkExternal>の各会場で実物が展示</li>
+			</ul>
 		</LibraryItemBook>
 
 		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2024年16号" release="2024-03-13" tags={['表紙']}>
@@ -2477,6 +2487,12 @@ const slugger = new GithubSlugger();
 				<li>背表紙画像が<LinkExternal href="https://x.com/shonen_sunday/status/1775177250192900578">少年サンデー編集部 X アカウント</LinkExternal>で公開</li>
 				<li>クイズの回答が翌週の2024年20号目次ページに記載</li>
 			</ul>
+		</LibraryItemBook>
+
+		<LibraryItemBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2024年27号" release="2024-05-29" tags={['表紙']}>
+			<div class="p-text">
+				<p>表紙: 制服姿の振り向き逸子<small>（江端妃咲と混じっての掲載、イラストは<LinkExternal href="https://www.amazon.co.jp/dp/B0BC8JM421/">単行本1巻</LinkExternal>および週刊少年サンデー 2023年30号表紙の流用）</small></p>
+			</div>
 		</LibraryItemBook>
 	</Section>
 	<Section slugger={slugger}>


### PR DESCRIPTION
「週刊少年サンデー 2023年30号」「週刊少年サンデー 2024年27号」を追加