### PR TITLE
iOS Firefox による電話番号自動リンクを無効化する

### DIFF
--- a/frontend/style/foundation/_elements.css
+++ b/frontend/style/foundation/_elements.css
@@ -27,22 +27,25 @@
 :any-link {
 	outline-offset: var(--outline-offset);
 	text-decoration-thickness: from-font;
+
+	/* for iOS Firefox auto link https://github.com/mozilla-mobile/firefox-ios/issues/8511 */
+	&[href^="tel:"] {
+		text-decoration: none;
+		color: inherit;
+		pointer-events: none;
+	}
+
+	&:not([href^="tel:"]):hover {
+		color: var(--link-color-hover);
+	}
 }
 
 :link {
 	color: var(--link-color);
-
-	&:hover {
-		color: var(--link-color-hover);
-	}
 }
 
 :visited {
 	color: var(--link-color-visited);
-
-	&:hover {
-		color: var(--link-color-hover);
-	}
 }
 
 ::placeholder {


### PR DESCRIPTION
iOS Firefox は `<meta name="format-detection" content="telephone=no">` が効かないため、CSS 側で対応する。