### PR TITLE
`aria-current` の見直し

### DIFF
--- a/astro/src/layouts/include/ContentHeader.astro
+++ b/astro/src/layouts/include/ContentHeader.astro
@@ -14,19 +14,19 @@ const { pagePath, structuredData, tocData } = Astro.props;
 <div class="l-content__header">
 	{
 		structuredData.breadcrumb !== undefined && (
-			<nav class="p-topic-path" aria-label="パンくず">
+			<nav class="p-breadcrumb" aria-label="パンくず">
 				{structuredData.breadcrumb.map((breadcrumbItem, index) => (
 					<>
 						{index === 0 && <a href={breadcrumbItem.path}>ホーム</a>}
 						{index >= 1 && (
 							<>
-								<span class="p-topic-path__separator">&gt;</span>
+								<span class="p-breadcrumb__separator">&gt;</span>
 								<a href={breadcrumbItem.path}>{breadcrumbItem.name}</a>
 							</>
 						)}
 					</>
 				))}
-				<span class="p-topic-path__separator">&gt;</span>
+				<span class="p-breadcrumb__separator">&gt;</span>
 				<a aria-current="page">現在のページ</a>
 			</nav>
 		)

--- a/astro/src/layouts/include/ContentHeader.astro
+++ b/astro/src/layouts/include/ContentHeader.astro
@@ -27,7 +27,7 @@ const { pagePath, structuredData, tocData } = Astro.props;
 					</>
 				))}
 				<span class="p-topic-path__separator">&gt;</span>
-				<a aria-current="location">現在のページ</a>
+				<a aria-current="page">現在のページ</a>
 			</p>
 		)
 	}

--- a/astro/src/layouts/include/ContentHeader.astro
+++ b/astro/src/layouts/include/ContentHeader.astro
@@ -14,7 +14,7 @@ const { pagePath, structuredData, tocData } = Astro.props;
 <div class="l-content__header">
 	{
 		structuredData.breadcrumb !== undefined && (
-			<p class="p-topic-path">
+			<nav class="p-topic-path" aria-label="パンくず">
 				{structuredData.breadcrumb.map((breadcrumbItem, index) => (
 					<>
 						{index === 0 && <a href={breadcrumbItem.path}>ホーム</a>}
@@ -28,7 +28,7 @@ const { pagePath, structuredData, tocData } = Astro.props;
 				))}
 				<span class="p-topic-path__separator">&gt;</span>
 				<a aria-current="page">現在のページ</a>
-			</p>
+			</nav>
 		)
 	}
 

--- a/astro/src/layouts/include/PageHeaderTokyu.astro
+++ b/astro/src/layouts/include/PageHeaderTokyu.astro
@@ -60,7 +60,7 @@ const { pagePath, top = false } = Astro.props;
 							</a>
 						)}
 						{page.path !== pagePath && pagePath.startsWith(page.path) && (
-							<a href={page.path} class="p-header-gnav__link -my-category">
+							<a href={page.path} aria-current="true" class="p-header-gnav__link">
 								{page.name}
 							</a>
 						)}

--- a/astro/style/object/project/_content.css
+++ b/astro/style/object/project/_content.css
@@ -3,7 +3,7 @@
  * ============================== */
 
 /* ===== パンくず ===== */
-.p-topic-path {
+.p-breadcrumb {
 	display: block flex;
 	flex-wrap: wrap;
 	gap: 0 0.5em;
@@ -15,7 +15,7 @@
 	}
 }
 
-.p-topic-path__separator {
+.p-breadcrumb__separator {
 	font-family: var(--font-monospace);
 }
 
@@ -23,7 +23,7 @@
 .p-title {
 	line-height: var(--line-height-narrow);
 
-	.p-topic-path + & {
+	.p-breadcrumb + & {
 		margin-block-start: calc(var(--stack-margin-base) / 2);
 	}
 

--- a/astro/style/object/project/_header.css
+++ b/astro/style/object/project/_header.css
@@ -109,10 +109,7 @@
 		}
 	}
 
-	&.-my-category {
-	}
-
-	&:is(:not(:any-link), .-my-category) {
+	&[aria-current] {
 		--_border-width: 2px;
 		--_border-color: var(--color-red);
 


### PR DESCRIPTION
## グローバルナビ

APG タスクフォース曰く、現在カテゴリーは `aria-current=true` を使えとのこと。👉w3c/aria-practices/issues/2583

## パンくず

#491 で現在地を `aria-current=location` に変更したが、[様々な意見、利用ケースを見た](https://fedibird.com/@SaekiTominaga/112942827716630383)結果、`location` がなんなのか分からなくなってきたので `page` に戻す。

`location` が不適切というわけではないが、APG では `page` が採用されているし、自信がないときの安パイという意味での消極的判断。

また `<nav>` 要素でのマークアップを行い、さらにクラス名を `topic-path` から `breadcrumb` へ変更した（これも APG に合わせての変更）。