### PR TITLE
メディア紹介 2025年3月24日更新分

### DIFF
--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -133,6 +133,10 @@ const slugger = new GithubSlugger();
 		</header>
 		<div class="p-top-update__main">
 			<ul class="p-top-update-list">
+				<TopUpdate date="2025-03-24">
+					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2025年16号」を追加</p>
+					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「アニメージュ 2007年8月号」「アニメディア 2007年8月号」を追加</p>
+				</TopUpdate>
 				<TopUpdate date="2025-02-18">
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「ゲッサン 2025年2月号」を追加</p>
 					<p><a href="/kumeta/library/book">メディア紹介 — 図書、一般雑誌</a>に「アニメージュ 2010年10月号」「アニメージュ 2013年9月号」「アニメージュ 2013年12月号」を追加</p>
@@ -145,11 +149,6 @@ const slugger = new GithubSlugger();
 				</TopUpdate>
 				<TopUpdate date="2024-12-10">
 					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2024年53号」「月刊少年マガジン 2025年1月号」を追加</p>
-				</TopUpdate>
-				<TopUpdate date="2024-11-09">
-					<p><a href="/kumeta/library/manga">メディア紹介 — 漫画雑誌</a>に「週刊少年サンデー 2024年49号」を追加</p>
-
-					<p><a href="/kumeta/library/newspaper">メディア紹介 — 新聞</a>に「朝日中高生新聞 2024年11月3日」を追加</p>
 				</TopUpdate>
 			</ul>
 		</div>

--- a/astro/src/pages/kumeta/library/book.astro
+++ b/astro/src/pages/kumeta/library/book.astro
@@ -13,7 +13,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の図書、一般雑誌での紹介例',
 	heading: 'メディア紹介 — 図書、一般雑誌',
-	dateModified: dayjs('2025-02-18'),
+	dateModified: dayjs('2025-03-24'),
 	description: '本や雑誌（漫画雑誌を除く）において久米田先生のインタビューや描き下ろしイラストが掲載された事例、また久米田作品が紹介された事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: '久米田康治データベース' }],
 	localNav: {
@@ -291,6 +291,18 @@ const slugger = new GithubSlugger();
 		<LibBook slugger={slugger} headingLevel={3} title="メガミマガジン 2007年8月号" release="2007-06-30" tags={['アニメ']} amazonAsin="B000S6GB7M" amazonImageId="61pxLSptdJL" amazonImageWidth={118} amazonImageHeight={160}>
 			<LibContent>
 				<LibItem pages={[67]}>アニメ『<cite>さよなら絶望先生</cite>』情報、絶望少女キャラ紹介</LibItem>
+			</LibContent>
+		</LibBook>
+
+		<LibBook slugger={slugger} headingLevel={3} title="アニメージュ 2007年8月号" release="2007-07" tags={['アニメ']} amazonAsin="B000SFKTCG" amazonImageId="616-PZI8duL" amazonImageWidth={117} amazonImageHeight={160}>
+			<LibContent>
+				<LibItem pages={[177]}>アニメ『<cite>さよなら絶望先生</cite>』情報、糸色望&amp;絶望少女キャラ紹介</LibItem>
+			</LibContent>
+		</LibBook>
+
+		<LibBook slugger={slugger} headingLevel={3} title="アニメディア 2007年8月号" release="2007-07" tags={['アニメ']} amazonAsin="B000SFKTD0" amazonImageId="61IBdHWh0VL" amazonImageWidth={113} amazonImageHeight={160}>
+			<LibContent>
+				<LibItem pages={[173]}>アニメ『<cite>さよなら絶望先生</cite>』情報、糸色望&amp;絶望少女キャラ紹介</LibItem>
 			</LibContent>
 		</LibBook>
 

--- a/astro/src/pages/kumeta/library/book.astro
+++ b/astro/src/pages/kumeta/library/book.astro
@@ -1069,7 +1069,7 @@ const slugger = new GithubSlugger();
 			</ul>
 		</LibBook>
 
-		<LibBook slugger={slugger} headingLevel={3} title="ニュータイプ・ロマンス 2010年2月号(冬)" release="2009-12-19" tags={['アニメ']} amazonAsin="B002X8EJ1I" amazonImageId="61WMJfWnqpL" amazonImageWidth={125} amazonImageHeight={160}>
+		<LibBook slugger={slugger} headingLevel={3} title="ニュータイプ・ロマンス 2010年2月号(冬)" release="2009-12-19" tags={['アニメ', '版権イラスト']} amazonAsin="B002X8EJ1I" amazonImageId="61WMJfWnqpL" amazonImageWidth={125} amazonImageHeight={160}>
 			<LibContent>
 				<LibItem pages={[10]}>ツヤツヤポートレートカレンダー（山村洋貴）<small>（<LinkExternal href="http://king-cr.jp/special/zetsubou3/gallery/07.html">アニメ公式サイト</LinkExternal>にも掲載）</small></LibItem>
 				<LibItem pages={[48, 49]}>『<cite>懺・さよなら絶望先生</cite>』望&amp;久藤&amp;木野&amp;青山のイラスト（2008年4月号掲載のものと同じ）</LibItem>

--- a/astro/src/pages/kumeta/library/book.astro
+++ b/astro/src/pages/kumeta/library/book.astro
@@ -1031,7 +1031,7 @@ const slugger = new GithubSlugger();
 
 		<LibBook slugger={slugger} headingLevel={3} title="アニメージュ 2009年12月号" release="2009-11-10" tags={['アニメ']} amazonAsin="B002UE1A4O" amazonImageId="61ij39qaHxL" amazonImageWidth={126} amazonImageHeight={160}>
 			<LibContent>
-				<LibItem pages={[137, 139]}>マイ・アニメージュ（読者投稿）で『<cite>懺・さよなら絶望先生</cite>』特集、守岡英行による選者コメント</LibItem>
+				<LibItem pages={[137, 139]}>マイ・アニメージュ（読者投稿）で『<cite>懺・さよなら絶望先生</cite>』特集、守岡英行による選者コメント、絶望少女えかきうた（小森霧）</LibItem>
 			</LibContent>
 		</LibBook>
 

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -13,7 +13,7 @@ import type { StructuredData } from '@type/types.js';
 const structuredData: StructuredData = {
 	title: '久米田康治作品の漫画雑誌での紹介例',
 	heading: 'メディア紹介 — 漫画雑誌',
-	dateModified: dayjs('2025-02-18'),
+	dateModified: dayjs('2025-03-24'),
 	description: '漫画雑誌において久米田作品がカラー掲載されたり、企画記事が載ったりするなど、通常の連載以外で注目すべき事例のリストです。',
 	breadcrumb: [{ path: '/kumeta/', name: '久米田康治データベース' }],
 	localNav: {

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -2504,6 +2504,12 @@ const slugger = new GithubSlugger();
 				<LibItem pages={[7]}>お祝いイラストを寄稿（逸子&amp;伊澄）</LibItem>
 			</LibContent>
 		</LibBook>
+
+		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2025年16号" release="2025-03-19" tags={['表紙']}>
+			<LibContent>
+				<LibItem position="表紙">逸子<small>（創刊66周年の集合イラスト）</small></LibItem>
+			</LibContent>
+		</LibBook>
 	</Section>
 	<Section slugger={slugger}>
 		<H slot="heading">調査中</H>


### PR DESCRIPTION
「週刊少年サンデー 2025年16号」「アニメージュ 2007年8月号」「アニメディア 2007年8月号」を追加