### PR TITLE
ランドマーク関連の整備

### DIFF
--- a/astro/src/layouts/Admin.astro
+++ b/astro/src/layouts/Admin.astro
@@ -37,10 +37,10 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 		<div class="l-page">
 			<PageHeader top={false} />
 
-			<div id="content" class="l-content -nosidebar">
+			<main id="content" class="l-content -nosidebar">
 				<ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />
 				<ContentMain html={mainHtml} footnoteData={footnoteData} />
-			</div>
+			</main>
 
 			<PageFooter pagePath={pagePath} ad={false} />
 		</div>

--- a/astro/src/layouts/Admin.astro
+++ b/astro/src/layouts/Admin.astro
@@ -4,7 +4,7 @@ import Head from '@layouts/include/HeadAdmin.astro';
 import PageHeader from '@layouts/include/PageHeader.astro';
 import PageFooter from '@layouts/include/PageFooter.astro';
 import ContentHeader from '@layouts/include/ContentHeader.astro';
-import ContentMain from '@layouts/include/ContentMain.astro';
+import ContentMain from '@layouts/include/ContentBody.astro';
 import type { StructuredData } from '@type/types.js';
 import FootnoteUtil from '@util/Footnote.js';
 import SsrUtil from '@util/Ssr.js';

--- a/astro/src/layouts/Error.astro
+++ b/astro/src/layouts/Error.astro
@@ -35,7 +35,7 @@ const { structuredData, search = false } = Astro.props;
 
 				{
 					search && (
-						<search role="search">
+						<search role="search" aria-label="サイト">
 							<form action="https://www.google.com/search" class="p-err-search">
 								<fieldset>
 									<legend class="p-err-search__legend">

--- a/astro/src/layouts/Kumeta.astro
+++ b/astro/src/layouts/Kumeta.astro
@@ -5,7 +5,7 @@ import PageHeader from '@layouts/include/PageHeaderKumeta.astro';
 import PageSidebar from '@layouts/include/PageSidebar.astro';
 import PageFooter from '@layouts/include/PageFooter.astro';
 import ContentHeader from '@layouts/include/ContentHeader.astro';
-import ContentMain from '@layouts/include/ContentMain.astro';
+import ContentMain from '@layouts/include/ContentBody.astro';
 import ContentFooter from '@layouts/include/ContentFooter.astro';
 import type { StructuredData } from '@type/types.js';
 import FootnoteUtil from '@util/Footnote.js';

--- a/astro/src/layouts/Kumeta.astro
+++ b/astro/src/layouts/Kumeta.astro
@@ -47,11 +47,11 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 			{
 				pageSidebar && (
 					<>
-						<div id="content" class="l-content">
+						<main id="content" class="l-content">
 							{!top && <ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />}
 							<ContentMain html={mainHtml} footnoteData={footnoteData} />
 							{contentFooter && <ContentFooter pagePath={pagePath} astroFilePath={astroFilePath} structuredData={structuredData} />}
-						</div>
+						</main>
 
 						<PageSidebar />
 					</>
@@ -59,11 +59,11 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 			}
 			{
 				!pageSidebar && (
-					<div id="content" class="l-content -nosidebar">
+					<main id="content" class="l-content -nosidebar">
 						{!top && <ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />}
 						<ContentMain html={mainHtml} footnoteData={footnoteData} />
 						{contentFooter && <ContentFooter pagePath={pagePath} astroFilePath={astroFilePath} structuredData={structuredData} />}
-					</div>
+					</main>
 				)
 			}
 

--- a/astro/src/layouts/Madoka.astro
+++ b/astro/src/layouts/Madoka.astro
@@ -47,11 +47,11 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 			{
 				pageSidebar && (
 					<>
-						<div id="content" class="l-content">
+						<main id="content" class="l-content">
 							{!top && <ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />}
 							<ContentMain html={mainHtml} footnoteData={footnoteData} />
 							{contentFooter && <ContentFooter pagePath={pagePath} astroFilePath={astroFilePath} structuredData={structuredData} />}
-						</div>
+						</main>
 
 						<PageSidebar />
 					</>
@@ -59,11 +59,11 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 			}
 			{
 				!pageSidebar && (
-					<div id="content" class="l-content -nosidebar">
+					<main id="content" class="l-content -nosidebar">
 						{!top && <ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />}
 						<ContentMain html={mainHtml} footnoteData={footnoteData} />
 						{contentFooter && <ContentFooter pagePath={pagePath} astroFilePath={astroFilePath} structuredData={structuredData} />}
-					</div>
+					</main>
 				)
 			}
 

--- a/astro/src/layouts/Madoka.astro
+++ b/astro/src/layouts/Madoka.astro
@@ -5,7 +5,7 @@ import PageHeader from '@layouts/include/PageHeaderMadoka.astro';
 import PageSidebar from '@layouts/include/PageSidebar.astro';
 import PageFooter from '@layouts/include/PageFooter.astro';
 import ContentHeader from '@layouts/include/ContentHeader.astro';
-import ContentMain from '@layouts/include/ContentMain.astro';
+import ContentMain from '@layouts/include/ContentBody.astro';
 import ContentFooter from '@layouts/include/ContentFooter.astro';
 import type { StructuredData } from '@type/types.js';
 import FootnoteUtil from '@util/Footnote.js';

--- a/astro/src/layouts/Tokyu.astro
+++ b/astro/src/layouts/Tokyu.astro
@@ -5,7 +5,7 @@ import PageHeader from '@layouts/include/PageHeaderTokyu.astro';
 import PageSidebar from '@layouts/include/PageSidebar.astro';
 import PageFooter from '@layouts/include/PageFooter.astro';
 import ContentHeader from '@layouts/include/ContentHeader.astro';
-import ContentMain from '@layouts/include/ContentMain.astro';
+import ContentMain from '@layouts/include/ContentBody.astro';
 import ContentFooter from '@layouts/include/ContentFooter.astro';
 import type { StructuredData } from '@type/types.js';
 import FootnoteUtil from '@util/Footnote.js';

--- a/astro/src/layouts/Tokyu.astro
+++ b/astro/src/layouts/Tokyu.astro
@@ -47,11 +47,11 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 			{
 				pageSidebar && (
 					<>
-						<div id="content" class="l-content">
+						<main id="content" class="l-content">
 							{!top && <ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />}
 							<ContentMain html={mainHtml} footnoteData={footnoteData} />
 							{contentFooter && <ContentFooter pagePath={pagePath} astroFilePath={astroFilePath} structuredData={structuredData} />}
-						</div>
+						</main>
 
 						<PageSidebar />
 					</>
@@ -59,11 +59,11 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 			}
 			{
 				!pageSidebar && (
-					<div id="content" class="l-content -nosidebar">
+					<main id="content" class="l-content -nosidebar">
 						{!top && <ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />}
 						<ContentMain html={mainHtml} footnoteData={footnoteData} />
 						{contentFooter && <ContentFooter pagePath={pagePath} astroFilePath={astroFilePath} structuredData={structuredData} />}
-					</div>
+					</main>
 				)
 			}
 

--- a/astro/src/layouts/W0s.astro
+++ b/astro/src/layouts/W0s.astro
@@ -47,11 +47,11 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 			{
 				pageSidebar && (
 					<>
-						<div id="content" class="l-content">
+						<main id="content" class="l-content">
 							{!top && <ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />}
 							<ContentMain html={mainHtml} footnoteData={footnoteData} />
 							{contentFooter && <ContentFooter pagePath={pagePath} astroFilePath={astroFilePath} structuredData={structuredData} />}
-						</div>
+						</main>
 
 						<PageSidebar />
 					</>
@@ -59,11 +59,11 @@ const mainHtml = `${document.head.innerHTML}${document.body.innerHTML}`;
 			}
 			{
 				!pageSidebar && (
-					<div id="content" class="l-content -nosidebar">
+					<main id="content" class="l-content -nosidebar">
 						{!top && <ContentHeader pagePath={pagePath} structuredData={structuredData} tocData={tocData} />}
 						<ContentMain html={mainHtml} footnoteData={footnoteData} />
 						{contentFooter && <ContentFooter pagePath={pagePath} astroFilePath={astroFilePath} structuredData={structuredData} />}
-					</div>
+					</main>
 				)
 			}
 

--- a/astro/src/layouts/W0s.astro
+++ b/astro/src/layouts/W0s.astro
@@ -5,7 +5,7 @@ import PageHeader from '@layouts/include/PageHeader.astro';
 import PageSidebar from '@layouts/include/PageSidebar.astro';
 import PageFooter from '@layouts/include/PageFooter.astro';
 import ContentHeader from '@layouts/include/ContentHeader.astro';
-import ContentMain from '@layouts/include/ContentMain.astro';
+import ContentMain from '@layouts/include/ContentBody.astro';
 import ContentFooter from '@layouts/include/ContentFooter.astro';
 import type { StructuredData } from '@type/types.js';
 import FootnoteUtil from '@util/Footnote.js';

--- a/astro/src/layouts/include/ContentBody.astro
+++ b/astro/src/layouts/include/ContentBody.astro
@@ -7,7 +7,7 @@ interface Props {
 const { html, footnoteData } = Astro.props;
 ---
 
-<div class="l-content__main">
+<div class="l-content__body">
 	<Fragment set:html={html} />
 
 	{

--- a/astro/src/layouts/include/ContentMain.astro
+++ b/astro/src/layouts/include/ContentMain.astro
@@ -7,7 +7,7 @@ interface Props {
 const { html, footnoteData } = Astro.props;
 ---
 
-<main class="l-content__main">
+<div class="l-content__main">
 	<Fragment set:html={html} />
 
 	{
@@ -31,4 +31,4 @@ const { html, footnoteData } = Astro.props;
 			</section>
 		)
 	}
-</main>
+</div>

--- a/astro/src/layouts/include/PageHeaderSearch.astro
+++ b/astro/src/layouts/include/PageHeaderSearch.astro
@@ -1,4 +1,4 @@
-<search role="search" class="p-header-search">
+<search role="search" class="p-header-search" aria-label="サイト">
 	<form action="https://www.google.com/search">
 		<fieldset>
 			<legend class="p-header-search__legend">サイト内検索<small>（Google 検索）</small></legend>

--- a/astro/src/layouts/include/PageHeaderTokyu.astro
+++ b/astro/src/layouts/include/PageHeaderTokyu.astro
@@ -43,7 +43,7 @@ const { pagePath, top = false } = Astro.props;
 		</div>
 	</div>
 	<div class="l-header__gnav">
-		<nav class="p-header-gnav" aria-label="サイトコンテンツ">
+		<nav class="p-header-gnav" aria-label="サイト">
 			<ul class="p-header-gnav__links">
 				{
 					[

--- a/astro/src/layouts/include/PageSidebar.astro
+++ b/astro/src/layouts/include/PageSidebar.astro
@@ -1,6 +1,6 @@
 <div id="sidebar" class="l-sidebar">
-	<aside class="p-sidebar-blog-entries" hidden="" aria-labelledby="sidebar-blog-newly-label">
-		<h2 class="p-sidebar-blog-entries__hdg" id="sidebar-blog-newly-label">最近の日記記事</h2>
+	<aside class="p-sidebar-blog-entries" hidden="" aria-labelledby="landmark-blog-newly-label">
+		<h2 class="p-sidebar-blog-entries__hdg" id="landmark-blog-newly-label">最近の日記記事</h2>
 
 		<ul class="p-sidebar-link -entry">
 			<template id="sidebar-blog-newly-template">

--- a/astro/src/layouts/include/PageSidebar.astro
+++ b/astro/src/layouts/include/PageSidebar.astro
@@ -1,6 +1,6 @@
 <div id="sidebar" class="l-sidebar">
-	<aside class="p-sidebar-blog-entries" hidden="">
-		<h2 class="p-sidebar-blog-entries__hdg">最近の日記記事</h2>
+	<aside class="p-sidebar-blog-entries" hidden="" aria-labelledby="sidebar-blog-newly-label">
+		<h2 class="p-sidebar-blog-entries__hdg" id="sidebar-blog-newly-label">最近の日記記事</h2>
 
 		<ul class="p-sidebar-link -entry">
 			<template id="sidebar-blog-newly-template">

--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -16,10 +16,10 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData} top={true}>
-	<nav class="p-top-nav" id="contents" aria-labelledby="contents-hdg">
+	<nav class="p-top-nav" id="contents" aria-labelledby="contents-label">
 		<header class="p-top-nav__header">
 			<div class="p-top-nav__hdg">
-				<h2 id="contents-hdg">サイトコンテンツ</h2>
+				<h2 id="contents-label">サイトコンテンツ</h2>
 			</div>
 		</header>
 		<div class="p-top-nav__main">

--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -16,10 +16,10 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData} top={true}>
-	<nav class="p-top-nav" id="contents" aria-labelledby="contents-label">
+	<nav class="p-top-nav" id="contents" aria-labelledby="landmark-contents-label">
 		<header class="p-top-nav__header">
 			<div class="p-top-nav__hdg">
-				<h2 id="contents-label">サイトコンテンツ</h2>
+				<h2 id="landmark-contents-label">サイトコンテンツ</h2>
 			</div>
 		</header>
 		<div class="p-top-nav__main">

--- a/astro/src/pages/madoka/index.astro
+++ b/astro/src/pages/madoka/index.astro
@@ -16,10 +16,10 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData} top={true}>
-	<nav class="p-top-nav" id="contents" aria-labelledby="contents-hdg">
+	<nav class="p-top-nav" id="contents" aria-labelledby="contents-label">
 		<header class="p-top-nav__header">
 			<div class="p-top-nav__hdg">
-				<h2 id="contents-hdg">サイトコンテンツ</h2>
+				<h2 id="contents-label">サイトコンテンツ</h2>
 			</div>
 		</header>
 		<div class="p-top-nav__main">

--- a/astro/src/pages/madoka/index.astro
+++ b/astro/src/pages/madoka/index.astro
@@ -16,10 +16,10 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData} top={true}>
-	<nav class="p-top-nav" id="contents" aria-labelledby="contents-label">
+	<nav class="p-top-nav" id="contents" aria-labelledby="landmark-contents-label">
 		<header class="p-top-nav__header">
 			<div class="p-top-nav__hdg">
-				<h2 id="contents-label">サイトコンテンツ</h2>
+				<h2 id="landmark-contents-label">サイトコンテンツ</h2>
 			</div>
 		</header>
 		<div class="p-top-nav__main">

--- a/astro/src/pages/tokyu/index.astro
+++ b/astro/src/pages/tokyu/index.astro
@@ -12,8 +12,8 @@ const structuredData: StructuredData = {
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData} top={true}>
-	<nav id="contents" aria-labelledby="contents-hdg">
-		<h2 id="contents-hdg">サイトコンテンツ</h2>
+	<nav id="contents" aria-labelledby="contents-label">
+		<h2 id="contents-label">サイトコンテンツ</h2>
 
 		<ul class="p-top-nav-card">
 			<li class="p-top-nav-card__box">

--- a/astro/src/pages/tokyu/index.astro
+++ b/astro/src/pages/tokyu/index.astro
@@ -12,8 +12,8 @@ const structuredData: StructuredData = {
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData} top={true}>
-	<nav id="contents" aria-labelledby="contents-label">
-		<h2 id="contents-label">サイトコンテンツ</h2>
+	<nav id="contents" aria-labelledby="landmark-contents-label">
+		<h2 id="landmark-contents-label">サイトコンテンツ</h2>
 
 		<ul class="p-top-nav-card">
 			<li class="p-top-nav-card__box">

--- a/astro/style/layout/_common.css
+++ b/astro/style/layout/_common.css
@@ -80,7 +80,7 @@
 .l-content__header {
 }
 
-.l-content__main {
+.l-content__body {
 	.l-content__header + & {
 		margin-block-start: 80px;
 	}

--- a/astro/style/layout/_error.css
+++ b/astro/style/layout/_error.css
@@ -8,8 +8,8 @@
 
 	display: block grid;
 	grid-template-areas:
-		"header-margin-left  header-padding-left  header  header-padding-right  header-margin-right "
-		"content-margin-left content-padding-left content content-padding-right content-margin-right";
+		"margin-left padding-left header  padding-right margin-right"
+		"margin-left padding-left content padding-right margin-right";
 	grid-template-columns: var(--_page-margin-inline) var(--page-padding-inline) 1fr var(--page-padding-inline) var(--_page-margin-inline);
 }
 

--- a/astro/style/layout/_page-full.css
+++ b/astro/style/layout/_page-full.css
@@ -3,9 +3,9 @@
  * ============================== */
 .l-page {
 	grid-template-areas:
-		"header              header               header  header              header  header                header              "
-		"content-margin-left content-padding-left content gap-content-sidebar sidebar content-padding-right content-margin-right"
-		"footer              footer               footer  footer              footer  footer                footer              ";
+		"header      header       header  header              header  header        header      "
+		"margin-left padding-left content gap-content-sidebar sidebar padding-right margin-right"
+		"footer      footer       footer  footer              footer  footer        footer      ";
 	grid-template-columns:
 		var(--_page-margin-inline) var(--page-padding-inline) 1fr var(--page-content-sidebar-gap) var(--page-sidebar-width) var(--page-padding-inline)
 		var(--_page-margin-inline);
@@ -14,10 +14,10 @@
 @media (--breakpoint) {
 	.l-page {
 		grid-template-areas:
-			"header               header  header               "
-			"content-padding-left content content-padding-right"
-			"sidebar-padding-left sidebar sidebar-padding-right"
-			"footer               footer  footer               ";
+			"header       header  header       "
+			"padding-left content padding-right"
+			"padding-left sidebar padding-right"
+			"footer       footer  footer       ";
 		grid-template-columns: var(--page-padding-inline) 1fr var(--page-padding-inline);
 	}
 

--- a/astro/style/object/component/_layout.css
+++ b/astro/style/object/component/_layout.css
@@ -82,10 +82,10 @@ Styleguide 1.5.3
 .c-grid {
 	--_gap-row: 1em;
 	--_gap-col: 50px;
-	--_max-inline-size: auto;
+	--_min-inline-size: auto;
 
 	display: block grid;
-	grid-template-columns: repeat(auto-fill, minmax(min(var(--_max-inline-size), 100%), 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(min(var(--_min-inline-size), 100%), 1fr));
 	gap: var(--_gap-row) var(--_gap-col);
 
 	&.-hdg-a {
@@ -102,23 +102,23 @@ Styleguide 1.5.3
 
 	/* 2カラム */
 	&.-wide {
-		--_max-inline-size: 330px;
+		--_min-inline-size: 360px;
 	}
 
 	/* 3カラム */
 	&.-medium {
-		--_max-inline-size: 240px;
+		--_min-inline-size: 240px;
 	}
 
 	/* 4カラム */
 	&.-narrow {
-		--_max-inline-size: 180px;
+		--_min-inline-size: 180px;
 	}
 
 	/* トップページ・ナビゲーション */
 	&.-top-nav {
 		--_gap-row: 4em;
-		--_max-inline-size: 330px;
+		--_min-inline-size: 360px;
 	}
 }
 

--- a/astro/style/object/component/_layout.css
+++ b/astro/style/object/component/_layout.css
@@ -16,7 +16,7 @@ Markup:
 
 Styleguide 1.5.1
 */
-:is(.l-content__main, .c-stack, .c-embed-sidebar__text, .p-section, .p-quote, .p-box, .p-toggle__contents, .p-library__main) {
+:is(.l-content__body, .c-stack, .c-embed-sidebar__text, .p-section, .p-quote, .p-box, .p-toggle__contents, .p-library__main) {
 	& > * + * {
 		margin-block-start: var(--stack-margin-base);
 	}

--- a/astro/style/object/project/_main-list.css
+++ b/astro/style/object/project/_main-list.css
@@ -309,7 +309,7 @@ Styleguide 2.3.8
 	padding: 1em;
 	font-size: calc(100% / pow(var(--font-ratio), 1));
 
-	.l-content__main & {
+	.l-content__body & {
 		&:last-child {
 			margin-block-start: calc(var(--stack-margin-base) * 6);
 		}


### PR DESCRIPTION
- ページ内のすべてのコンテンツをランドマーク領域に収める
  - `<main>` 領域の変更
- `<aside>` はトップレベルのランドマーク
  - 宣伝エリアをコンテンツフッター内からサイドバーの下へ移動
- `<nav>`, `<aside>`, `<search>` は（ページ内に1つであっても）常にラベルを含める
- ランドマークのラベルを見出し要素で提示する（`aria-labelledby` で紐付ける）場合、ID のプレフィックスは `landmark-` とする