### PR TITLE
PostCSS Nesting@13 にアップデート

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -91,7 +91,7 @@
 		"postcss-cli": "^11.0.0",
 		"postcss-custom-media": "^11.0.1",
 		"postcss-import": "^16.1.0",
-		"postcss-nesting": "^12.1.5",
+		"postcss-nesting": "^13.0.0",
 		"prettier-plugin-astro": "^0.14.1",
 		"rollup": "^4.21.0"
 	}

--- a/astro/style/object/project/_main.css
+++ b/astro/style/object/project/_main.css
@@ -125,22 +125,22 @@ Styleguide 2.99.3
 		max-inline-size: min(30em, 100%);
 		color: var(--color-black);
 		font-size: calc(100% / pow(var(--font-ratio), 1));
+	}
 
-		&:focus {
-			outline: var(--outline-width-bold) solid var(--outline-color);
-		}
+	&::part(content):focus {
+		outline: var(--outline-width-bold) solid var(--outline-color);
+	}
 
-		&:hover {
-			box-shadow: 0 0 0.5em var(--_border-color);
-		}
+	&::part(content):hover {
+		box-shadow: 0 0 0.5em var(--_border-color);
+	}
 
-		&::before {
-			display: block flow;
-			float: inline-end;
-			block-size: calc(var(--_hide-button-image-size) + var(--_hide-button-padding) * 2);
-			inline-size: calc(var(--_hide-button-image-size) + var(--_hide-button-padding) * 2);
-			content: "";
-		}
+	&::part(content)::before {
+		display: block flow;
+		float: inline-end;
+		block-size: calc(var(--_hide-button-image-size) + var(--_hide-button-padding) * 2);
+		inline-size: calc(var(--_hide-button-image-size) + var(--_hide-button-padding) * 2);
+		content: "";
 	}
 
 	&::part(hide-button) {
@@ -155,15 +155,15 @@ Styleguide 2.99.3
 		border-radius: var(--border-radius-normal);
 		background: var(--_background-color);
 		padding: var(--_hide-button-padding);
+	}
 
-		&:focus {
-			outline: var(--outline-width-bold) solid var(--outline-color);
-		}
+	&::part(hide-button):focus {
+		outline: var(--outline-width-bold) solid var(--outline-color);
+	}
 
-		&:hover {
-			--_border-color: var(--color-bg-light);
-			--_background-color: var(--color-bg-superlight);
-		}
+	&::part(hide-button):hover {
+		--_border-color: var(--color-bg-light);
+		--_background-color: var(--color-bg-superlight);
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,58 +94,9 @@
 				"postcss-cli": "^11.0.0",
 				"postcss-custom-media": "^11.0.1",
 				"postcss-import": "^16.1.0",
-				"postcss-nesting": "^12.1.5",
+				"postcss-nesting": "^13.0.0",
 				"prettier-plugin-astro": "^0.14.1",
 				"rollup": "^4.21.0"
-			}
-		},
-		"astro/node_modules/@csstools/selector-resolve-nested": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-1.1.0.tgz",
-			"integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"engines": {
-				"node": "^14 || ^16 || >=18"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^6.0.13"
-			}
-		},
-		"astro/node_modules/postcss-nesting": {
-			"version": "12.1.5",
-			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.1.5.tgz",
-			"integrity": "sha512-N1NgI1PDCiAGWPTYrwqm8wpjv0bgDmkYHH72pNsqTCv9CObxjxftdYu6AKtGN+pnJa7FQjMm3v4sp8QJbFsYdQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"dependencies": {
-				"@csstools/selector-resolve-nested": "^1.1.0",
-				"@csstools/selector-specificity": "^3.1.1",
-				"postcss-selector-parser": "^6.1.0"
-			},
-			"engines": {
-				"node": "^14 || ^16 || >=18"
-			},
-			"peerDependencies": {
-				"postcss": "^8.4"
 			}
 		},
 		"astro/node_modules/slash": {
@@ -807,6 +758,28 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
+			}
+		},
+		"node_modules/@csstools/selector-resolve-nested": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-2.0.0.tgz",
+			"integrity": "sha512-oklSrRvOxNeeOW1yARd4WNCs/D09cQjunGZUgSq6vM8GpzFswN+8rBZyJA29YFZhOTQ6GFzxgLDNtVbt9wPZMA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^6.1.0"
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
@@ -12028,6 +12001,55 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-nesting": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.0.tgz",
+			"integrity": "sha512-TCGQOizyqvEkdeTPM+t6NYwJ3EJszYE/8t8ILxw/YoeUvz2rz7aM8XTAmBWh9/DJjfaaabL88fWrsVHSPF2zgA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"dependencies": {
+				"@csstools/selector-resolve-nested": "^2.0.0",
+				"@csstools/selector-specificity": "^4.0.0",
+				"postcss-selector-parser": "^6.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4"
+			}
+		},
+		"node_modules/postcss-nesting/node_modules/@csstools/selector-specificity": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz",
+			"integrity": "sha512-189nelqtPd8++phaHNwYovKZI0FOzH1vQEE3QhHHkNIGrg5fSs9CbYP3RvfEH5geztnIA9Jwq91wyOIwAW5JIQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^6.1.0"
 			}
 		},
 		"node_modules/postcss-normalize-charset": {


### PR DESCRIPTION
#569 で緊急的に v12 に戻していたが、解決法が判明したので再び v13 にアップデートする。

`::part()` に付随する疑似クラス、疑似要素はネストせず独立させる必要がある。