### PR TITLE
見出しのセルフリンクのスタイルを微調整

### DIFF
--- a/astro/style/foundation/_var.css
+++ b/astro/style/foundation/_var.css
@@ -330,34 +330,15 @@
 	initial-value: 1.12;
 }
 
-/* 遊ゴシック体 */
+/* 遊ゴシック */
 @property --font-yu-gothic {
 	syntax: "*";
 	inherits: false;
-	initial-value:
-		system-ui,
-		-apple-system,
-		"YuGothic",
-		"Yu Gothic",
-		"Hiragino Sans",
-		"Meiryo",
-		sans-serif; /* '-apple-system' は macOS, iOS の Firefox 向け */
+	initial-value: "YuGothic", "Yu Gothic", sans-serif;
 }
 
-/* 角ゴシック体 */
-@property --font-kaku-gothic {
-	syntax: "*";
-	inherits: false;
-	initial-value:
-		system-ui,
-		-apple-system,
-		"Hiragino Sans",
-		"Meiryo",
-		sans-serif; /* '-apple-system' は macOS, iOS の Firefox 向け */
-}
-
-/* 明朝体 */
-@property --font-mincho {
+/* 遊明朝 */
+@property --font-yu-mincho {
 	syntax: "*";
 	inherits: false;
 	initial-value: "YuMincho", "Yu Mincho", serif;

--- a/astro/style/object/component/_form.css
+++ b/astro/style/object/component/_form.css
@@ -223,7 +223,7 @@ Styleguide 1.4.6
 	line-height: var(--line-height-nowrap);
 	white-space: nowrap;
 	color: var(--_color);
-	font-family: var(--font-yu-gothic); /* Chrome で下側の空きが出てしまう対策 */
+	font-family: system-ui, sans-serif; /* Chrome で下側の空きが出てしまう対策 */
 	font-size: var(--_font-size);
 	font-weight: var(--font-weight-bold);
 

--- a/astro/style/object/component/_text.css
+++ b/astro/style/object/component/_text.css
@@ -62,6 +62,7 @@ Styleguide 1.2.2
 	outline-width: var(--outline-width-bold);
 	min-inline-size: var(--self-link-size);
 	text-decoration: none;
+	font-family: var(--font-yu-gothic);
 }
 
 /*

--- a/astro/style/object/project/_header.css
+++ b/astro/style/object/project/_header.css
@@ -14,7 +14,7 @@
 .p-header-site__name {
 	text-shadow: 0.05em 0.05em 0.1em var(--color-border-light);
 	color: #f00;
-	font: 700 2rem / var(--line-height-narrow) var(--font-mincho);
+	font: 700 2rem / var(--line-height-narrow) var(--font-yu-mincho);
 	font-feature-settings: "palt";
 
 	& :any-link {

--- a/astro/style/object/project/_main-library.css
+++ b/astro/style/object/project/_main-library.css
@@ -18,13 +18,12 @@
 	flex-wrap: wrap;
 	gap: 0.5em;
 	align-items: center;
+	contain: layout;
 	border-start-start-radius: var(--_border-radius-inner);
 	border-start-end-radius: var(--_border-radius-inner);
 	background: var(--color-verylightgreen);
-	padding: var(--_header-padding-block) var(--_padding-inline);
-
-	& :is(h1, h2, h3, h4, h5, h6) {
-	}
+	padding-block: var(--_header-padding-block);
+	padding-inline: calc(var(--_padding-inline) + var(--self-link-size)) var(--_padding-inline);
 }
 
 .p-library__main {
@@ -36,7 +35,9 @@
 }
 
 .p-library__self-link {
-	order: -1;
+	position: absolute;
+	inset-block-start: calc(var(--_header-padding-block) + 0.25ex);
+	inset-inline-start: calc(var(--_padding-inline) - 0.25em);
 }
 
 .p-library__release {


### PR DESCRIPTION
- フォントが環境によって異なるため游明朝を指定
- #528 で配置を `order` にしていたが、見出しが長いときに改行されるのを防ぐため `position: absolute` に戻す