### PR TITLE
メディア紹介 2025年2月18日更新分

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -146,6 +146,10 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2025-02-18">
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「ゲッサン 2025年2月号」を追加</p>
+					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「アニメージュ 2010年10月号」「アニメージュ 2013年9月号」「アニメージュ 2013年12月号」を追加</p>
+				</TopUpdate>
 				<TopUpdate date="2025-01-10">
 					<p><a href="/kumeta/anime/zetsubou/diff">『さよなら絶望先生』放送版とパッケージ版の比較</a>に 0′00″, 14′12″, 14′35″, 14′53″, 15′23″, 16′06″, 16′40″の差分データを追加</p>
 				</TopUpdate>
@@ -159,9 +163,6 @@ const slugger = new GithubSlugger();
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2024年49号」を追加</p>
 
 					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に「朝日中高生新聞 2024年11月3日」を追加</p>
-				</TopUpdate>
-				<TopUpdate date="2024-10-30">
-					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に「朝日新聞 2024年10月29日 朝刊」を追加</p>
 				</TopUpdate>
 			</ul>
 		</div>

--- a/astro/src/pages/kumeta/library/book.astro
+++ b/astro/src/pages/kumeta/library/book.astro
@@ -13,7 +13,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の図書、一般雑誌での紹介例',
 	heading: 'メディア紹介 — 図書、一般雑誌',
-	dateModified: dayjs('2024-10-13'),
+	dateModified: dayjs('2025-02-18'),
 	description: '本や雑誌（漫画雑誌を除く）において久米田先生のインタビューや描き下ろしイラストが掲載された事例、また久米田作品が紹介された事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: '久米田康治データベース' }],
 	localNav: {
@@ -615,7 +615,7 @@ const slugger = new GithubSlugger();
 
 		<LibBook slugger={slugger} headingLevel={3} title="アニメージュ 2008年5月号" release="2008-04-10" tags={['アニメ']} amazonAsin="B00172JCWW" amazonImageId="51lymDRgJVL" amazonImageWidth={117} amazonImageHeight={160}>
 			<LibContent>
-				<LibItem pages={[110, 114]}>「<cite>この人に話を聞きたい</cite>」第百八回、小林ゆうインタビューの中で木村カエレの演技についての話題も挙がる</LibItem>
+				<LibItem pages={[110, 114]}>「<cite>この人に話を聞きたい</cite>」第百八回、小林ゆうインタビューの中で木村カエレの演技の話題も挙がる</LibItem>
 			</LibContent>
 		</LibBook>
 
@@ -1135,6 +1135,12 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 
+		<LibBook slugger={slugger} headingLevel={3} title="アニメージュ 2010年10月号" release="2010-09-10" tags={['アニメ']} amazonAsin="B003ZTRFGU" amazonImageId="81tpIA0fg5L" amazonImageWidth={125} amazonImageHeight={160}>
+			<LibContent>
+				<LibItem pages={[92, 95]}>「<cite>この人に話を聞きたい</cite>」第百三十五回、尾石達也インタビューの中でいわゆるシャフトスタイルや『<cite>さよなら絶望先生</cite>』の話題も挙がる</LibItem>
+			</LibContent>
+		</LibBook>
+
 		<LibBook slugger={slugger} headingLevel={3} title="季刊エス 32号（2010年秋号）" release="2010-09-15" tags={['インタビュー']} amazonAsin="B00414ZH22" amazonImageId="61WNcvQqa7L" amazonImageWidth={121} amazonImageHeight={160}>
 			<LibContent>
 				<LibItem pages={[44, 52]}>『<cite>新装版　かってに改蔵</cite>』久米田康治インタビュー</LibItem>
@@ -1497,6 +1503,13 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 
+		<LibBook slugger={slugger} headingLevel={3} title="アニメージュ 2013年9月号" release="2013-08-10" tags={['アニメ']} amazonAsin="B00DZS2LPG" amazonImageId="81aT8JW0m5L" amazonImageWidth={128} amazonImageHeight={160}>
+			<LibContent>
+				<LibItem pages={[84, 89]}>「<cite>設定資料FILE Vol.181『有頂天家族』の巻</cite>」</LibItem>
+				<LibItem pages={[90, 93]}>「<cite>この人に話を聞きたい</cite>」第百五十八回、堀川憲司インタビューの中で『<cite>有頂天家族</cite>』の話題も挙がる</LibItem>
+			</LibContent>
+		</LibBook>
+
 		<LibBook slugger={slugger} headingLevel={3} title="別冊spoon.2Di Vol.41" release="2013-08-31" tags={['アニメ']} isbn="978-4-04-898220-7" amazonAsin="4048982206" amazonImageId="51IxgKXU6lL" amazonImageWidth={113} amazonImageHeight={160}>
 			<LibContent>
 				<LibItem pages={[34, 39]}>『<cite>有頂天家族</cite>』櫻井孝宏インタビュー、森見登美彦インタビュー（キャラクター原案を見ての感想）</LibItem>
@@ -1518,6 +1531,12 @@ const slugger = new GithubSlugger();
 
 		<LibBook slugger={slugger} headingLevel={3} title="有頂天家族　設定資料集" release="2013-10-26" tags={['作品公式', 'アニメ']} amazonAsin="B00UKPQXOC" amazonImageId="31YiUMJsOqL" amazonImageWidth={160} amazonImageHeight={108}>
 			<p>『<cite>有頂天家族</cite>』公式資料集</p>
+		</LibBook>
+
+		<LibBook slugger={slugger} headingLevel={3} title="アニメージュ 2013年12月号" release="2013-11-09" tags={['アニメ']} amazonAsin="B00G4T7V26" amazonImageId="81ji4yaR2UL" amazonImageWidth={128} amazonImageHeight={160}>
+			<LibContent>
+				<LibItem pages={[94, 97]}>「<cite>この人に話を聞きたい</cite>」第百六十一回、吉原正行インタビューの中で『<cite>有頂天家族</cite>』の話題も挙がる</LibItem>
+			</LibContent>
 		</LibBook>
 
 		<LibBook slugger={slugger} headingLevel={3} title="毎月あだち充 Vol.32" release="2013-11-29" tags={['インタビュー']} isbn="978-4-09-119298-1" amazonAsin="409119298X" amazonImageId="51kmwmx8+kL" amazonImageWidth={111} amazonImageHeight={160}>

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -13,7 +13,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の漫画雑誌での紹介例',
 	heading: 'メディア紹介 — 漫画雑誌',
-	dateModified: dayjs('2024-12-10'),
+	dateModified: dayjs('2025-02-18'),
 	description: '漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: '久米田康治データベース' }],
 	localNav: {
@@ -1450,7 +1450,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 
-		<LibBook slugger={slugger} headingLevel={3} title="ゲッサン 2010年11月号　別冊付録「あだち充画業40周年記念!」" release="2010-10-12" tags={['描き下ろし']} amazonAsin="B0044TIM6C" amazonImageId="61IXmUqtwaL" amazonImageWidth={110} amazonImageHeight={160}>
+		<LibBook slugger={slugger} headingLevel={3} title="ゲッサン 2010年11月号　別冊付録「あだち充画業40周年記念!」" release="2010-10-12" tags={['描き下ろし']}>
 			<LibContent>
 				<LibItem pages={[31, 36]}>改蔵&amp;すず&amp;羽美&amp;地丹による、あだち作品に関するエッセイ漫画</LibItem>
 			</LibContent>
@@ -2494,6 +2494,15 @@ const slugger = new GithubSlugger();
 			<ul class="p-notes">
 				<li>集合イラスト、色紙ともに<LinkExternal href="https://50th.gmaga.co/">月刊少年マガジン50周年記念サイト</LinkExternal>で公開</li>
 			</ul>
+		</LibBook>
+	</Section>
+	<Section slugger={slugger}>
+		<H slot="heading">2025年</H>
+
+		<LibBook slugger={slugger} headingLevel={3} title="ゲッサン 2025年2月号　別冊付録「あだち充画業55周年記念!」" release="2025-01-10" tags={['描き下ろし']}>
+			<LibContent>
+				<LibItem pages={[7]}>お祝いイラストを寄稿（逸子&amp;伊澄）</LibItem>
+			</LibContent>
 		</LibBook>
 	</Section>
 	<Section slugger={slugger}>


### PR DESCRIPTION
「ゲッサン 2025年2月号」「アニメージュ 2010年10月号」「アニメージュ 2013年9月号」「アニメージュ 2013年12月号」を追加