### PR TITLE
リンクアイコンの表示サイズと縦位置調整

### DIFF
--- a/astro/src/components/+phrasing/Anchor.astro
+++ b/astro/src/components/+phrasing/Anchor.astro
@@ -176,7 +176,11 @@ const hostIcon = url !== undefined ? HOST_ICONS.find((data) => data.host === url
 		:is(.type, .domain) {
 			word-break: break-all;
 			color: var(--color-gray);
-			font-size: calc(100% / pow(var(--font-ratio), 1));
+			font-size: calc(100% * var(--_font-size-ratio, 1));
+
+			&:not(:has(img)) {
+				--_font-size-ratio: calc(1 / pow(var(--font-ratio), 1));
+			}
 		}
 
 		.domain {

--- a/astro/src/components/+phrasing/AnchorIcon.astro
+++ b/astro/src/components/+phrasing/AnchorIcon.astro
@@ -14,7 +14,7 @@ const { fileName, alt } = Astro.props;
 		.link-icon {
 			block-size: 1em;
 			inline-size: auto;
-			vertical-align: -0.1lh;
+			vertical-align: calc((1cap - 1em) / 2);
 		}
 	}
 </style>


### PR DESCRIPTION
- テキストと同じ大きさで表示するように変更
- cap 単位の使用により上下揃えをちゃんとする

参考: [vertical-align プロパティと cap 単位を使って、アイコンとテキストの縦位置をいい感じに中央で揃える CSS / JeffreyFrancesco.org](https://jeffreyfrancesco.org/weblog/2025111301/)