### PR TITLE
Flexbox と Grid の子アイテムの `<div>` にクラス名を付与

### DIFF
--- a/astro/src/components/FlexItem.astro
+++ b/astro/src/components/FlexItem.astro
@@ -1,3 +1,3 @@
-<div>
+<div class="flex-item">
 	<slot />
 </div>

--- a/astro/src/components/GridItem.astro
+++ b/astro/src/components/GridItem.astro
@@ -1,3 +1,3 @@
-<div>
+<div class="grid-item">
 	<slot />
 </div>


### PR DESCRIPTION
`class` 属性なしの `<div>` で Markuplint エラーが出ていたのを修正