### PR TITLE
ページ URL 取得処理を変更

### DIFF
--- a/astro/src/+util/ssr.ts
+++ b/astro/src/+util/ssr.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import type { AstroGlobal } from 'astro';
 import * as dotenv from 'dotenv';
 import Log4js from 'log4js';
@@ -34,7 +33,7 @@ export const init = (Astro: AstroGlobal, options: Options): { logger: Log4js.Log
 /**
  * `Astro.url` を元にページ URL を組み立てる
  *
- * @param astroUrl - Astro.url <https://docs.astro.build/en/reference/api-reference/#astrourl>
+ * @param astroUrl - Astro.url <https://docs.astro.build/en/reference/api-reference/#url>
  * @param astroFilePath - Astro.self.moduleId
  *
  * @returns ページ URL
@@ -42,23 +41,10 @@ export const init = (Astro: AstroGlobal, options: Options): { logger: Log4js.Log
 export const getPageUrl = (astroUrl: URL, astroFilePath: string | undefined): string => {
 	const astroPathname = astroUrl.pathname;
 
-	const urlParsed = path.parse(astroPathname);
-	if (urlParsed.ext === '') {
-		/* 拡張子がない場合（開発環境ないしトップページ） */
-		return astroPathname;
+	/* build - format: 'preserve' の設定ではビルド時のみ末尾に / が付いてしまうので除去する */
+	if (astroFilePath !== undefined && !astroFilePath.endsWith('/index.astro') && astroPathname.endsWith('/')) {
+		return astroPathname.slice(0, -1);
 	}
 
-	const dir = urlParsed.dir === '/' ? '' : urlParsed.dir;
-
-	/* 拡張子を除去する */
-	const urlExclusionExt = `${dir}/${urlParsed.name}`;
-
-	if (astroFilePath !== undefined) {
-		if (path.basename(astroFilePath) === 'index.astro') {
-			/* トップページ以外のインデックスページ */
-			return `${urlExclusionExt}/`;
-		}
-	}
-
-	return urlExclusionExt;
+	return astroPathname;
 };

--- a/astro/src/layouts/Admin.astro
+++ b/astro/src/layouts/Admin.astro
@@ -11,14 +11,13 @@ import { getPageUrl } from '@util/ssr.js';
 import TocUtil from '@util/Toc.js';
 
 interface Props {
-	pagePath?: string;
 	astroFilePath: string | undefined;
 	structuredData: StructuredData;
 }
 
-const { pagePath: pagePathTemp, astroFilePath, structuredData } = Astro.props;
+const { astroFilePath, structuredData } = Astro.props;
 
-const pagePath = pagePathTemp ?? getPageUrl(Astro.url, astroFilePath);
+const pagePath = getPageUrl(Astro.url, astroFilePath);
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/layouts/Kumeta.astro
+++ b/astro/src/layouts/Kumeta.astro
@@ -13,7 +13,6 @@ import { getPageUrl } from '@util/ssr.js';
 import TocUtil from '@util/Toc.js';
 
 interface Props {
-	pagePath?: string;
 	astroFilePath: string | undefined;
 	structuredData: StructuredData;
 	top?: boolean;
@@ -23,9 +22,9 @@ interface Props {
 	ad?: boolean;
 }
 
-const { pagePath: pagePathTemp, astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
+const { astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
 
-const pagePath = pagePathTemp ?? getPageUrl(Astro.url, astroFilePath);
+const pagePath = getPageUrl(Astro.url, astroFilePath);
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/layouts/Madoka.astro
+++ b/astro/src/layouts/Madoka.astro
@@ -13,7 +13,6 @@ import { getPageUrl } from '@util/ssr.js';
 import TocUtil from '@util/Toc.js';
 
 interface Props {
-	pagePath?: string;
 	astroFilePath: string | undefined;
 	structuredData: StructuredData;
 	top?: boolean;
@@ -23,9 +22,9 @@ interface Props {
 	ad?: boolean;
 }
 
-const { pagePath: pagePathTemp, astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
+const { astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
 
-const pagePath = pagePathTemp ?? getPageUrl(Astro.url, astroFilePath);
+const pagePath = getPageUrl(Astro.url, astroFilePath);
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/layouts/Tokyu.astro
+++ b/astro/src/layouts/Tokyu.astro
@@ -13,7 +13,6 @@ import { getPageUrl } from '@util/ssr.js';
 import TocUtil from '@util/Toc.js';
 
 interface Props {
-	pagePath?: string;
 	astroFilePath: string | undefined;
 	structuredData: StructuredData;
 	top?: boolean;
@@ -23,9 +22,9 @@ interface Props {
 	ad?: boolean;
 }
 
-const { pagePath: pagePathTemp, astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
+const { astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
 
-const pagePath = pagePathTemp ?? getPageUrl(Astro.url, astroFilePath);
+const pagePath = getPageUrl(Astro.url, astroFilePath);
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/layouts/W0s.astro
+++ b/astro/src/layouts/W0s.astro
@@ -13,7 +13,6 @@ import { getPageUrl } from '@util/ssr.js';
 import TocUtil from '@util/Toc.js';
 
 interface Props {
-	pagePath?: string;
 	astroFilePath: string | undefined;
 	structuredData: StructuredData;
 	top?: boolean;
@@ -23,9 +22,9 @@ interface Props {
 	ad?: boolean;
 }
 
-const { pagePath: pagePathTemp, astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
+const { astroFilePath, structuredData, top = false, toc = true, contentFooter = true, pageSidebar = true, ad = true } = Astro.props;
 
-const pagePath = pagePathTemp ?? getPageUrl(Astro.url, astroFilePath);
+const pagePath = getPageUrl(Astro.url, astroFilePath);
 
 const rendered = await Astro.slots.render('default');
 const dom = new JSDOM(rendered);

--- a/astro/src/pages/admin/crawler-news/data.astro
+++ b/astro/src/pages/admin/crawler-news/data.astro
@@ -4,7 +4,7 @@ import CrawlerNewsDataDao from '@dao/CrawlerNewsDataDao.js';
 import { response303 } from '@util/httpResponse.js';
 import { env } from '@util/env.js';
 import RequestUtil from '@util/Request.js';
-import { init as ssrInit, getPageUrl } from '@util/ssr.js';
+import { init as ssrInit } from '@util/ssr.js';
 import type { StructuredData } from '@type/types.js';
 
 interface RequestQuery {
@@ -20,8 +20,6 @@ const structuredData: StructuredData = {
 	title: 'ウェブ巡回（ニュース）',
 	breadcrumb: [{ path: '/admin/crawler-news/', name: 'ウェブ巡回（ニュース）' }],
 };
-
-const pagePath = getPageUrl(Astro.url, Astro.self.moduleId);
 
 const requestParams = RequestUtil.getParams(Astro.url);
 const requestBody = Astro.request.method === 'POST' ? await Astro.request.formData() : undefined;
@@ -48,7 +46,7 @@ if (requestQuery.action_delete) {
 const newsDataList = requestQuery.url !== null ? await dao.getNewsDataList(requestQuery.url) : []; // 新着データ
 ---
 
-<Layout pagePath={pagePath} astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
+<Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<p><a href={requestQuery.url} referrerpolicy="no-referrer" class="c-link">{requestQuery.url}</a></p>
 
 	<div class="p-table p-admin-crawler-table">
@@ -65,7 +63,7 @@ const newsDataList = requestQuery.url !== null ? await dao.getNewsDataList(reque
 					newsDataList.map((newsData) => (
 						<tr>
 							<td>
-								<form action={pagePath} method="post">
+								<form action={Astro.url.pathname} method="post">
 									<p>
 										<input type="hidden" name="url" value={requestQuery.url} />
 									</p>

--- a/astro/src/pages/admin/crawler-news/index.astro
+++ b/astro/src/pages/admin/crawler-news/index.astro
@@ -7,7 +7,7 @@ import CrawlerNewsDao from '@dao/CrawlerNewsDao.js';
 import { env } from '@util/env.js';
 import { response303 } from '@util/httpResponse.js';
 import RequestUtil from '@util/Request.js';
-import { init as ssrInit, getPageUrl } from '@util/ssr.js';
+import { init as ssrInit } from '@util/ssr.js';
 import type { StructuredData } from '@type/types.js';
 
 interface RequestQuery {
@@ -31,8 +31,6 @@ const { logger } = ssrInit(Astro, { dev: import.meta.env.DEV });
 const structuredData: StructuredData = {
 	title: 'ウェブ巡回（ニュース）',
 };
-
-const pagePath = getPageUrl(Astro.url, Astro.self.moduleId);
 
 const slugger = new GithubSlugger();
 
@@ -133,11 +131,11 @@ for (const newsPage of newsPageListDto) {
 }
 ---
 
-<Layout pagePath={pagePath} astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
+<Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<Section slugger={slugger}>
 		<H slot="heading">データ登録</H>
 
-		<form action={pagePath} method="post" class="c-stack">
+		<form action={Astro.url.pathname} method="post" class="c-stack">
 			<div class="p-form-grid">
 				<div class="p-form-grid__group">
 					<fieldset>
@@ -309,7 +307,7 @@ for (const newsPage of newsPageListDto) {
 							{newsPageOfCategory.map((newsPage) => (
 								<tr>
 									<td class="u-cell -wrap-no">
-										<form action={pagePath} method="post">
+										<form action={Astro.url.pathname} method="post">
 											<p>
 												<input type="hidden" name="url" value={newsPage.url} />
 											</p>

--- a/astro/src/pages/admin/crawler-resource/index.astro
+++ b/astro/src/pages/admin/crawler-resource/index.astro
@@ -7,7 +7,7 @@ import CrawlerResourceDao from '@dao/CrawlerResourceDao.js';
 import { env } from '@util/env.js';
 import { response303 } from '@util/httpResponse.js';
 import RequestUtil from '@util/Request.js';
-import { init as ssrInit, getPageUrl } from '@util/ssr.js';
+import { init as ssrInit } from '@util/ssr.js';
 import type { StructuredData } from '@type/types.js';
 
 interface RequestQuery {
@@ -29,8 +29,6 @@ const { logger } = ssrInit(Astro, { dev: import.meta.env.DEV });
 const structuredData: StructuredData = {
 	title: 'ウェブ巡回（リソース）',
 };
-
-const pagePath = getPageUrl(Astro.url, Astro.self.moduleId);
 
 const slugger = new GithubSlugger();
 
@@ -125,11 +123,11 @@ for (const resoursePage of resourcePageListDto) {
 }
 ---
 
-<Layout pagePath={pagePath} astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
+<Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<Section slugger={slugger}>
 		<H slot="heading">データ登録</H>
 
-		<form action={pagePath} method="post" class="c-stack">
+		<form action={Astro.url.pathname} method="post" class="c-stack">
 			<div class="p-form-grid">
 				<div class="p-form-grid__group">
 					<fieldset>
@@ -277,7 +275,7 @@ for (const resoursePage of resourcePageListDto) {
 							{resourcePageOfCategory.map((resourcePage) => (
 								<tr>
 									<td class="u-cell -wrap-no">
-										<form action={pagePath} method="post" class="c-stack">
+										<form action={Astro.url.pathname} method="post" class="c-stack">
 											<p>
 												<input type="hidden" name="url" value={resourcePage.url.toString()} />
 												<button name="actionrevpre" value="1" formmethod="get" class="c-submit -compact">


### PR DESCRIPTION
#649 で `build.format` を preserve に変更したことで index 以外のページ URL にも末尾に / が付いてしまい、ローカルナビの現在地表示が無効になってしまった。