### PR TITLE
パンくずのラベル変更

### DIFF
--- a/astro/src/components/content-header&footer/Breadcrumb.astro
+++ b/astro/src/components/content-header&footer/Breadcrumb.astro
@@ -10,7 +10,7 @@ const { data } = Astro.props;
 
 {
 	data !== undefined && (
-		<nav class="breadcrumb" aria-label="パンくず">
+		<nav class="breadcrumb" aria-label="現在位置">
 			{data.map((breadcrumbItem, index) => (
 				<>
 					{index === 0 && <a href={breadcrumbItem.path}>ホーム</a>}


### PR DESCRIPTION
「パンくず」は専門用語感があるので、より一般的な用語に変更する。

主な日本語サイトの例


|サイト名（リンク先はトップページ以外の一例）|ラベル|表示方法|備考|
|-|-|-|-|
| [WAIC](https://waic.jp/knowledge/accessibility/) | 現在位置: | Visually hidden ||
| [デジタル庁](https://www.digital.go.jp/individual) | 現在位置： | 普通に見える形 ||
| [横浜市](https://www.city.yokohama.lg.jp/bousai-kyukyu-bohan/) |現在位置 | 普通に見える形 ||
| [楽天ブックス](https://books.rakuten.co.jp/rk/9a30b8e534703b678f5b62b70bbe7d9f/) | 現在地 | `<dt>` ||
| [ユニクロ](https://www.uniqlo.com/jp/ja/products/E476311-001/00) | Breadcrumbs | `aria-label` | ページ最下部 |
| [Markuplint](https://markuplint.dev/ja/docs/guides) | パンくずリストのナビゲーション | `aria-label` ||