### PR TITLE
ウェブ巡回で URL を更新できるように

### DIFF
--- a/astro/src/+dao/CrawlerNewsDao.ts
+++ b/astro/src/+dao/CrawlerNewsDao.ts
@@ -151,6 +151,7 @@ export default class CrawlerNewsDao extends CrawlerDao {
 	 * @param selectorWrap - セレクター文字列（包括要素）
 	 * @param selectorDate - 包括要素からのセレクター文字列（日付）
 	 * @param selectorContent - 包括要素からのセレクター文字列（内容）
+	 * @param baseUrl - 元 URL
 	 */
 	async update(
 		url: string,
@@ -161,6 +162,7 @@ export default class CrawlerNewsDao extends CrawlerDao {
 		selectorWrap: string,
 		selectorDate: string | null,
 		selectorContent: string | null,
+		baseUrl: string,
 	): Promise<void> {
 		const dbh = await this.getDbh();
 
@@ -170,6 +172,7 @@ export default class CrawlerNewsDao extends CrawlerDao {
 				UPDATE
 					d_news
 				SET
+					url = :url,
 					title = :title,
 					class = :category,
 					priority = :priority,
@@ -178,9 +181,10 @@ export default class CrawlerNewsDao extends CrawlerDao {
 					selector_date = :selector_date,
 					selector_content = :selector_content
 				WHERE
-					url = :url
+					url = :baseurl
 			`);
 			await sth.run({
+				':url': url,
 				':title': title,
 				':category': category,
 				':priority': priority,
@@ -188,7 +192,7 @@ export default class CrawlerNewsDao extends CrawlerDao {
 				':selector_wrap': selectorWrap,
 				':selector_date': DbUtil.emptyToNull(selectorDate),
 				':selector_content': DbUtil.emptyToNull(selectorContent),
-				':url': url,
+				':baseurl': baseUrl,
 			});
 			await sth.finalize();
 

--- a/astro/src/+dao/CrawlerResourceDao.ts
+++ b/astro/src/+dao/CrawlerResourceDao.ts
@@ -134,8 +134,9 @@ export default class CrawlerResourceDao extends CrawlerDao {
 	 * @param priority - 優先度
 	 * @param browser - ウェブブラウザでアクセスするか
 	 * @param selector - セレクター文字列
+	 * @param baseUrl - 元 URL
 	 */
-	async update(url: string, title: string, category: number, priority: number, browser: boolean, selector: string | null): Promise<void> {
+	async update(url: string, title: string, category: number, priority: number, browser: boolean, selector: string | null, baseUrl: string): Promise<void> {
 		const dbh = await this.getDbh();
 
 		await dbh.exec('BEGIN');
@@ -144,21 +145,23 @@ export default class CrawlerResourceDao extends CrawlerDao {
 				UPDATE
 					d_resource
 				SET
+					url = :url,
 					title = :title,
 					category = :category,
 					priority = :priority,
 					browser = :browser,
 					selector = :selector
 				WHERE
-					url = :url
+					url = :baseurl
 			`);
 			await sth.run({
+				':url': url,
 				':title': title,
 				':category': category,
 				':priority': priority,
 				':browser': browser,
 				':selector': DbUtil.emptyToNull(selector),
-				':url': url,
+				':baseurl': baseUrl,
 			});
 			await sth.finalize();
 

--- a/astro/src/pages/admin/crawler-news/index.astro
+++ b/astro/src/pages/admin/crawler-news/index.astro
@@ -30,6 +30,7 @@ interface RequestQuery {
 	selector_wrap: string | null;
 	selector_date: string | null;
 	selector_content: string | null;
+	base_url: string | null;
 	action_add: boolean;
 	action_revise: boolean;
 	action_revise_preview: boolean;
@@ -57,6 +58,7 @@ const requestQuery: RequestQuery = {
 	selector_wrap: RequestUtil.string(requestBody?.get('selectorwrap')),
 	selector_date: RequestUtil.string(requestBody?.get('selectordate')),
 	selector_content: RequestUtil.string(requestBody?.get('selectorcontent')),
+	base_url: RequestUtil.string(requestBody?.get('baseurl')),
 	action_add: RequestUtil.boolean(requestBody?.get('actionadd')),
 	action_revise: RequestUtil.boolean(requestBody?.get('actionrev')),
 	action_revise_preview: RequestUtil.boolean(requestParams.get('actionrevpre')),
@@ -95,8 +97,8 @@ if (requestQuery.action_add) {
 } else if (requestQuery.action_revise) {
 	/* 修正実行 */
 
-	if (requestQuery.url !== null && requestQuery.title !== null && requestQuery.category !== null && requestQuery.priority !== null && requestQuery.selector_wrap !== null) {
-		await dao.update(requestQuery.url, requestQuery.title, requestQuery.category, requestQuery.priority, requestQuery.browser, requestQuery.selector_wrap, requestQuery.selector_date, requestQuery.selector_content);
+	if (requestQuery.url !== null && requestQuery.title !== null && requestQuery.category !== null && requestQuery.priority !== null && requestQuery.selector_wrap !== null && requestQuery.base_url !== null) {
+		await dao.update(requestQuery.url, requestQuery.title, requestQuery.category, requestQuery.priority, requestQuery.browser, requestQuery.selector_wrap, requestQuery.selector_date, requestQuery.selector_content, requestQuery.base_url);
 		logger.info('データ更新', requestQuery.url);
 
 		return response303(Astro.request);
@@ -172,7 +174,7 @@ for (const newsPage of newsPageListDto) {
 					<Fragment slot="legend"><label for="fc-url">URL <FormLabelIcon type="required">必須</FormLabelIcon></label></Fragment>
 
 					<Fragment slot="contents">
-						<FormCtrlInput><input type="url" name="url" value={requestQuery.url} required="" readonly={requestQuery.action_revise_preview || requestQuery.action_revise} class="js-convert-trim" id="fc-url" /></FormCtrlInput>
+						<FormCtrlInput><input type="url" name="url" value={requestQuery.url} required="" class="js-convert-trim" id="fc-url" /></FormCtrlInput>
 					</Fragment>
 				</FormGridGroup>
 				<FormGridGroup>
@@ -257,6 +259,8 @@ for (const newsPage of newsPageListDto) {
 					</Fragment>
 				</FormGridGroup>
 			</FormGrid>
+
+			<p><input type="hidden" name="baseurl" value={requestQuery.url} /></p>
 
 			<FormButtons>
 				{

--- a/astro/src/pages/admin/crawler-resource/index.astro
+++ b/astro/src/pages/admin/crawler-resource/index.astro
@@ -29,6 +29,7 @@ interface RequestQuery {
 	priority: number | null;
 	browser: boolean;
 	selector: string | null;
+	base_url: string | null;
 	action_add: boolean;
 	action_revise: boolean;
 	action_revise_preview: boolean;
@@ -54,6 +55,7 @@ const requestQuery: RequestQuery = {
 	priority: RequestUtil.number(requestBody?.get('priority')),
 	browser: RequestUtil.boolean(requestBody?.get('browser')),
 	selector: RequestUtil.string(requestBody?.get('selector')),
+	base_url: RequestUtil.string(requestBody?.get('baseurl')),
 	action_add: RequestUtil.boolean(requestBody?.get('actionadd')),
 	action_revise: RequestUtil.boolean(requestBody?.get('actionrev')),
 	action_revise_preview: RequestUtil.boolean(requestParams.get('actionrevpre')),
@@ -90,8 +92,9 @@ if (requestQuery.action_add) {
 	}
 } else if (requestQuery.action_revise) {
 	/* 修正実行 */
-	if (requestQuery.url !== null && requestQuery.title !== null && requestQuery.category !== null && requestQuery.priority !== null) {
-		await dao.update(requestQuery.url, requestQuery.title, requestQuery.category, requestQuery.priority, requestQuery.browser, requestQuery.selector);
+	if (requestQuery.url !== null && requestQuery.title !== null && requestQuery.category !== null && requestQuery.priority !== null && requestQuery.base_url !== null) {
+		logger.debug(requestQuery);
+		await dao.update(requestQuery.url, requestQuery.title, requestQuery.category, requestQuery.priority, requestQuery.browser, requestQuery.selector, requestQuery.base_url);
 		logger.info('データ更新', requestQuery.url);
 
 		return response303(Astro.request);
@@ -165,7 +168,7 @@ for (const resoursePage of resourcePageListDto) {
 					<Fragment slot="legend"><label for="fc-url">URL <FormLabelIcon type="required">必須</FormLabelIcon></label></Fragment>
 
 					<Fragment slot="contents">
-						<FormCtrlInput><input type="url" name="url" value={requestQuery.url} required="" readonly={requestQuery.action_revise_preview || requestQuery.action_revise} class="js-convert-trim" id="fc-url" /></FormCtrlInput>
+						<FormCtrlInput><input type="url" name="url" value={requestQuery.url} required="" class="js-convert-trim" id="fc-url" /></FormCtrlInput>
 					</Fragment>
 				</FormGridGroup>
 				<FormGridGroup>
@@ -236,6 +239,8 @@ for (const resoursePage of resourcePageListDto) {
 					</Fragment>
 				</FormGridGroup>
 			</FormGrid>
+
+			<p><input type="hidden" name="baseurl" value={requestQuery.url} /></p>
 
 			<FormButtons>
 				{


### PR DESCRIPTION
従来は http:// → https:// などの URL 変更時も既存データを削除→新規追加しなければならなかったが、直接 update を掛けられるようにした。