### PR TITLE
メディア紹介 2024年12月10日更新分

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -123,6 +123,9 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2024-12-10">
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2024年53号」「月刊少年マガジン 2025年1月号」を追加</p>
+				</TopUpdate>
 				<TopUpdate date="2024-11-09">
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2024年49号」を追加</p>
 
@@ -140,9 +143,6 @@ const slugger = new GithubSlugger();
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2024年28号」「週刊少年サンデー 2024年41号」を追加</p>
 
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「GyAO Magazine No.004」（2006年）、「まんが秘宝　男のための青春まんがクロニクル」（2013年）、「人気マンガ・アニメのトラウマ最終回100」（2015年）、「人気マンガ・アニメのトラウマ最終回100　極限編」（2016年）、「人気マンガ・アニメのトラウマ最終回100　総集編」（2017年）、「人気マンガ・アニメのトラウマ最終回　総集編」（2022年）を追加</p>
-				</TopUpdate>
-				<TopUpdate date="2024-08-17">
-					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に「朝日新聞 2007年5月20日 朝刊」「埼玉新聞 2010年6月27日」「西日本新聞 2017年9月25日 夕刊」「北國新聞 2024年6月21日 夕刊」「毎日新聞 2024年6月22日 朝刊」「埼玉新聞 2024年6月22日」「中国新聞 2024年6月22日」「東京新聞 2024年8月3日 朝刊」「日本経済新聞 2024年8月3日 夕刊」を追加</p>
 				</TopUpdate>
 			</ul>
 		</div>

--- a/astro/src/pages/kumeta/library/book.astro
+++ b/astro/src/pages/kumeta/library/book.astro
@@ -1794,7 +1794,7 @@ const slugger = new GithubSlugger();
 
 		<LibBook slugger={slugger} headingLevel={3} title="人気マンガ・アニメのトラウマ最終回100　総集編" release="2017-01" isbn="978-4-86537-070-6" amazonAsin="4865370706" amazonImageId="71NRy9r0A+L" amazonImageWidth={113} amazonImageHeight={160}>
 			<LibContent>
-				<LibItem pages={[108-109]}>『<cite>かってに改蔵</cite>』の最終話が紹介</LibItem>
+				<LibItem pages={[108, 109]}>『<cite>かってに改蔵</cite>』の最終話が紹介</LibItem>
 				<LibItem pages={[189]}>アニメ『<cite>俗・さよなら絶望先生</cite>』の最終回が紹介<small>（BS11 の「<cite>ANIME+</cite>」において縦長映像が流れる放送事故が起こった件）</small></LibItem>
 			</LibContent>
 
@@ -2016,7 +2016,7 @@ const slugger = new GithubSlugger();
 
 		<LibBook slugger={slugger} headingLevel={3} title="人気マンガ・アニメのトラウマ最終回　総集編" release="2022-01-14" isbn="978-4-86537-229-8" amazonAsin="4865372296" amazonImageId="81brfnqPUaL" amazonImageWidth={111} amazonImageHeight={160}>
 			<LibContent>
-				<LibItem pages={[54,55]}>『<cite>さよなら絶望先生</cite>』の最終話が紹介</LibItem>
+				<LibItem pages={[54, 55]}>『<cite>さよなら絶望先生</cite>』の最終話が紹介</LibItem>
 				<LibItem pages={[56]}>アニメ『<cite>俗・さよなら絶望先生</cite>』の最終回が紹介<small>（BS11 の「<cite>ANIME+</cite>」において縦長映像が流れる放送事故が起こった件）</small></LibItem>
 			</LibContent>
 

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -13,7 +13,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の漫画雑誌での紹介例',
 	heading: 'メディア紹介 — 漫画雑誌',
-	dateModified: dayjs('2024-11-09'),
+	dateModified: dayjs('2024-12-10'),
 	description: '漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: '久米田康治データベース' }],
 	localNav: {
@@ -2478,15 +2478,30 @@ const slugger = new GithubSlugger();
 				<li>クイズの回答が翌週の2024年50号目次ページに記載</li>
 			</ul>
 		</LibBook>
+
+		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2024年53号" release="2024-11-27" tags={['企画']}>
+			<LibContent>
+				<LibItem pages={[12, 13]}>「<cite>描いたのだ〜れだ?　クイズ正解発表!!!!!</cite>」</LibItem>
+			</LibContent>
+		</LibBook>
+
+		<LibBook slugger={slugger} headingLevel={3} title="月刊少年マガジン 2025年1月号" release="2024-12-06" tags={['企画']}>
+			<LibContent>
+				<LibItem pages={[4]}>創刊50周年の集合イラストに可久士と姫<small>（<LinkExternal href="https://www.amazon.co.jp/dp/B01N3CRBG8/">単行本3巻</LinkExternal>表紙の流用）</small></LibItem>
+				<LibItem pages={[6]}>50周年記念サイン色紙（可久士、姫、十丸院、羅砂、一子）</LibItem>
+			</LibContent>
+
+			<ul class="p-notes">
+				<li>集合イラスト、色紙ともに<LinkExternal href="https://50th.gmaga.co/">月刊少年マガジン50周年記念サイト</LinkExternal>で公開</li>
+			</ul>
+		</LibBook>
 	</Section>
 	<Section slugger={slugger}>
 		<H slot="heading">調査中</H>
 
 		<ul class="p-list">
 			<li>週刊少年サンデー 1992年30号の「<cite>ガチャガチャカンパニー</cite>」で募集した「<cite>ウソペンネーム</cite>」の選定結果発表は行われたのか? 週刊少年サンデー1992年31号〜40号を確認したが、発見できなかった。</li>
-			<li>
-				1999年、雑誌に久米田先生の仕事環境の紹介ページがカラーで掲載されたらしい<small>（<LinkExternal href="http://tukigamiteta.blog43.fc2.com/blog-entry-104.html">もう、いーかげんなおはなし 「かってに改蔵」連載中に行われた企画について</LinkExternal>）</small>。週刊少年サンデー1998年36・37号〜2000年7号、および週刊少年サンデー超（増刊）1999年1月号〜2000年1月号を確認したが、それらしき記事は発見できなかった。1998年に週刊少年サンデーの企画「<cite>突撃!!プロテク研究所</cite>」で久米田先生の仕事場の写真が掲載されたことがあり（ただしこちらはモノクロページ）、それと混同されているのか、それともサンデー以外の雑誌なのか引き続き調査したい。
-			</li>
+			<li>1999年、雑誌に久米田先生の仕事環境の紹介ページがカラーで掲載されたらしい<small>（<LinkExternal href="http://tukigamiteta.blog43.fc2.com/blog-entry-104.html">もう、いーかげんなおはなし 「かってに改蔵」連載中に行われた企画について</LinkExternal>）</small>。週刊少年サンデー1998年36・37号〜2000年7号、および週刊少年サンデー超（増刊）1999年1月号〜2000年1月号を確認したが、それらしき記事は発見できなかった。1998年に週刊少年サンデーの企画「<cite>突撃!!プロテク研究所</cite>」で久米田先生の仕事場の写真が掲載されたことがあり（ただしこちらはモノクロページ）、それと混同されているのか、それともサンデー以外の雑誌なのか引き続き調査したい。</li>
 		</ul>
 	</Section>
 </Layout>


### PR DESCRIPTION
「週刊少年サンデー 2024年53号」「月刊少年マガジン 2025年1月号」を追加