### PR TITLE
見出し A が Firefox の印刷プレビューで崩れる対策

### DIFF
--- a/astro/style/object/project/_main-section.css
+++ b/astro/style/object/project/_main-section.css
@@ -81,11 +81,14 @@ Styleguide 2.1.1
 		font-size: calc(100% * var(--font-ratio-6));
 
 		&::before {
-			transform: scaleY(75%);
 			border: 0.125em solid var(--color-gray);
 			border-radius: var(--border-radius-full);
 			background: var(--color-gray); /* for Chrome */
 			content: "";
+
+			@media not print { /* Firefox の印刷プレビューで2ページ目以降の場合に縦線が上方にずれてしまうバグの対策 */
+				transform: scaleY(75%);
+			}
 		}
 
 		& + * {


### PR DESCRIPTION
2ページ目以降の場合に縦線が上方にずれてしまうバグの対策（Firefox 127, 129 Nightly で確認）