### PR TITLE
GTO-VVVF のようなハイフン区切りをやめてスペース区切りにする

### DIFF
--- a/astro/src/components/tokyu/+phrasing/MachineFormAPS.astro
+++ b/astro/src/components/tokyu/+phrasing/MachineFormAPS.astro
@@ -21,7 +21,7 @@ switch (type) {
 }
 ---
 
-<span class:list={['aps', use !== undefined ? `-${use}` : undefined]}>{capacity}kVA-{typeDisplay}</span>
+<span class:list={['aps', use !== undefined ? `-${use}` : undefined]}>{capacity}kVA {typeDisplay}</span>
 
 <style>
 	@layer component {

--- a/astro/src/components/tokyu/+phrasing/MachineFormCont.astro
+++ b/astro/src/components/tokyu/+phrasing/MachineFormCont.astro
@@ -17,11 +17,11 @@ switch (type) {
 		break;
 	}
 	case 'gto': {
-		typeDisplay = 'GTO-VVVF';
+		typeDisplay = 'GTO VVVF';
 		break;
 	}
 	case 'igbt': {
-		typeDisplay = `IGBT-VVVF`;
+		typeDisplay = `IGBT VVVF`;
 		break;
 	}
 	default:
@@ -30,7 +30,7 @@ switch (type) {
 
 <span class:list={['cont', type !== undefined ? `-${type}` : undefined]}>
 	<span class="type">{typeDisplay}</span>
-	{siv !== undefined && <span class="siv">（{siv}kVA-SIV一体型）</span>}
+	{siv !== undefined && <span class="siv">（{siv}kVA SIV 一体型）</span>}
 </span>
 
 <style>

--- a/astro/src/pages/tokyu/data/form_car.astro
+++ b/astro/src/pages/tokyu/data/form_car.astro
@@ -533,7 +533,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 
 			<ListNote>
-				<li>デハ8296 の補助電源装置は 100kVA-SIV</li>
+				<li>デハ8296 の補助電源装置は 100kVA SIV</li>
 			</ListNote>
 		</Section>
 
@@ -579,7 +579,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 
 			<ListNote>
-				<li>デハ8298、8282、8290 の補助電源装置は 100kVA-SIV</li>
+				<li>デハ8298、8282、8290 の補助電源装置は 100kVA SIV</li>
 			</ListNote>
 		</Section>
 

--- a/astro/src/pages/tokyu/data/form_line.astro
+++ b/astro/src/pages/tokyu/data/form_line.astro
@@ -594,7 +594,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 
 			<ListNote>
-				<li>デハ8296 の補助電源装置は 100kVA-SIV</li>
+				<li>デハ8296 の補助電源装置は 100kVA SIV</li>
 			</ListNote>
 		</Section>
 
@@ -640,7 +640,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 
 			<ListNote>
-				<li>デハ8298、8282、8290 の補助電源装置は 100kVA-SIV</li>
+				<li>デハ8298、8282、8290 の補助電源装置は 100kVA SIV</li>
 			</ListNote>
 		</Section>
 


### PR DESCRIPTION
MOS-FET のように用語そのものにハイフンが含まれるケースに対応できないため