### PR TITLE
東京芝浦電気→芝浦製作所に修正

### DIFF
--- a/astro/src/pages/tokyu/machine/cont_old.astro
+++ b/astro/src/pages/tokyu/machine/cont_old.astro
@@ -157,7 +157,7 @@ const structuredData: StructuredData = {
 					</tr>
 					<tr>
 						<td>CS-5</td>
-						<td>東洋<FootnoteReference>国鉄制式である CS-5 型は東京芝浦電気<small>（現：東芝）</small>、日立製作所、三菱電機など複数のメーカーにより製造されています。東急デハ3700形用のメーカー内訳は不明なものの、<RefBook name="東洋電機五十年史" article="第5章　戦後の復興と再建の努力 – 8. 製品の推移" pages={[113]} url="https://dl.ndl.go.jp/pid/11956837/1/77" urlScope="page" />には東急電鉄への納入実績があったとされており、その一部ないし全部は東洋電機製造であったようです。</FootnoteReference></td>
+						<td>東洋<FootnoteReference>国鉄制式である CS-5 型は芝浦製作所<small>（現：東芝）</small>、日立製作所、三菱電機など複数のメーカーにより製造されています。東急デハ3700形用のメーカー内訳は不明なものの、<RefBook name="東洋電機五十年史" article="第5章　戦後の復興と再建の努力 – 8. 製品の推移" pages={[113]} url="https://dl.ndl.go.jp/pid/11956837/1/77" urlScope="page" />には東急電鉄への納入実績があったとされており、その一部ないし全部は東洋電機製造であったようです。</FootnoteReference></td>
 						<td>デハ3700形、3800形ほか</td>
 						<td>1948年</td>
 						<td>電空カム軸</td>


### PR DESCRIPTION
CS-5 型が設計された時代の東芝の社名は芝浦製作所である。