### PR TITLE
`href` なしの `<a>` の文字色を明記

### DIFF
--- a/frontend/style/foundation/_reset.css
+++ b/frontend/style/foundation/_reset.css
@@ -150,6 +150,10 @@ iframe {
 /**
   * etc
   */
+a:not(:any-link) {
+	color: inherit;
+} /* for iOS Firefox with Website Dark Mode https://github.com/mozilla-mobile/firefox-ios/issues/29461 */
+
 input,
 select,
 button,


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-ios/issues/29461 で文字色が青色になってしまうバグ対策