### PR TITLE
ニュースの自動投稿先を Mastodon に一本化

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -102,28 +102,15 @@ const slugger = new GithubSlugger();
 								</LinkExternal>
 							</li>
 							<li>
-								<LinkExternal href="https://discord.gg/3G4kchxRgk" icon={false}>
-									<span class="p-kumeta-top-news__image"><img src="/kumeta/image/icon_discord.svg" alt="" width="64" height="49" /></span>
-									<span class="p-kumeta-top-news__text">Discord</span></LinkExternal
-								>
-							</li>
-							<li>
 								<LinkExternal href="https://mastodon.social/@kumeta_news" icon={false}>
 									<span class="p-kumeta-top-news__image"><img src="/kumeta/image/icon_mastodon.svg" alt="" width="61" height="64" /></span>
 									<span class="p-kumeta-top-news__text">Mastodon</span></LinkExternal
 								>
 							</li>
-							<li>
-								<LinkExternal href="https://bsky.app/profile/kumeta-news.mastodon.social.ap.brid.gy" icon={false}>
-									<span class="p-kumeta-top-news__image"><img src="/kumeta/image/icon_bluesky.svg" alt="" width="64" height="64" /></span>
-									<span class="p-kumeta-top-news__text">Bluesky</span></LinkExternal
-								>
-							</li>
 						</ul>
 
 						<ul class="p-notes">
-							<li>本誌連載、コミックス発売、イベント開催などの情報を Google カレンダーに蓄積し、自動投稿で Discord と Mastodon、Bluesky に流しています。</li>
-							<li>情報提供も歓迎します。上記 Discord サーバーに参加のうえ <code>#news</code> チャンネルに投稿ください。</li>
+							<li>本誌連載、コミックス発売、イベント開催などの情報を Google カレンダーに蓄積し、自動投稿で Mastodon に流しています。</li>
 						</ul>
 					</Section>
 				</div>


### PR DESCRIPTION
Discord と Bluesky を削除