### PR TITLE
Favicon の `link` 要素に `sizes` 属性を追加

### DIFF
--- a/astro/src/layouts/head/Kumeta.astro
+++ b/astro/src/layouts/head/Kumeta.astro
@@ -23,8 +23,8 @@ const jsonLd = StructuredDataUtil.getJsonLd(structuredData, { site: import.meta.
 	<link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 	<link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-	<link rel="icon" href="/favicon.ico" type="image/svg+xml" />
-	<link rel="alternate icon" href="/favicon.png" type="image/png" />
+	<link rel="icon" href="/favicon.ico" type="image/svg+xml" sizes="any" />
+	<link rel="alternate icon" href="/favicon.png" type="image/png" sizes="32x32" />
 
 	{structuredData.opensearch !== undefined && <link rel="search" href={structuredData.opensearch.path} type="application/opensearchdescription+xml" title={structuredData.opensearch.name} />}
 

--- a/astro/src/layouts/head/Madoka.astro
+++ b/astro/src/layouts/head/Madoka.astro
@@ -23,8 +23,8 @@ const jsonLd = StructuredDataUtil.getJsonLd(structuredData, { site: import.meta.
 	<link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 	<link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-	<link rel="icon" href="/favicon.ico" type="image/svg+xml" />
-	<link rel="alternate icon" href="/favicon.png" type="image/png" />
+	<link rel="icon" href="/favicon.ico" type="image/svg+xml" sizes="any" />
+	<link rel="alternate icon" href="/favicon.png" type="image/png" sizes="32x32" />
 
 	{structuredData.opensearch !== undefined && <link rel="search" href={structuredData.opensearch.path} type="application/opensearchdescription+xml" title={structuredData.opensearch.name} />}
 

--- a/astro/src/layouts/head/Site.astro
+++ b/astro/src/layouts/head/Site.astro
@@ -21,8 +21,8 @@ const jsonLd = StructuredDataUtil.getJsonLd(structuredData, { site: import.meta.
 	<link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 	<link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-	<link rel="icon" href="/favicon.ico" type="image/svg+xml" />
-	<link rel="alternate icon" href="/favicon.png" type="image/png" />
+	<link rel="icon" href="/favicon.ico" type="image/svg+xml" sizes="any" />
+	<link rel="alternate icon" href="/favicon.png" type="image/png" sizes="32x32" />
 
 	{structuredData.opensearch !== undefined && <link rel="search" href={structuredData.opensearch.path} type="application/opensearchdescription+xml" title={structuredData.opensearch.name} />}
 

--- a/astro/src/layouts/head/Tokyu.astro
+++ b/astro/src/layouts/head/Tokyu.astro
@@ -23,8 +23,8 @@ const jsonLd = StructuredDataUtil.getJsonLd(structuredData, { site: import.meta.
 	<link rel="alternate stylesheet" href="/assets/style/layout_reader.css" title="リーダー表示" />
 	<link rel="stylesheet" href="/assets/style/layout_reader.css" media="print" />
 
-	<link rel="icon" href="/favicon.ico" type="image/svg+xml" />
-	<link rel="alternate icon" href="/favicon.png" type="image/png" />
+	<link rel="icon" href="/favicon.ico" type="image/svg+xml" sizes="any" />
+	<link rel="alternate icon" href="/favicon.png" type="image/png" sizes="32x32" />
 
 	{structuredData.opensearch !== undefined && <link rel="search" href={structuredData.opensearch.path} type="application/opensearchdescription+xml" title={structuredData.opensearch.name} />}
 


### PR DESCRIPTION
Chrome 139 は `sizes` 属性がないと PNG への無駄なリクエストが発生するため。👉[Safari にも実装が入ることだし、あらためて SVG ファビコンのベスト・プラクティスを考えよう 2025 晩夏（実験） / JeffreyFrancesco.org](https://jeffreyfrancesco.org/weblog/2025082901/)