### PR TITLE
ページ全体のスタイル指定を `:root` に戻したうえで配色設定を `head, body` で明記

### DIFF
--- a/frontend/style/foundation/_elements.css
+++ b/frontend/style/foundation/_elements.css
@@ -1,14 +1,7 @@
 :root {
-	@media (prefers-reduced-motion: no-preference) {
-		scroll-behavior: smooth;
-	}
-}
-
-body {
 	--_color: var(--page-color);
 	--_bg-color: var(--page-bg-color);
 
-	background-color: var(--_bg-color);
 	color: var(--_color);
 	font: var(--font-weight-normal) var(--page-font-size) / var(--line-height-wide) sans-serif;
 
@@ -16,6 +9,16 @@ body {
 		--_color: var(--color-black);
 		--_bg-color: var(--color-white);
 	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		scroll-behavior: smooth;
+	}
+}
+
+head /* for iOS Vialdi 7.7 (Force a dark theme on all websites) */,
+body {
+	background-color: var(--_bg-color);
+	color: inherit;
 }
 
 :focus {

--- a/frontend/style/foundation/_reset.css
+++ b/frontend/style/foundation/_reset.css
@@ -3,6 +3,7 @@
  *
  * https://html.spec.whatwg.org/multipage/rendering.html#the-page
  */
+/* stylelint-disable-next-line plugin/root-colors */
 body {
 	margin: 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@types/node": "^24.10.0",
 				"@w0s/eslint-config": "^9.3.1",
 				"@w0s/markuplint-config": "^3.12.0",
-				"@w0s/stylelint-config": "^4.15.1",
+				"@w0s/stylelint-config": "^4.16.0",
 				"@w0s/tsconfig": "^1.7.0",
 				"concurrently": "^9.2.1",
 				"prettier": "^3.7.4",
@@ -5283,9 +5283,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@w0s/stylelint-config": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@w0s/stylelint-config/-/stylelint-config-4.15.1.tgz",
-			"integrity": "sha512-L7vdbfpcxx0+IQSCBf4ZuQnNGVuyQh+LniBqn8Gm32PxzdQYBVwevb4W6RORgoD6ZEeZc7CVrnH1tZ+X1x1UkQ==",
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/@w0s/stylelint-config/-/stylelint-config-4.16.0.tgz",
+			"integrity": "sha512-9H70EtJivg5vWd3YtXGz/ue/W5fUEU/Oe0uh8Y49Ko1Pypr9MyRyieDlKfx9mec17upVAdfhrhguf7wR89vPUQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -5296,7 +5296,7 @@
 				"stylelint-display-multi-keyword": "^1.0.0",
 				"stylelint-no-default-viewport": "^1.0.0",
 				"stylelint-plugin-logical-css": "^1.2.0",
-				"stylelint-root-colors": "^1.0.0"
+				"stylelint-root-colors": "^2.0.0"
 			}
 		},
 		"node_modules/@w0s/table-cell-ditto": {
@@ -14558,7 +14558,9 @@
 			}
 		},
 		"node_modules/stylelint-root-colors": {
-			"version": "1.0.1",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stylelint-root-colors/-/stylelint-root-colors-2.0.2.tgz",
+			"integrity": "sha512-23YDB3Vh7EPHRSYFuxEGFYF9kvbHDik7G+zxzgRePgQ42jlU/SDChxL22KE0YmgKRX/HfhBzFJRZiDTqvitnxQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"@types/node": "^24.10.0",
 		"@w0s/eslint-config": "^9.3.1",
 		"@w0s/markuplint-config": "^3.12.0",
-		"@w0s/stylelint-config": "^4.15.1",
+		"@w0s/stylelint-config": "^4.16.0",
 		"@w0s/tsconfig": "^1.7.0",
 		"concurrently": "^9.2.1",
 		"prettier": "^3.7.4",


### PR DESCRIPTION
#921 の追加対応

`<head>` 内要素をユーザースタイルシートで表示したケースに対応