### PR TITLE
3ドメインの Express → hono 化に伴う「当サイトの Web 技術」ページ内容追従

### DIFF
--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -237,16 +237,16 @@ const structuredData: StructuredData = {
 
 			<CodeBlock
 				code={`window.addEventListener('error', (ev) => {
-	const formData = new FormData();
-	formData.append('location', location.toString());
-	formData.append('message', ev.message);
-	formData.append('filename', ev.filename);
-	formData.append('lineno', String(ev.lineno));
-	formData.append('colno', String(ev.colno));
-
 	fetch(ENDPOINT, {
 		method: 'POST',
-		body: new URLSearchParams([...formData]),
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			documentURL: location.toString(),
+			message: ev.message,
+			jsURL: ev.filename,
+			lineNumber: ev.lineno,
+			columnNumber: ev.colno,
+		}),
 	});
 });`}
 				language="javascript"

--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -12,7 +12,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: 'w0s.jp の Web 技術',
 	heading: '当サイトの Web 技術',
-	dateModified: dayjs('2024-06-23'),
+	dateModified: dayjs('2025-02-09'),
 	breadcrumb: [{ path: '/', name: 'ホーム' }],
 };
 ---
@@ -47,7 +47,7 @@ const structuredData: StructuredData = {
 			<dd>
 				<p>NURS はドメインがサブドメインで分ける方式ではなく全ユーザー共通であり、Cookie の導入がセキュリティ上の理由<NoteRef by="nurs-cookie" />で躊躇われることから<LinkExternal href="https://www.inetd.co.jp/">アイネットディー</LinkExternal>に移転したうえで独自ドメインを取得。月額270円の格安サーバーにしては Cron の制限が緩いのがありがたかった。</p>
 
-				<NoteRefContent id="nurs-cookie"><LinkExternal href="http://takagi-hiromitsu.jp/diary/20100501.html">高木浩光＠自宅の日記 - 共用SSLサーバの危険性が理解されていない</LinkExternal>で解説されているように、フレームを利用して他サイトから読み出すことが可能なため。</NoteRefContent>
+				<NoteRefContent id="nurs-cookie"><LinkExternal href="http://takagi-hiromitsu.jp/diary/20100501.html">高木浩光＠自宅の日記 - <cite>共用SSLサーバの危険性が理解されていない</cite></LinkExternal>で解説されているように、フレームを利用して他サイトから読み出すことが可能なため。</NoteRefContent>
 			</dd>
 			<dt>2017年1月</dt>
 			<dd>
@@ -143,7 +143,7 @@ const structuredData: StructuredData = {
 
 		<ul class="p-list">
 			<li>
-				静的ファイルを事前に生成するページは、<a href="https://w0s.jp/"><code>w0s.jp</code></a> では <LinkExternal href="https://astro.build/">Astro</LinkExternal> を使用、一方 <a href="https://blog.w0s.jp/"><code>blog.w0s.jp</code></a> では自作の Node.js プログラムにテンプレート言語として <LinkExternal href="https://ejs.co/">EJS</LinkExternal> を組み合わせているが、そのままだと HTML のインデントが不揃いになってしまう。周知のとおりブラウザにはソースの表示機能があり、これはユーザースタイルシートを設定する場合などに欠かせない。昨今ではソースを開発者ツールで見るユーザーも多いと思うが、公共施設のパソコンなど開発者ツールの機能が封じられているケースもあるため、生の HTML を綺麗に整形しておくことは重要なことと考えている。さらに事前に圧縮ファイルを生成しておくことで通信量の削減にも繋がるため、ビルドに際して以下の処理を挟んでいる。
+				静的ファイルを事前に生成するページは、<code>w0s.jp</code> では <LinkExternal href="https://astro.build/">Astro</LinkExternal> を使用、一方 <code>blog.w0s.jp</code> では自作の Node.js プログラムにテンプレート言語として <LinkExternal href="https://ejs.co/">EJS</LinkExternal> を組み合わせているが、そのままだと HTML のインデントが不揃いになってしまう。周知のとおりブラウザにはソースの表示機能があり、これはユーザースタイルシートを設定する場合などに欠かせない。昨今ではソースを開発者ツールで見るユーザーも多いと思うが、公共施設のパソコンなど開発者ツールの機能が封じられているケースもあるため、生の HTML を綺麗に整形しておくことは重要なことと考えている。さらに事前に圧縮ファイルを生成しておくことで通信量の削減にも繋がるため、ビルドに際して以下の処理を挟んでいる。
 				<ul>
 					<li><LinkExternal href="https://prettier.io/">Prettier</LinkExternal>で HTML ファイルを整形</li>
 					<li><LinkExternal href="https://github.com/dzek69/brotli-cli">brotli-cli</LinkExternal>で Brotli 圧縮したファイル（e.g. <code>index.html.br</code>）を出力</li>
@@ -158,25 +158,25 @@ const structuredData: StructuredData = {
 				</ul>
 			</li>
 			<li>HTML ページの MIME タイプは <code>text/html</code> としている。コンテンツのデータをスクレイピングで活用したいユーザーにとっては XML として処理できた方が便利だろうとの考えで以前は <code>application/xhtml+xml</code> で配信していたが、Google 翻訳（URL 指定）が対応していないなどの外部要因によりデメリットの方が大きくなってきており、今や <code>text/html</code> の方が利便性は高いものと判断する。ちなみに HTML Living Standard では2024年4月より XML 構文の使用は推奨されないとの記述が追加された<NoteRef type="ref" by="xhtml-blog" />。</li>
-			<li>
-				ウェブページの URL に拡張子が含まれるのは好ましくないと考えているので<NoteRef by="ext" />、拡張子なしの URL でアクセスできるようにしている。
-			</li>
+			<li>ウェブページの URL に拡張子が含まれるのは好ましくないので<NoteRef type="ref" by="ext" />、拡張子なしの URL でアクセスできるようにしている。</li>
 		</ul>
 
-		<NoteRefContent id="xhtml-blog">ブログ記事 <a href="https://blog.w0s.jp/706">XHTML の終焉と XHTML 1.0 Transitional 時代の思い出</a>（2024年4月）</NoteRefContent>
+		<NoteRefContent id="xhtml-blog">ブログ記事 <a href="https://blog.w0s.jp/entry/706"><cite>XHTML の終焉と XHTML 1.0 Transitional 時代の思い出</cite></a>（2024年4月）</NoteRefContent>
 
-		<NoteRefContent id="ext">Tim Berners-Lee による <LinkExternal href="https://www.w3.org/Provider/Style/URI" lang="en" hreflang="en">Cool URIs don't change</LinkExternal>でも URL にファイル名拡張子を含めることは問題を引き起こすと言われている。</NoteRefContent>
+		<NoteRefContent id="ext"><span lang="en"><LinkExternal href="https://www.w3.org/Provider/Style/URI" hreflang="en"><cite>Cool URIs don't change</cite></LinkExternal> (Tim Berners-Lee, 1998)</span></NoteRefContent>
 
 		<Section id="html-redirect" depth={2} headingType="c">
 			<H slot="heading">3xx リダイレクトページ</H>
 
-			<p>URL が変更になった場合は <code>301 Moved Permanently</code>、フォームの POST 送信後には <code>303 See Other</code> などいくつかのケースでは HTTP レスポンス 3xx でリダイレクトを設定している。</p>
+			<p>URL が変更になった場合は 301 Moved Permanently、フォームの POST 送信後には 303 See Other などいくつかのケースでは HTTP レスポンス 3xx でリダイレクトを設定している。</p>
 
-			<p><LinkExternal href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4">RFC 7231 の 6.4. Redirection 3xx</LinkExternal>では、ステータスコード 3xx で <code>Location</code> ヘッダーフィールドが設定されている場合のユーザーエージェントの挙動として<q lang="en" cite="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.4">the user agent <mark>MAY</mark> automatically redirect its request to the URI</q>と書かれており（あくまで <em lang="en">MAY</em> であることに注目）、実際にブラウザの環境によっては自動リダイレクトが行われず、レスポンスボディの内容が画面に表示されることがある<NoteRef by="3xx-error" />。</p>
+			<p><LinkExternal href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4">RFC 7231 の <cite lang="en">6.4. Redirection 3xx</cite></LinkExternal>では、ステータスコード 3xx で <code>Location</code> ヘッダーフィールドが設定されている場合のユーザーエージェントの挙動として<q lang="en" cite="https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.4">the user agent <mark>MAY</mark> automatically redirect its request to the URI</q>と書かれており（あくまで <em lang="en">MAY</em> であることに注目）、実際にブラウザの環境によっては自動リダイレクトが行われず、レスポンスボディの内容が画面に表示されるケースが存在する<NoteRef by="3xx-error" />。</p>
 
 			<NoteRefContent id="3xx-error">Android Firefox ではアプリ連携された URL に 3xx でリダイレクトすると、当該アプリが自動で起動するが、ブラウザでは 3xx のレスポンスボディが表示された状態になる。（2022年2月現在、Android Firefox 96 にて確認）</NoteRefContent>
 
-			<p>当サイトで使用している Node.js フレームワークの Express では、<LinkExternal href="https://expressjs.com/en/4x/api.html#res.redirect"><code>res.redirect()</code></LinkExternal> メソッドでリダイレクト設定を行うことができるが、この場合レスポンスボディは <code is:raw>&lt;p&gt;Moved Permanently. Redirecting to &lt;a href="${path}"&gt;${path}&lt;/a&gt;&lt;/p&gt;</code> のように、DOCTYPE や <code>&lt;title&gt;</code> 要素のない不正な HTML となってしまう。これについては <LinkExternal href="https://github.com/expressjs/express/issues/5058">Issue を上げており</LinkExternal>、それに対する <LinkExternal href="https://github.com/expressjs/express/pull/5167">Pull Request も提出されている</LinkExternal>が、2024年6月現在マージはされていない。そのためこの機能は使わず、<LinkExternal href="https://expressjs.com/en/4x/api.html#res.send"><code>res.send()</code></LinkExternal> メソッドにて独自の HTML を返すようにカスタマイズしている。</p>
+			<p><code>w0s.jp</code> で使用している Node.js フレームワークの Express では、<LinkExternal href="https://expressjs.com/en/5x/api.html#res.redirect"><code>res.redirect()</code></LinkExternal> メソッドでリダイレクト設定を行うことができるが、この場合レスポンスボディは <code lang="en" is:raw>&lt;p&gt;Moved Permanently. Redirecting to &lt;a href="${path}"&gt;${path}&lt;/a&gt;&lt;/p&gt;</code> のように、DOCTYPE や <code>&lt;title&gt;</code> 要素のない不正な HTML となってしまう。これについては <LinkExternal href="https://github.com/expressjs/express/issues/5058">Issue を上げており</LinkExternal>、それに対する <LinkExternal href="https://github.com/expressjs/express/pull/5167">Pull Request も提出されている</LinkExternal>が、2025年2月現在マージはされていない。そのためこの機能は使わず、<LinkExternal href="https://expressjs.com/en/5x/api.html#res.send"><code>res.send()</code></LinkExternal> メソッドにて独自の HTML を返すようにカスタマイズしている。</p>
+
+			<p>同じ理由で <code>blog.w0s.jp</code> でも Hono の <LinkExternal href="https://hono.dev/docs/api/context#redirect"><code>c.redirect()</code></LinkExternal> メソッドは使わず、<LinkExternal href="https://hono.dev/docs/api/context#html"><code>c.html()</code></LinkExternal> メソッドの第2～3引数を活用する形で実装している。</p>
 		</Section>
 
 		<Section id="html-clienterror" depth={2} headingType="c">
@@ -185,8 +185,8 @@ const structuredData: StructuredData = {
 			<p><code>404 Not Found</code> のエラーページには JavaScript で以下の機能を組み込んでいる。</p>
 
 			<ul class="p-list">
-				<li>同一ドメインのリファラーがあった場合（= サイト内から無効なリンクが張られている）は管理者へ通知する。<LinkExternal href="https://github.com/SaekiTominaga/frontend/tree/main/packages/report-same-referrer">検知プログラムは GitHub で公開</LinkExternal>している。</li>
-				<li>直近の有効な祖先ディレクトリへのリンクを提示する。（e.g. <code>/foo/bar/baz</code> へのリクエストに対し、<code>/foo/bar/baz</code> のレスポンスコードが 404 で <code>/foo/bar/</code> が 403、<code>/foo/</code> が 200 の場合、<code>/foo/</code> へのリンクを提示）</li>
+				<li>同一ドメインのリファラーがあった場合（= サイト内から無効なリンクが張られている）は管理者へ通知する。<LinkExternal href="https://github.com/SaekiTominaga/js-library-browser/tree/main/packages/report-same-referrer">検知プログラムは GitHub で公開</LinkExternal>している。</li>
+				<li>直近の有効な祖先ディレクトリへのリンクを提示する。（e.g. <code>/foo/bar</code> へのリクエストに対し、そのレスポンスコードが 404 で <code>/foo/</code> が 200 の場合、<code>/foo/</code> のリンクを提示）</li>
 			</ul>
 		</Section>
 	</Section>
@@ -200,7 +200,7 @@ const structuredData: StructuredData = {
 			<li><LinkExternal href="https://stylelint.io/">Stylelint</LinkExternal>を使用したチェックを実施している。<LinkExternal href="https://github.com/SaekiTominaga/config/tree/main/packages/stylelint">設定ファイルは GitHub で公開</LinkExternal>している。</li>
 		</ul>
 
-		<NoteRefContent id="css-minify-blog">ブログ記事 <a href="https://blog.w0s.jp/674">CSS ファイルの最小化を止めた</a>（2022年6月）</NoteRefContent>
+		<NoteRefContent id="css-minify-blog">ブログ記事 <a href="https://blog.w0s.jp/entry/674"><cite>CSS ファイルの最小化を止めた</cite></a>（2022年6月）</NoteRefContent>
 
 		<Section id="style-print" depth={2} headingType="c">
 			<H slot="heading">印刷用スタイル</H>
@@ -218,6 +218,17 @@ const structuredData: StructuredData = {
 				<li>ヘッダーやフッターを非表示にする簡易なスタイルシートを用意し、<LinkExternal href="https://html.spec.whatwg.org/multipage/links.html#the-link-is-an-alternative-stylesheet">代替スタイルシート</LinkExternal>で任意に適用可能な状態としている。PC 版 Firefox ではメニューバーの「表示」→「スタイルシート」から切り替え可能である。Chrome など他ブラウザでも拡張機能が公開されている。</li>
 			</ul>
 		</Section>
+
+		<Section id="style-darkmode" depth={2} headingType="c">
+			<H slot="heading">ダークモード</H>
+
+			<ul class="p-list">
+				<li>制作者スタイルシートでいわゆるダークモードを提供するサイトが多いが、本来そのような機能はブラウザが提供すべきものと考えており、本サイトにおいて背景色などの切り替え機構を提供するつもりはない。</li>
+				<li>Edge は2024年にページカラーをカスタマイズする機能を実装している<NoteRef type="ref" by="edge-color-blog" />。そのような機能を持たないブラウザを使っている方はアドオンを探すなり、ユーザースタイルシートを書くなりして各自で対応して欲しい。</li>
+			</ul>
+
+			<NoteRefContent id="edge-color-blog">ブログ記事 <a href="https://blog.w0s.jp/entry/724"><cite>Edge の新しいページカラー設定と `background-color` や `border` 使用時のアクセシビリティ</cite></a>（2024年10月）</NoteRefContent>
+		</Section>
 	</Section>
 
 	<Section id="script">
@@ -227,13 +238,13 @@ const structuredData: StructuredData = {
 
 		<ul class="p-list">
 			<li>ソースコードは TypeScript による記述とし、コンパイルには <LinkExternal href="https://www.rollupjs.org/">Rollup</LinkExternal> を使用している。</li>
-			<li>外部サービスに関係した機能など一部を除き ES modules で作成しており、本来であれば機能ごとに別れたファイルを <code>import</code> / <code>export</code> を使ってそのままブラウザに読ませることができるが、実際のところ HTTP/2 通信下であっても画面描画への影響が体感できるほど大きかったため、ビルド時にファイル結合を行うようにしている。</li>
+			<li>外部サービスに関係した機能など一部を除き ES modules で作成しており、本来であれば機能ごとに別れたファイルを <code>import</code> / <code>export</code> を使ってそのままブラウザに読ませることができるのだが、実際には HTTP/2 通信下であっても画面描画への影響が体感できるほど大きかったため、ビルド時にファイル結合を行うようにしている。</li>
 		</ul>
 
 		<Section id="script-error" depth={2} headingType="c">
 			<H slot="heading">エラー検知</H>
 
-			<p>作成したスクリプト機能は普段使いのブラウザでの軽い動作確認はしているが、きちんとしたテストは行っていない。というより、サーバーサイドプログラムとは異なりブラウザには様々な設定項目があり、Bot 等も含めたあらゆる環境を想定したテストを行うことなど不可能だと考えている。もとより前述のとおりスクリプトが動かなくてもコンテンツの閲覧には支障がないため、テストはそこそこで良いと割り切り、せめて発生してしまったエラーは把握できるよう、<code>error</code> イベントを検知し通知する機能を組み込んでいる。この<LinkExternal href="https://github.com/SaekiTominaga/frontend/tree/main/packages/report-js-error">検知プログラムは GitHub で公開</LinkExternal>しているが、簡略化したコード例を下記に示す。</p>
+			<p>作成したスクリプト機能は普段使いのブラウザでの軽い動作確認はしているが、きちんとしたテストは行っていない。というより、サーバーサイドプログラムとは異なりブラウザには様々な設定項目があり、Bot 等も含めたあらゆる環境を想定したテストを行うことなど不可能だと考えている。もとより前述のとおりスクリプトが動かなくてもコンテンツの閲覧には支障がないため、テストはそこそこで良いと割り切り、せめて発生してしまったエラーは把握できるよう、<code>error</code> イベントを検知し通知する機能を組み込んでいる。この<LinkExternal href="https://github.com/SaekiTominaga/js-library-browser/tree/main/packages/report-js-error">検知プログラムは GitHub で公開</LinkExternal>しているが、簡略化したコード例を下記に示す。</p>
 
 			<CodeBlock
 				code={`window.addEventListener('error', (ev) => {
@@ -278,14 +289,10 @@ const structuredData: StructuredData = {
 		<p>これらの画像は <code>/path/to/image.jpg?type=avif;w=360;h=240;quality=30</code> のように URL パラメーターでサイズや画質を指定して動的生成している。詳細は画像を配置している <a href="https://media.w0s.jp/"><code>media.w0s.jp</code></a> にドキュメントを置いているが、ドキュメントで触れていないポイントについて以下に述べる。</p>
 
 		<ul class="p-list">
+			<li>URL パラメーターの区切り文字は一般的な <code>&amp;</code> だけでなく <code>;</code> にも対応しており、原則として後者を利用する。これは HTML4 時代に <LinkExternal href="https://www.w3.org/TR/2018/SPSD-html401-20180327/appendix/notes.html#h-B.2.2" lang="en"><cite>B.2.2 Ampersands in URI attribute values</cite></LinkExternal>で推奨されていたテクニックである。設定は Hono のミドルウェアに <LinkExternal href="https://github.com/ljharb/qs">qs</LinkExternal>のライブラリを適用することで実現している。</li>
+			<li>画像生成は <LinkExternal href="https://sharp.pixelplumbing.com/">sharp</LinkExternal>を利用しているが、AVIF への変換処理は JPEG や WebP と比較して遅く、多数の画像を埋め込んだページでは問題があるため AVIF の初回リクエストに限っては代替として WebP を動的生成して返し、別途バッチ処理で AVIF を生成するようにしている。この場合、ブラウザ視点では「<code>&lt;source type="image/avif"&gt;</code> の画像をリクエストしたら <code>image/webp</code> が返ってきた」という状態になる。一見違和感があるものの、<LinkExternal href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">HTML 仕様における <code>&lt;source&gt;</code> 要素の定義</LinkExternal>では <q lang="en" cite="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">The type attribute gives the type of the images in the source set, to allow the user agent to skip to the next source element if it does not support the given type.</q> とされているため問題なく、どのブラウザも正常に動作する。</li>
 			<li>
-				URL パラメーターの区切り文字は一般的な <code>&amp;</code> だけでなく <code>;</code> にも対応しており、原則として後者を利用する。これは HTML4 時代に <LinkExternal href="https://www.w3.org/TR/2018/SPSD-html401-20180327/appendix/notes.html#h-B.2.2">B.2.2 Ampersands in URI attribute values</LinkExternal>で推奨されていたテクニックである。設定は Express の <LinkExternal href="https://expressjs.com/en/4x/api.html#app.settings.table"><code>app.set('query parser', value)</code></LinkExternal>にカスタムクエリ文字列解析関数を指定することで実現している。
-			</li>
-			<li>
-				画像生成は <LinkExternal href="https://sharp.pixelplumbing.com/">sharp</LinkExternal>を利用しているが、AVIF への変換処理は JPEG や WebP と比較して遅く、多数の画像を埋め込んだページでは問題があるため AVIF の初回リクエストに限っては代替として WebP を動的生成して返し、別途バッチ処理で AVIF を生成するようにしている。この場合、ブラウザ視点では「<code>&lt;source type="image/avif"&gt;</code> の画像をリクエストしたら <code>image/webp</code> が返ってきた」という状態になる。一見違和感があるものの、<LinkExternal href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">HTML 仕様における <code>&lt;source&gt;</code> 要素の定義</LinkExternal>では <q lang="en" cite="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">The type attribute gives the type of the images in the source set, to allow the user agent to skip to the next source element if it does not support the given type.</q> とされているため問題なく、どのブラウザも正常に動作する。
-			</li>
-			<li>
-				一般論として GET リクエストでファイル生成という副作用を及ぼすのは好ましいことではなく、可能なら POST や PUT リクエストを使うべきだろう。一方で <LinkExternal href="https://www.rfc-editor.org/rfc/rfc7231#section-4.2.1">RFC 7231 の 4.2.1. Safe Methods</LinkExternal>では <q lang="en" cite="https://www.rfc-editor.org/rfc/rfc7231#section-4.2.1">This definition of safe methods does not prevent an implementation from including behavior that is potentially harmful, that is not entirely read-only, or that causes side effects while invoking a safe method.</q> と書かれており、
+				一般論として GET リクエストでファイル生成という副作用を及ぼすのは好ましいことではなく、可能なら POST や PUT リクエストを使うべきだろう。一方で <LinkExternal href="https://www.rfc-editor.org/rfc/rfc7231#section-4.2.1">RFC 7231 の <cite lang="en">4.2.1. Safe Methods</cite></LinkExternal>では <q lang="en" cite="https://www.rfc-editor.org/rfc/rfc7231#section-4.2.1">This definition of safe methods does not prevent an implementation from including behavior that is potentially harmful, that is not entirely read-only, or that causes side effects while invoking a safe method.</q> と書かれており、
 				<ul>
 					<li>副作用を起こす実装が禁止されているものではない</li>
 					<li>アクセスログのように GET でサーバー内にファイルを追加・更新する機能は一般的に存在する</li>
@@ -301,9 +308,9 @@ const structuredData: StructuredData = {
 
 		<p>ファビコンは SVG 形式で提供している。</p>
 
-		<p><LinkExternal href="https://web.archive.org/web/20150306041048/http://support.microsoft.com/kb/415022/ja">Internet Explorer 5 の実装</LinkExternal>を発端とする歴史的な経緯により、<code>/favicon.ico</code> のファイルパスにすることでブラウザが自動的に読み取るようになっている。あくまで URL が <code>/favicon.ico</code> であれば良く、ファイルの実体が ICO 形式である必要はないため、SVG 形式のファビコンファイルを <code>/favicon.ico</code> に配置し、MIME タイプを <code>image/svg+xml</code> で返すように設定することで <code>&lt;link rel="icon"&gt;</code> の記述を省略できる<NoteRef type="ref" by="favicon-svg-blog" />。ただし以下のデメリットがある（いずれも2024年6月現在）。</p>
+		<p><LinkExternal href="https://web.archive.org/web/20150306041048/http://support.microsoft.com/kb/415022/ja">Internet Explorer 5 の実装</LinkExternal>を発端とする歴史的な経緯により、<code>/favicon.ico</code> のファイルパスにすることでブラウザが自動的に読み取るようになっているが、あくまで URL が <code lang="en">/favicon.ico</code> であれば良く、ファイルの実体が ICO 形式である必要はない。そのため SVG 形式のファビコンファイルを <code>/favicon.ico</code> に配置し、MIME タイプを <code>image/svg+xml</code> で返すように設定することで <code>&lt;link rel="icon"&gt;</code> の記述を省略できる<NoteRef type="ref" by="favicon-svg-blog" />。ただし以下のデメリットがある（いずれも2024年6月現在）。</p>
 
-		<NoteRefContent id="favicon-svg-blog">ブログ記事 <a href="https://blog.w0s.jp/656">SVG ファビコンのファイル名を <code>favicon.ico</code> にして <code>&lt;link rel="icon"&gt;</code> を省略する</a>（2021年10月）</NoteRefContent>
+		<NoteRefContent id="favicon-svg-blog">ブログ記事 <a href="https://blog.w0s.jp/entry/656"><cite>SVG ファビコンのファイル名を <code>favicon.ico</code> にして <code>&lt;link rel="icon"&gt;</code> を省略する</cite></a>（2021年10月）</NoteRefContent>
 
 		<ul class="p-list">
 			<li>Safari は最新のバージョン 17 系においても SVG ファビコンに対応していない</li>
@@ -322,6 +329,6 @@ const structuredData: StructuredData = {
 			<li>Reporting のエンドポイントは <code>report.w0s.jp</code> 内に作成しており、<LinkExternal href="https://github.com/SaekiTominaga/report.w0s.jp/blob/main/node/src/controller/csp.ts">ソースコードは GitHub で公開</LinkExternal>している<NoteRef type="ref" by="csp-blog" />。</li>
 		</ul>
 
-		<NoteRefContent id="csp-blog">ブログ記事 <a href="https://blog.w0s.jp/730">Report URI サービスの有料化に伴い CSP レポートのエンドポイントを自作</a>（2025年1月）</NoteRefContent>
+		<NoteRefContent id="csp-blog">ブログ記事 <a href="https://blog.w0s.jp/entry/730"><cite>Report URI サービスの有料化に伴い CSP レポートのエンドポイントを自作</cite></a>（2025年1月）</NoteRefContent>
 	</Section>
 </Layout>

--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -59,26 +59,16 @@ const structuredData: StructuredData = {
 	<Section id="server">
 		<H slot="heading">サーバー構成</H>
 
-		<dl class="p-list-description">
-			<dt>サーバー</dt>
-			<dd><LinkExternal href="https://httpd.apache.org/">Apache HTTP Server</LinkExternal></dd>
-			<dt>アプリケーション</dt>
-			<dd><LinkExternal href="https://nodejs.org/">Node.js</LinkExternal></dd>
-			<dt>プロセス・マネージャー</dt>
-			<dd><LinkExternal href="https://pm2.keymetrics.io/">PM2</LinkExternal></dd>
-			<dt>データベース (RDBMS)</dt>
-			<dd><LinkExternal href="https://sqlite.org/">SQLite</LinkExternal>, <LinkExternal href="https://www.mysql.com/">MySQL</LinkExternal></dd>
-		</dl>
-
-		<div class="p-table">
+		<div class="p-table -scroll">
 			<table>
-				<caption>ドメイン一覧</caption>
 				<thead>
 					<tr>
 						<th scope="col">ドメイン</th>
 						<th scope="col">用途</th>
+						<th scope="col">サーバー実行環境</th>
 						<th scope="col">フレームワーク</th>
-						<th scope="col">ソースコード</th>
+						<th scope="col">RDBMS</th>
+						<th scope="col">ソース</th>
 						<th scope="col">備考</th>
 					</tr>
 				</thead>
@@ -86,34 +76,29 @@ const structuredData: StructuredData = {
 					<tr>
 						<td><a href="https://w0s.jp/"><code>w0s.jp</code></a></td>
 						<td>個人サイト</td>
+						<td rowspan="4"><LinkExternal href="https://nodejs.org/" icon={false}>Node.js</LinkExternal> + <LinkExternal href="https://pm2.keymetrics.io/" icon={false}>PM2</LinkExternal></td>
 						<td><LinkExternal href="https://expressjs.com/" icon={false}>Express</LinkExternal>, <LinkExternal href="https://astro.build/" icon={false}>Astro</LinkExternal></td>
+						<td class="u-cell -center">―</td>
 						<td class="u-cell -center">
 							<a href="https://github.com/SaekiTominaga/w0s.jp" rel="external" aria-label="w0s.jp の GitHub"><img src="/assets/image/icon/github.svg" alt="GitHub" width="24" height="24" /></a>
 						</td>
-						<td></td>
+						<td>静的コンテンツ中心</td>
 					</tr>
 					<tr>
 						<td><a href="https://blog.w0s.jp/"><code>blog.w0s.jp</code></a></td>
 						<td>ブログ</td>
 						<td><LinkExternal href="https://expressjs.com/" icon={false}>Express</LinkExternal></td>
+						<td><LinkExternal href="https://sqlite.org/" icon={false}>SQLite</LinkExternal></td>
 						<td class="u-cell -center">
 							<a href="https://github.com/SaekiTominaga/blog.w0s.jp" rel="external" aria-label="blog.w0s.jp の GitHub"><img src="/assets/image/icon/github.svg" alt="GitHub" width="24" height="24" /></a>
 						</td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://labs.w0s.jp/"><code>labs.w0s.jp</code></a></td>
-						<td>Web 技術の遊び場</td>
-						<td></td>
-						<td class="u-cell -center">
-							<a href="https://github.com/SaekiTominaga/labs.w0s.jp" rel="external" aria-label="labs.w0s.jp の GitHub"><img src="/assets/image/icon/github.svg" alt="GitHub" width="24" height="24" /></a>
-						</td>
-						<td>HTTP でもアクセス可</td>
-					</tr>
-					<tr>
 						<td><a href="https://media.w0s.jp/"><code>media.w0s.jp</code></a></td>
 						<td>画像、動画、音声の配信</td>
-						<td><LinkExternal href="https://expressjs.com/" icon={false}>Express</LinkExternal></td>
+						<td><LinkExternal href="https://hono.dev/" icon={false}>Hono</LinkExternal></td>
+						<td><LinkExternal href="https://sqlite.org/" icon={false}>SQLite</LinkExternal></td>
 						<td class="u-cell -center">
 							<a href="https://github.com/SaekiTominaga/media.w0s.jp" rel="external" aria-label="media.w0s.jp の GitHub"><img src="/assets/image/icon/github.svg" alt="GitHub" width="24" height="24" /></a>
 						</td>
@@ -122,16 +107,29 @@ const structuredData: StructuredData = {
 					<tr>
 						<td><code>report.w0s.jp</code></td>
 						<td>エラーレポート収集</td>
-						<td><LinkExternal href="https://expressjs.com/" icon={false}>Express</LinkExternal></td>
+						<td><LinkExternal href="https://hono.dev/" icon={false}>Hono</LinkExternal></td>
+						<td><LinkExternal href="https://sqlite.org/" icon={false}>SQLite</LinkExternal></td>
 						<td class="u-cell -center">
 							<a href="https://github.com/SaekiTominaga/report.w0s.jp" rel="external" aria-label="report.w0s.jp の GitHub"><img src="/assets/image/icon/github.svg" alt="GitHub" width="24" height="24" /></a>
 						</td>
 						<td></td>
 					</tr>
 					<tr>
+						<td><a href="https://labs.w0s.jp/"><code>labs.w0s.jp</code></a></td>
+						<td>Web 技術の遊び場</td>
+						<td rowspan="2"><LinkExternal href="https://httpd.apache.org/" icon={false}>Apache</LinkExternal> + <LinkExternal href="https://www.php.net/" icon={false}>PHP</LinkExternal></td>
+						<td class="u-cell -center">―</td>
+						<td class="u-cell -center">―</td>
+						<td class="u-cell -center">
+							<a href="https://github.com/SaekiTominaga/labs.w0s.jp" rel="external" aria-label="labs.w0s.jp の GitHub"><img src="/assets/image/icon/github.svg" alt="GitHub" width="24" height="24" /></a>
+						</td>
+						<td>HTTP でもアクセス可</td>
+					</tr>
+					<tr>
 						<td><code>analytics.w0s.jp</code></td>
 						<td>アクセス解析</td>
-						<td></td>
+						<td class="u-cell -center">―</td>
+						<td><LinkExternal href="https://www.mysql.com/" icon={false}>MySQL</LinkExternal></td>
 						<td class="u-cell -center">―</td>
 						<td><LinkExternal href="https://matomo.org/">Matomo Analytics</LinkExternal> を利用</td>
 					</tr>

--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -157,13 +157,13 @@ const structuredData: StructuredData = {
 					<li>公式のプリセットは HTML Standard や WAI-ARIA への仕様適合だけではなく、パフォーマンスやセキュリティを含めたベストプラクティス的な考えも取り入れられている。純粋な構文チェックに留まらないところは Markuplint の良い点であるが、そのすべてに賛同できるわけではない。</li>
 				</ul>
 			</li>
-			<li>HTML ページの MIME タイプは <code>text/html</code> としている。コンテンツのデータをスクレイピングで活用したいユーザーにとっては XML として処理できた方が便利だろうとの考えで以前は <code>application/xhtml+xml</code> で配信していたが、Google 翻訳（URL 指定）が対応していないなどの外部要因によりデメリットの方が大きくなってきており、今や <code>text/html</code> の方が利便性は高いものと判断する。ちなみに HTML Living Standard では2024年4月より XML 構文の使用は推奨されないとの記述が追加された<NoteRef by="xhtml" />。</li>
+			<li>HTML ページの MIME タイプは <code>text/html</code> としている。コンテンツのデータをスクレイピングで活用したいユーザーにとっては XML として処理できた方が便利だろうとの考えで以前は <code>application/xhtml+xml</code> で配信していたが、Google 翻訳（URL 指定）が対応していないなどの外部要因によりデメリットの方が大きくなってきており、今や <code>text/html</code> の方が利便性は高いものと判断する。ちなみに HTML Living Standard では2024年4月より XML 構文の使用は推奨されないとの記述が追加された<NoteRef type="ref" by="xhtml-blog" />。</li>
 			<li>
 				ウェブページの URL に拡張子が含まれるのは好ましくないと考えているので<NoteRef by="ext" />、拡張子なしの URL でアクセスできるようにしている。
 			</li>
 		</ul>
 
-		<NoteRefContent id="xhtml">詳細はブログ記事 <a href="https://blog.w0s.jp/706">XHTML の終焉と XHTML 1.0 Transitional 時代の思い出</a>（2024年4月）を参照。</NoteRefContent>
+		<NoteRefContent id="xhtml-blog">ブログ記事 <a href="https://blog.w0s.jp/706">XHTML の終焉と XHTML 1.0 Transitional 時代の思い出</a>（2024年4月）</NoteRefContent>
 
 		<NoteRefContent id="ext">Tim Berners-Lee による <LinkExternal href="https://www.w3.org/Provider/Style/URI" lang="en" hreflang="en">Cool URIs don't change</LinkExternal>でも URL にファイル名拡張子を含めることは問題を引き起こすと言われている。</NoteRefContent>
 
@@ -196,11 +196,11 @@ const structuredData: StructuredData = {
 
 		<ul class="p-list">
 			<li>CSS ファイルのビルドには <LinkExternal href="https://postcss.org/">PostCSS</LinkExternal>を使用している。これはブラウザが対応していない機能の先行使用、あるいはファイルをまとめることによるパフォーマンス向上が目的であり、標準化の見込みのないプラグインは使っていない。将来的には変換前のコードをそのままブラウザに読み込ませても問題ないようにすることが目標である。</li>
-			<li>ビルド過程で <LinkExternal href="https://cssnano.github.io/cssnano/">CSSNANO</LinkExternal>を適用しているが、minify 処理が目的ではなくコメントの除去など最小限の最適化のみを行っている。以前は minify 処理も行っていたが、IE 11 のサポート終了によりすべてのメジャーブラウザが Brotli に対応する状況になったことから、通信量の削減効果は薄くなったと考えている<NoteRef by="css-minify" />。</li>
+			<li>ビルド過程で <LinkExternal href="https://cssnano.github.io/cssnano/">CSSNANO</LinkExternal>を適用しているが、minify 処理が目的ではなくコメントの除去など最小限の最適化のみを行っている。以前は minify 処理も行っていたが、IE 11 のサポート終了によりすべてのメジャーブラウザが Brotli に対応する状況になったことから、通信量の削減効果は薄くなったと考えている<NoteRef type="ref" by="css-minify-blog" />。</li>
 			<li><LinkExternal href="https://stylelint.io/">Stylelint</LinkExternal>を使用したチェックを実施している。<LinkExternal href="https://github.com/SaekiTominaga/config/tree/main/packages/stylelint">設定ファイルは GitHub で公開</LinkExternal>している。</li>
 		</ul>
 
-		<NoteRefContent id="css-minify">詳細はブログ記事 <a href="https://blog.w0s.jp/674">CSS ファイルの最小化を止めた</a>（2022年6月）を参照。</NoteRefContent>
+		<NoteRefContent id="css-minify-blog">ブログ記事 <a href="https://blog.w0s.jp/674">CSS ファイルの最小化を止めた</a>（2022年6月）</NoteRefContent>
 
 		<Section id="style-print" depth={2} headingType="c">
 			<H slot="heading">印刷用スタイル</H>
@@ -301,9 +301,9 @@ const structuredData: StructuredData = {
 
 		<p>ファビコンは SVG 形式で提供している。</p>
 
-		<p><LinkExternal href="https://web.archive.org/web/20150306041048/http://support.microsoft.com/kb/415022/ja">Internet Explorer 5 の実装</LinkExternal>を発端とする歴史的な経緯により、<code>/favicon.ico</code> のファイルパスにすることでブラウザが自動的に読み取るようになっている。あくまで URL が <code>/favicon.ico</code> であれば良く、ファイルの実体が ICO 形式である必要はないため、SVG 形式のファビコンファイルを <code>/favicon.ico</code> に配置し、MIME タイプを <code>image/svg+xml</code> で返すように設定することで <code>&lt;link rel="icon"&gt;</code> の記述を省略できる<NoteRef by="favicon-svg" />。ただし以下のデメリットがある（いずれも2024年6月現在）。</p>
+		<p><LinkExternal href="https://web.archive.org/web/20150306041048/http://support.microsoft.com/kb/415022/ja">Internet Explorer 5 の実装</LinkExternal>を発端とする歴史的な経緯により、<code>/favicon.ico</code> のファイルパスにすることでブラウザが自動的に読み取るようになっている。あくまで URL が <code>/favicon.ico</code> であれば良く、ファイルの実体が ICO 形式である必要はないため、SVG 形式のファビコンファイルを <code>/favicon.ico</code> に配置し、MIME タイプを <code>image/svg+xml</code> で返すように設定することで <code>&lt;link rel="icon"&gt;</code> の記述を省略できる<NoteRef type="ref" by="favicon-svg-blog" />。ただし以下のデメリットがある（いずれも2024年6月現在）。</p>
 
-		<NoteRefContent id="favicon-svg">詳細はブログ記事 <a href="https://blog.w0s.jp/656">SVG ファビコンのファイル名を <code>favicon.ico</code> にして <code>&lt;link rel="icon"&gt;</code> を省略する</a>（2021年10月）を参照。</NoteRefContent>
+		<NoteRefContent id="favicon-svg-blog">ブログ記事 <a href="https://blog.w0s.jp/656">SVG ファビコンのファイル名を <code>favicon.ico</code> にして <code>&lt;link rel="icon"&gt;</code> を省略する</a>（2021年10月）</NoteRefContent>
 
 		<ul class="p-list">
 			<li>Safari は最新のバージョン 17 系においても SVG ファビコンに対応していない</li>
@@ -316,10 +316,12 @@ const structuredData: StructuredData = {
 		<H slot="heading">CSP</H>
 
 		<ul class="p-list">
-			<li>Fetch ディレクティブ（*-src）は <code>Content-Security-Policy-Report-Only</code> で設定。ユーザースタイルシート、ユーザースクリプトによるカスタマイズを妨げないため、あくまで実態調査目的として Report-Only にしている。</li>
+			<li>Fetch ディレクティブ（*-src）は <code>Content-Security-Policy-Report-Only</code> で設定。ユーザースタイルシートやユーザースクリプト、アドオン等によるカスタマイズを妨げないため、あくまで実態調査目的として Report-Only にしている。</li>
 			<li>Trusted Types 関係も現状は <code>Content-Security-Policy-Report-Only</code> で設定している。</li>
 			<li>それ以外のディレクティブは <code>Content-Security-Policy</code> で設定している。</li>
-			<li>Reporting は <LinkExternal href="https://report-uri.com/">Report URI</LinkExternal> を利用している。</li>
+			<li>Reporting のエンドポイントは <code>report.w0s.jp</code> 内に作成しており、<LinkExternal href="https://github.com/SaekiTominaga/report.w0s.jp/blob/main/node/src/controller/csp.ts">ソースコードは GitHub で公開</LinkExternal>している<NoteRef type="ref" by="csp-blog" />。</li>
 		</ul>
+
+		<NoteRefContent id="csp-blog">ブログ記事 <a href="https://blog.w0s.jp/730">Report URI サービスの有料化に伴い CSP レポートのエンドポイントを自作</a>（2025年1月）</NoteRefContent>
 	</Section>
 </Layout>

--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -87,7 +87,7 @@ const structuredData: StructuredData = {
 					<tr>
 						<td><a href="https://blog.w0s.jp/"><code>blog.w0s.jp</code></a></td>
 						<td>ブログ</td>
-						<td><LinkExternal href="https://expressjs.com/" icon={false}>Express</LinkExternal></td>
+						<td><LinkExternal href="https://hono.dev/" icon={false}>Hono</LinkExternal></td>
 						<td><LinkExternal href="https://sqlite.org/" icon={false}>SQLite</LinkExternal></td>
 						<td class="u-cell -center">
 							<a href="https://github.com/SaekiTominaga/blog.w0s.jp" rel="external" aria-label="blog.w0s.jp の GitHub"><img src="/assets/image/icon/github.svg" alt="GitHub" width="24" height="24" /></a>
@@ -182,7 +182,7 @@ const structuredData: StructuredData = {
 		<Section id="html-clienterror" depth={2} headingType="c">
 			<H slot="heading">4xx クライアントエラーページ</H>
 
-			<p><code>403 Forbidden</code> および <code>404 Not Found</code> のクライアントエラーページには JavaScript で以下の機能を組み込んでいる。</p>
+			<p><code>404 Not Found</code> のエラーページには JavaScript で以下の機能を組み込んでいる。</p>
 
 			<ul class="p-list">
 				<li>同一ドメインのリファラーがあった場合（= サイト内から無効なリンクが張られている）は管理者へ通知する。<LinkExternal href="https://github.com/SaekiTominaga/frontend/tree/main/packages/report-same-referrer">検知プログラムは GitHub で公開</LinkExternal>している。</li>


### PR DESCRIPTION
- blog.w0s.jp, media.w0s.jp, report.w0s.jp の hono 化に伴う記述修正
- ダークモードに関する記述を追加