### PR TITLE
本の表紙画像の代替テキストから「表紙: 」を削除

### DIFF
--- a/astro/src/pages/madoka/dojin/pictorial10.astro
+++ b/astro/src/pages/madoka/dojin/pictorial10.astro
@@ -48,7 +48,7 @@ const structuredData: StructuredData = {
 		<Flex>
 			<FlexItem>
 				<Embedded border={true}>
-					<Image path="madoka/dojin/pictorial10_cover.jpg" alt="表紙: 建物内にある[新編]の告知イラストが書かれた大きなポスターと、券売機ディスプレイに流れる[新編]映像の写真" width={170} height={240} quality={60} slot="media" />
+					<Image path="madoka/dojin/pictorial10_cover.jpg" alt="建物内にある[新編]の告知イラストが書かれた大きなポスターと、券売機ディスプレイに流れる[新編]映像の写真" width={170} height={240} quality={60} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>
 			</FlexItem>

--- a/astro/src/pages/madoka/dojin/pictorial11.astro
+++ b/astro/src/pages/madoka/dojin/pictorial11.astro
@@ -46,7 +46,7 @@ const structuredData: StructuredData = {
 		<Flex>
 			<FlexItem>
 				<Embedded border={true}>
-					<Image path="madoka/dojin/pictorial11_cover.jpg" alt="表紙: 複数並んだ駅のホームの一つに横長のマギレコポスターが掲出されており、隣の線路には路面電車が停車している写真" width={170} height={240} quality={60} slot="media" />
+					<Image path="madoka/dojin/pictorial11_cover.jpg" alt="複数並んだ駅のホームの一つに横長のマギレコポスターが掲出されており、隣の線路には路面電車が停車している写真" width={170} height={240} quality={60} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>
 			</FlexItem>

--- a/astro/src/pages/madoka/dojin/pictorial6.astro
+++ b/astro/src/pages/madoka/dojin/pictorial6.astro
@@ -50,7 +50,7 @@ const slugger = new GithubSlugger();
 		<Flex>
 			<FlexItem>
 				<Embedded border={true}>
-					<Image path="madoka/dojin/pictorial6_cover.jpg" alt="表紙: [新編]パッケージを取り囲むように大量の特典フィルムが並べられた写真" width={170} height={240} quality={60} slot="media" />
+					<Image path="madoka/dojin/pictorial6_cover.jpg" alt="[新編]パッケージを取り囲むように大量の特典フィルムが並べられた写真" width={170} height={240} quality={60} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>
 			</FlexItem>

--- a/astro/src/pages/madoka/dojin/pictorial7.astro
+++ b/astro/src/pages/madoka/dojin/pictorial7.astro
@@ -49,7 +49,7 @@ const slugger = new GithubSlugger();
 		<Flex>
 			<FlexItem>
 				<Embedded border={true}>
-					<Image path="madoka/dojin/pictorial7_cover.jpg" alt="表紙: イベント会場での展示ブースの中央にあるディスプレイに『まどか☆マギカ』のアニメが流れている様子を写した写真" width={170} height={240} quality={60} slot="media" />
+					<Image path="madoka/dojin/pictorial7_cover.jpg" alt="イベント会場での展示ブースの中央にあるディスプレイに『まどか☆マギカ』のアニメが流れている様子を写した写真" width={170} height={240} quality={60} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>
 			</FlexItem>

--- a/astro/src/pages/madoka/dojin/pictorial8.astro
+++ b/astro/src/pages/madoka/dojin/pictorial8.astro
@@ -47,7 +47,7 @@ const structuredData: StructuredData = {
 		<Flex>
 			<FlexItem>
 				<Embedded border={true}>
-					<Image path="madoka/dojin/pictorial8_cover.jpg" alt="表紙: 教室のスクリーンにスライドを映しながらマイクを持って説明している写真" width={170} height={240} quality={60} slot="media" />
+					<Image path="madoka/dojin/pictorial8_cover.jpg" alt="教室のスクリーンにスライドを映しながらマイクを持って説明している写真" width={170} height={240} quality={60} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>
 			</FlexItem>

--- a/astro/src/pages/madoka/dojin/pictorial9.astro
+++ b/astro/src/pages/madoka/dojin/pictorial9.astro
@@ -50,7 +50,7 @@ const structuredData: StructuredData = {
 		<Flex>
 			<FlexItem>
 				<Embedded border={true}>
-					<Image path="madoka/dojin/pictorial9_cover.jpg" alt="表紙: 駅の壁に掲出されたさやかポスターと、ホームに進入する東急電車の写真" width={170} height={240} quality={60} slot="media" />
+					<Image path="madoka/dojin/pictorial9_cover.jpg" alt="駅の壁に掲出されたさやかポスターと、ホームに進入する東急電車の写真" width={170} height={240} quality={60} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>
 			</FlexItem>

--- a/astro/src/pages/tokyu/book/7700.astro
+++ b/astro/src/pages/tokyu/book/7700.astro
@@ -30,7 +30,7 @@ const structuredData: StructuredData = {
 	<Flex>
 		<FlexItem>
 			<Embedded border={true}>
-				<Image path="tokyu/book/7700_cover.jpg" alt="表紙: 上部に赤文字で書名、下部に7700系の正面写真が12枚並んでいる" width={170} height={240} quality={60} slot="media" />
+				<Image path="tokyu/book/7700_cover.jpg" alt="上部に赤文字で書名、下部に7700系の正面写真が12枚並んでいる" width={170} height={240} quality={60} slot="media" />
 				<Fragment slot="caption">表紙</Fragment>
 			</Embedded>
 		</FlexItem>

--- a/astro/src/pages/tokyu/book/tamagawa1067.astro
+++ b/astro/src/pages/tokyu/book/tamagawa1067.astro
@@ -32,7 +32,7 @@ const structuredData: StructuredData = {
 	<Flex>
 		<FlexItem>
 			<Embedded border={true}>
-				<Image path="tokyu/book/tamagawa1067_cover.jpg" alt="表紙: クリーム色の背景に縦書きの書名、左下に公文書の本文（一部分）と青焼き図面の写真が1枚ずつ" width={170} height={240} quality={60} slot="media" />
+				<Image path="tokyu/book/tamagawa1067_cover.jpg" alt="クリーム色の背景に縦書きの書名、左下に公文書の本文（一部分）と青焼き図面の写真が1枚ずつ" width={170} height={240} quality={60} slot="media" />
 				<Fragment slot="caption">表紙</Fragment>
 			</Embedded>
 		</FlexItem>


### PR DESCRIPTION
キャプション（figcaption）と重複するため