### PR TITLE
チェックボックス、ラジオボタンの上下マージンが無効になっていたバグを修正

### DIFF
--- a/astro/src/components/+phrasing/Label.astro
+++ b/astro/src/components/+phrasing/Label.astro
@@ -39,11 +39,11 @@ const switchCtrl = document.querySelector('w0s-input-switch') !== null;
 				--_border-color: transparent;
 				--_bg-color: transparent;
 
-				margin-block: calc(var(--form-control-padding-block) / 2);
+				margin-block: calc(var(--form-control-padding) / 2);
 				border: 1px solid var(--_border-color);
 				border-radius: var(--border-radius-normal);
 				background: var(--_bg-color);
-				padding: calc(var(--form-control-padding-block) / 2);
+				padding: calc(var(--form-control-padding) / 2);
 
 				&:hover {
 					--_border-color: var(--color-superlightblue);


### PR DESCRIPTION
CSS 変数名の置換漏れによるもの