### PR TITLE
origin ヘッダーのチェックを無効化

### DIFF
--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -12,6 +12,9 @@ export default defineConfig({
 	publicDir: './public',
 	outDir: './dist',
 	compressHTML: false,
+	security: {
+		checkOrigin: false, // https://github.com/withastro/astro/issues/12851
+	},
 	build: {
 		format: 'file',
 	},


### PR DESCRIPTION
#603 で Astro v5 にアップデート以後、問い合わせフォームの送信処理ができていなかった（送信ボタンを押すと Astro デフォルトのエラー画面になる）