### PR TITLE
View transitions を設定

### DIFF
--- a/astro/style/admin.css
+++ b/astro/style/admin.css
@@ -2,6 +2,7 @@
 
 /* Foundation */
 @import url("foundation/_var.css");
+@import url("foundation/_view-transition.css");
 @import url("foundation/_reset.css") layer(reset);
 @import url("foundation/_elements.css") layer(elements);
 

--- a/astro/style/error.css
+++ b/astro/style/error.css
@@ -2,6 +2,7 @@
 
 /* Foundation */
 @import url("foundation/_var.css");
+@import url("foundation/_view-transition.css");
 @import url("foundation/_reset.css") layer(reset);
 @import url("foundation/_elements.css") layer(elements);
 

--- a/astro/style/foundation/_view-transition.css
+++ b/astro/style/foundation/_view-transition.css
@@ -1,0 +1,5 @@
+/* stylelint-disable-next-line at-rule-no-unknown */
+@view-transition {
+	/* stylelint-disable-next-line property-no-unknown */
+	navigation: auto;
+}

--- a/astro/style/kumeta.css
+++ b/astro/style/kumeta.css
@@ -2,6 +2,7 @@
 
 /* Foundation */
 @import url("foundation/_var.css");
+@import url("foundation/_view-transition.css");
 @import url("foundation/_reset.css") layer(reset);
 @import url("foundation/_elements.css") layer(elements);
 

--- a/astro/style/madoka.css
+++ b/astro/style/madoka.css
@@ -3,6 +3,7 @@
 /* Foundation */
 @import url("foundation/_var.css");
 @import url("foundation/_var-madoka.css");
+@import url("foundation/_view-transition.css");
 @import url("foundation/_reset.css") layer(reset);
 @import url("foundation/_elements.css") layer(elements);
 

--- a/astro/style/tokyu.css
+++ b/astro/style/tokyu.css
@@ -3,6 +3,7 @@
 /* Foundation */
 @import url("foundation/_var.css");
 @import url("foundation/_var-tokyu.css");
+@import url("foundation/_view-transition.css");
 @import url("foundation/_reset.css") layer(reset);
 @import url("foundation/_elements.css") layer(elements);
 

--- a/astro/style/w0s.css
+++ b/astro/style/w0s.css
@@ -2,6 +2,7 @@
 
 /* Foundation */
 @import url("foundation/_var.css");
+@import url("foundation/_view-transition.css");
 @import url("foundation/_reset.css") layer(reset);
 @import url("foundation/_elements.css") layer(elements);
 


### PR DESCRIPTION
Chrome 126 で[マルチページ アプリケーションのドキュメント間のビュー遷移](https://developer.chrome.com/docs/web-platform/view-transitions/cross-document)が使用可能になる。