### PR TITLE
Rollup ビルドが失敗するバグを修正

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,8 @@
 		"postcss-discard-empty": "7.0.1",
 		"postcss-import": "16.1.1",
 		"postcss-nesting": "14.0.0",
-		"rollup": "4.57.1"
+		"rollup": "4.57.1",
+		"tslib": "2.8.1"
 	},
 	"packageManager": "pnpm@10.28.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       rollup:
         specifier: 4.57.1
         version: 4.57.1
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
 
 packages:
 
@@ -9829,8 +9832,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:


### PR DESCRIPTION
tslib が自動でインストールされない（pnpm 環境等でのみ発生する事象?）ため、手動で依存関係に追加する必要がある👉[[@rollup/plugin-typescript] Could not find module 'tslib', which is required by this plugin · rollup/plugins · Discussion #1533](https://github.com/rollup/plugins/discussions/1533)