### PR TITLE
問い合わせフォームの確認画面が表示されていなかったバグを修正

### DIFF
--- a/frontend/script/unique/Contact.ts
+++ b/frontend/script/unique/Contact.ts
@@ -96,7 +96,7 @@ export default class Contact {
 					inputScreenElement.hidden = true;
 				});
 				this.#confirmScreenElements.forEach((confirmScreenElement) => {
-					confirmScreenElement.hidden = true;
+					confirmScreenElement.hidden = false;
 				});
 				this.#sendButtonElement.disabled = false;
 


### PR DESCRIPTION
#799 の作業においてコピペミスなのか `hidden` 属性値が逆転していた