### PR TITLE
メディア紹介 2024年10月30日更新分

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -123,6 +123,9 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2024-10-30">
+					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に「朝日新聞 2024年10月29日 朝刊」を追加</p>
+				</TopUpdate>
 				<TopUpdate date="2024-10-13">
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「めざせ！まんが家　PCでまんがを描こう！」（2014年）を追加</p>
 					<p><a href="/kumeta/library/freepaper">メディア紹介 — フリーペーパー</a>に「GCLマガジン」（2024年）を追加</p>
@@ -137,9 +140,6 @@ const slugger = new GithubSlugger();
 				<TopUpdate date="2024-08-08">
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「月刊ニュータイプ　2011年9月号」を追加</p>
 					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に「読売新聞（島根版） 2009年3月19日　朝刊」「読売新聞（熊本版） 2017年9月8日　朝刊」「日刊スポーツ 2024年6月22日」「スポーツ報知 2024年6月22日」を追加</p>
-				</TopUpdate>
-				<TopUpdate date="2024-07-22">
-					<p><a href="/kumeta/yomoyama/zetsubou_web">アニメ『さよなら絶望先生』公式サイトのアーカイブ</a>の一覧表を2024年の TV アニメ 3サイト構成変更に追従</p>
 				</TopUpdate>
 			</ul>
 		</div>

--- a/astro/src/pages/kumeta/library/newspaper.astro
+++ b/astro/src/pages/kumeta/library/newspaper.astro
@@ -13,7 +13,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の新聞での紹介例',
 	heading: 'メディア紹介 — 新聞',
-	dateModified: dayjs('2024-08-17'),
+	dateModified: dayjs('2024-10-30'),
 	description: '新聞紙上において久米田先生のインタビューや作品紹介などが掲載された事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: '久米田康治データベース' }],
 	localNav: {
@@ -382,7 +382,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 
 			<ul class="p-notes">
-				<li><LinkExternal href="https://www.ntv.co.jp/goten/articles/32dxmld9epjxplcgbp.html">「人によく怒られる有名人」特集</LinkExternal>で久米田先生が出演</li>
+				<li><LinkExternal href="https://www.ntv.co.jp/goten/articles/32dxmld9epjxplcgbp.html">「人によく怒られる有名人」特集</LinkExternal>で久米田先生が同番組2回目の出演</li>
 				<li>一例として朝日新聞の朝刊を挙げたが、他の多くの新聞の TV 欄でも同様の内容が夕刊を含めて掲載</li>
 			</ul>
 		</LibNewspaper>
@@ -478,6 +478,17 @@ const slugger = new GithubSlugger();
 			<LibContent>
 				<LibItem position="9面">「<cite>車窃盗疑い、2人不起訴　地検、漫画家が被害</cite>」レクサス盗難事件の容疑者が不起訴になった記事（被害者実名報道）</LibItem>
 			</LibContent>
+		</LibNewspaper>
+
+		<LibNewspaper slugger={slugger} headingLevel={3} title="朝日新聞" release="2024-10-29" npClass="朝刊">
+			<LibContent>
+				<LibItem position="40面（TV欄）">『<cite>踊る！さんま御殿!!</cite>』の紹介文に<q>売れたくて絵を変えた人気漫画家悲しい告白</q></LibItem>
+			</LibContent>
+
+			<ul class="p-notes">
+				<li><LinkExternal href="https://www.ntv.co.jp/goten/articles/3250d1gen2jm3xjyth.html">「流行りに乗りたい人vs流行りに乗らない人」特集</LinkExternal>で久米田先生が同番組3回目の出演</li>
+				<li>一例として朝日新聞の朝刊を挙げたが、他の多くの新聞の TV 欄でも同様の内容が夕刊を含めて掲載</li>
+			</ul>
 		</LibNewspaper>
 	</Section>
 


### PR DESCRIPTION
「朝日新聞 2024年10月29日 朝刊」を追加