### PR TITLE
車歴表におけるクハ3660形の挿入位置を変更

### DIFF
--- a/astro/src/pages/tokyu/data/history_tokyu.astro
+++ b/astro/src/pages/tokyu/data/history_tokyu.astro
@@ -16,7 +16,7 @@ const structuredData: StructuredData = {
 	title: '東京急行電鉄　車歴表（1949年以前）',
 	heading: '東京急行電鉄　車歴表',
 	subHeading: '1949年以前',
-	dateModified: dayjs('2024-08-08'),
+	dateModified: dayjs('2024-08-20'),
 	description: '東京急行電鉄成立（1942年）から1949年までの鉄道線車両のうごきをまとめました。',
 	breadcrumb: [
 		{ path: '/tokyu/', name: '東急電車資料室' },
@@ -325,7 +325,7 @@ const slugger = new GithubSlugger();
 
 		<p>小田原線で全焼事故を起こした車両の代替として川崎車輛<small>（現：川崎車両）</small>で<DateWareki value="1947" />に2両分の車体が製造されたものの、事故車は独自に復旧したため、(元)京浜電気鉄道<small>（現：京浜急行電鉄）</small>の木造車の復旧扱いとしてその新造車体を流用することになりました。</p>
 		<p>台車こそ運輸省 TR-10 型の中古品ですが、車両の新製許可が厳しい時代に廃車同然となっていた戦災車と事故車の名義を利用した面が大きいものと思われ、申請書類においても<q>舊設計圖書は戦災等によって逸散したものが多い</q>との理由を付けて改造工事における各種諸元の新旧比較を省略しています<FootnoteReference><RefTetsudosho government="運輸省" company="東京横浜電鉄" no="東急車丑発第24号" date="1949-05-20" title="車輛設計變更認可申請書" url="https://www.digital.archives.go.jp/item/501674" /></FootnoteReference>。</p>
-		<p>下表のとおり認可、竣功は<DateWareki value="1949" />に行われたものの、車体はデハ3700形、クハ3750形より早く<DateWareki value="1947" />の秋に出場していたことから<FootnoteReference><RefMagazine name="Romance Car" no={19} article="東京急行電鉄3" author="川垣恭三" pages={[7]} /></FootnoteReference>、終戦後初の（事実上の）新車ということになります。</p>
+		<p>下表のとおり認可、竣功は<DateWareki value="1949" />に行われたものの、車体はデハ3700形、クハ3750形より早く<DateWareki value="1947" />の秋に出場し<FootnoteReference><RefMagazine name="Romance Car" no={19} article="東京急行電鉄3" author="川垣恭三" pages={[7]} /></FootnoteReference>、10月～11月にかけて使用を開始していたことから<FootnoteReference><RefMagazine name="鉄道ピクトリアル 1991年7月臨時増刊号" no={546} article="大東急時代の小田急～当時のメモから新造車配属を見て" author="久原秀雄" pages={[87]} /></FootnoteReference>、終戦後初の（事実上の）新車ということになります。</p>
 
 		<div class="p-table -scroll">
 			<table>

--- a/astro/src/pages/tokyu/data/history_tokyu.astro
+++ b/astro/src/pages/tokyu/data/history_tokyu.astro
@@ -320,6 +320,46 @@ const slugger = new GithubSlugger();
 		</div>
 	</Section>
 
+	<Section id="kuha3660">
+		<H slot="heading">クハ3660形</H>
+
+		<p>小田原線で全焼事故を起こした車両の代替として川崎車輛<small>（現：川崎車両）</small>で<DateWareki value="1947" />に2両分の車体が製造されたものの、事故車は独自に復旧したため、(元)京浜電気鉄道<small>（現：京浜急行電鉄）</small>の木造車の復旧扱いとしてその新造車体を流用することになりました。</p>
+		<p>台車こそ運輸省 TR-10 型の中古品ですが、車両の新製許可が厳しい時代に廃車同然となっていた戦災車と事故車の名義を利用した面が大きいものと思われ、申請書類においても<q>舊設計圖書は戦災等によって逸散したものが多い</q>との理由を付けて改造工事における各種諸元の新旧比較を省略しています<FootnoteReference><RefTetsudosho government="運輸省" company="東京横浜電鉄" no="東急車丑発第24号" date="1949-05-20" title="車輛設計變更認可申請書" url="https://www.digital.archives.go.jp/item/501674" /></FootnoteReference>。</p>
+		<p>下表のとおり認可、竣功は<DateWareki value="1949" />に行われたものの、車体はデハ3700形、クハ3750形より早く<DateWareki value="1947" />の秋に出場していたことから<FootnoteReference><RefMagazine name="Romance Car" no={19} article="東京急行電鉄3" author="川垣恭三" pages={[7]} /></FootnoteReference>、終戦後初の（事実上の）新車ということになります。</p>
+
+		<div class="p-table -scroll">
+			<table>
+				<colgroup></colgroup>
+				<colgroup></colgroup>
+				<colgroup span="3"></colgroup>
+				<thead>
+					<tr>
+						<th scope="colgroup" rowspan="2">車号</th>
+						<th scope="colgroup" rowspan="2">旧車号</th>
+						<th scope="colgroup" colspan="3">半鋼体化</th>
+					</tr>
+					<tr>
+						<th scope="col">申請</th>
+						<th scope="col">認可</th>
+						<th scope="col">竣功</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th scope="row">クハ3661</th>
+						<td rowspan="2">クハ5213, 5222</td>
+						<td rowspan="2"><Licence no="東急車丑発第24号" title="車両設計変更認可申請書" date="1949-05-20" /></td>
+						<td rowspan="2"><Licence no="東陸鉄技第173号" date="1949-10-21" /></td>
+						<td rowspan="2"><Licence no="東急車丑発第53号" title="車両竣功届" date="1949-11-30" /></td>
+					</tr>
+					<tr>
+						<th scope="row">クハ3662</th>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</Section>
+
 	<Section id="kuha3670">
 		<H slot="heading">クハ3670形、クハ3770形</H>
 
@@ -757,46 +797,6 @@ const slugger = new GithubSlugger();
 		</div>
 	</Section>
 
-	<Section id="kuha3660">
-		<H slot="heading">クハ3660形</H>
-
-		<p>小田原線で全焼事故を起こした車両の代替として川崎車輛<small>（現：川崎車両）</small>で<DateWareki value="1947" />に2両分の車体が製造されたものの、事故車は独自に復旧したため、(元)京浜電気鉄道<small>（現：京浜急行電鉄）</small>の木造車の復旧扱いとしてその新造車体を流用することになりました。</p>
-		<p>台車こそ運輸省 TR-10 型の中古品ですが、車両の新製許可が厳しい時代に廃車同然となっていた戦災車と事故車の名義を利用した面が大きいものと思われ、申請書類においても<q>舊設計圖書は戦災等によって逸散したものが多い</q>との理由を付けて改造工事における各種諸元の新旧比較を省略しています<FootnoteReference><RefTetsudosho government="運輸省" company="東京横浜電鉄" no="東急車丑発第24号" date="1949-05-20" title="車輛設計變更認可申請書" url="https://www.digital.archives.go.jp/item/501674" /></FootnoteReference>。</p>
-		<p>下表のとおり認可、竣功は<DateWareki value="1949" />に行われたものの、車体はデハ3700形、クハ3750形より早く<DateWareki value="1947" />の秋に出場していたことから<FootnoteReference><RefMagazine name="Romance Car" no={19} article="東京急行電鉄3" author="川垣恭三" pages={[7]} /></FootnoteReference>、終戦後初の（事実上の）新車ということになります。</p>
-
-		<div class="p-table -scroll">
-			<table>
-				<colgroup></colgroup>
-				<colgroup></colgroup>
-				<colgroup span="3"></colgroup>
-				<thead>
-					<tr>
-						<th scope="colgroup" rowspan="2">車号</th>
-						<th scope="colgroup" rowspan="2">旧車号</th>
-						<th scope="colgroup" colspan="3">半鋼体化</th>
-					</tr>
-					<tr>
-						<th scope="col">申請</th>
-						<th scope="col">認可</th>
-						<th scope="col">竣功</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th scope="row">クハ3661</th>
-						<td rowspan="2">クハ5213, 5222</td>
-						<td rowspan="2"><Licence no="東急車丑発第24号" title="車両設計変更認可申請書" date="1949-05-20" /></td>
-						<td rowspan="2"><Licence no="東陸鉄技第173号" date="1949-10-21" /></td>
-						<td rowspan="2"><Licence no="東急車丑発第53号" title="車両竣功届" date="1949-11-30" /></td>
-					</tr>
-					<tr>
-						<th scope="row">クハ3662</th>
-					</tr>
-				</tbody>
-			</table>
-		</div>
-	</Section>
-
 	<Section id="kuha3230">
 		<H slot="heading">クハ3230形</H>
 
@@ -1048,7 +1048,7 @@ const slugger = new GithubSlugger();
 		<ul class="p-list">
 			<li><DateWareki value="1945" />の相模鉄道経営委託に伴い厚木線へデハ3401〜3404 を貸し渡し、翌年の電車線 1500V 統一に伴い返還</li>
 			<li><DateWareki value="1947" />頃の数か月の間、厚木線の日立電鉄供出予定車デハ1051〜1052 を暫定的に東横線で使用</li>
-			<li><DateWareki value="1947" />から1年強の間、厚木線からクハ1113〜1114 を借り入れ、東横線で使用</li>
+			<li><DateWareki value="1947" />から1年強の間、厚木線からクハ1113〜1114 を借り入れて東横線で使用</li>
 			<li><DateWareki value="1947" />に井の頭線から東横線へデハ1366、デハ1401、クハ1553〜1554 が転籍</li>
 		</ul>
 	</Section>

--- a/astro/src/pages/tokyu/data/index.astro
+++ b/astro/src/pages/tokyu/data/index.astro
@@ -9,7 +9,7 @@ const structuredData: StructuredData = {
 	type: 'website',
 	title: '東急電車の車両データ',
 	heading: '車両データ',
-	dateModified: dayjs('2024-08-17'),
+	dateModified: dayjs('2024-08-20'),
 	description: '東急電鉄の車両の車歴や編成表などのデータを紹介します。',
 	breadcrumb: [{ path: '/tokyu/', name: '東急電車資料室' }],
 };

--- a/astro/src/pages/tokyu/index.astro
+++ b/astro/src/pages/tokyu/index.astro
@@ -76,6 +76,9 @@ const structuredData: StructuredData = {
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2024-08-20">
+					<p>車両履歴に<a href="/tokyu/data/history_tokyu#kuha3660">クハ3660形の車両履歴</a>に使用開始日の情報を追記</p>
+				</TopUpdate>
 				<TopUpdate date="2024-08-17">
 					<p><a href="/tokyu/data/history_mekama&toyoko_passenger#kiha1">キハ1形の車両履歴</a>に五日市鉄道への譲渡前の貸し渡しの具体的な期間と申請・認可日を追記、同様に<a href="/tokyu/data/count_mekama&toyoko_passenger">車種別車両数推移</a>も修正</p>
 				</TopUpdate>


### PR DESCRIPTION
基本的には許認可日を基準にしているが、クハ3660形は実態と離れすぎているため、例外的に入籍日（使用開始日）を基準にする。