### PR TITLE
新聞コンポーネントのセクション ID の生成元データに日付などを追加

### DIFF
--- a/astro/src/components/LibNewspaper.astro
+++ b/astro/src/components/LibNewspaper.astro
@@ -13,7 +13,7 @@ interface Props {
 
 const { slugger, headingLevel, title, release, npClass, tags } = Astro.props;
 
-const sectionId = slugger.slug(title);
+const sectionId = slugger.slug(`${title} ${release ?? ''} ${npClass ?? ''}`.trim());
 
 let releaseDisplay = release;
 if (release !== undefined) {


### PR DESCRIPTION
現状は新聞タイトルのみから生成しているため、`id="朝日新聞-1"`, `id="朝日新聞-2"` など自動連番のみが付与されるケースが大量に存在してしまい望ましくないため、極力ユニークになるよう日付データなどを追加する。