### PR TITLE
表の横スクロールは印刷時には無効にする

### DIFF
--- a/astro/style/object/project/_main-tabular.css
+++ b/astro/style/object/project/_main-tabular.css
@@ -65,10 +65,12 @@ Styleguide 2.6.1
 
 	/* 横スクロール */
 	&.-scroll {
-		--_text-wrap: nowrap;
+		@media not print {
+			--_text-wrap: nowrap;
 
-		padding-block-end: 2px; /* 横スクロールバー上部の空き */
-		overflow-x: auto;
+			padding-block-end: 2px; /* 横スクロールバー上部の空き */
+			overflow-x: auto;
+		}
 	}
 
 	/* 文字サイズを小さくする */


### PR DESCRIPTION
#459 で追加した横スクロールパターンは印刷時の考慮ができていなかったので改修