### PR TITLE
`border-color: transparent` を原則廃止

### DIFF
--- a/astro/src/components/+phrasing/NoteRefX.astro
+++ b/astro/src/components/+phrasing/NoteRefX.astro
@@ -3,27 +3,24 @@
 <style>
 	@layer component {
 		.note-ref {
+			display: inline flow-root;
 			vertical-align: super;
 			font-size: calc(100% / pow(var(--font-ratio), 2));
 
 			& > :global(a) {
-				--_border-color: transparent;
-				--_bg-color: transparent;
-
-				border: 1px solid var(--_border-color);
-				background-color: var(--_bg-color);
-				text-wrap-mode: nowrap;
+				outline-offset: calc(0px - var(--outline-width-bold));
+				outline-width: var(--outline-width-bold);
+				padding: 0.25em;
 				text-decoration-skip-ink: none; /* JS 無効環境向け */
 			}
 
 			& > :global(a:target) {
-				--_border-color: var(--color-red);
-				--_bg-color: var(--color-verylightred);
+				border: 1px solid var(--color-red);
+				background-color: var(--color-verylightred);
 			}
 
 			& > :global(a[role='button' i]) {
 				/* JS 有効時のみ */
-				outline-offset: calc(0px - var(--outline-width));
 				cursor: default;
 				text-decoration: none;
 				color: var(--link-color);

--- a/astro/src/components/Footnote.astro
+++ b/astro/src/components/Footnote.astro
@@ -36,43 +36,42 @@ const { title, data, prefix, refPrefix } = Astro.props;
 		.footnote {
 			border: 1px solid var(--color-bg-light);
 			border-radius: var(--border-radius-large);
-			background: var(--color-bg-light);
+			background-color: var(--color-bg-light);
 			padding: 1em;
 			font-size: calc(100% / pow(var(--font-ratio), 1));
+
+			& > * + * {
+				margin-block-start: 1em;
+			}
 		}
 
 		.hdg {
 		}
 
 		.list {
-			display: block table;
-			margin-block-start: 0.25em;
+			display: block grid;
+			grid-template-columns: auto 1fr;
+			gap: 1em 0.5em;
 
 			& > :global(li) {
-				display: table-row;
+				display: block grid;
+				grid-template-columns: subgrid;
+				grid-column: 1 / -1;
 			}
 
 			& > :global(li:not(:first-child) > *) {
-				border-block-start: 0.5em solid transparent;
 			}
 		}
 
 		.no,
 		.content {
-			display: table-cell;
-			vertical-align: top;
 		}
 
 		.no {
-			padding-block-start: 0.5em;
 			text-align: end;
-			text-wrap-mode: nowrap;
 		}
 
 		.content {
-			padding-block-start: 0.5em;
-			padding-inline-start: 0.5em;
-			inline-size: 100%;
 		}
 
 		.backref {

--- a/astro/src/components/Section.astro
+++ b/astro/src/components/Section.astro
@@ -112,9 +112,8 @@ if (id !== undefined) {
 
 			.section.-a > & {
 				margin-block-end: 2rem;
-				border-block-start: 1px solid transparent;
 				border-block-end: 1px solid var(--color-border-dark);
-				padding-block: 0.25em;
+				padding-block-end: 0.375em;
 				font-size: calc(100% * pow(var(--font-ratio), 6));
 			}
 

--- a/astro/src/components/header/GlobalNav.astro
+++ b/astro/src/components/header/GlobalNav.astro
@@ -47,44 +47,40 @@ const { pagePath, data } = Astro.props;
 				display: block flex;
 				flex: auto;
 				margin: calc(0px - var(--_border-width) / 2);
-				border: 1px solid var(--color-border-light);
+				border: var(--_border-width) solid var(--color-border-light);
 			}
 		}
 
 		.link {
-			--_border-color: transparent;
-			--_border-width: 0px;
-			--_color: var(--color-darkgray);
-			--_background: var(--color-white);
+			--_link-border-width: 0px;
 
 			flex: 100%;
-			contain: content;
+			contain: content; /* フォーカスリングとの関係 */
 			outline-offset: calc(1px - var(--outline-width-bold));
 			outline-width: var(--outline-width-bold);
-			border-block-end: var(--_border-width) solid var(--_border-color);
-			background: var(--_background);
-			padding: 0.5em 0.25em calc(0.5em - var(--_border-width));
+			background-color: var(--color-white);
+			padding: 0.5em 0.25em calc(0.5em - var(--_link-border-width));
 			text-align: center;
 			text-decoration: none;
-			color: var(--_color);
+			color: var(--color-darkgray);
 			font-size: clamp(100%, 2.5svi, calc(100% * pow(var(--font-ratio), 2)));
 
 			&:any-link {
-				--_background: linear-gradient(var(--color-white), var(--color-bg-light));
+				background-image: linear-gradient(var(--color-white), var(--color-bg-light));
 
 				&:hover {
-					--_background: linear-gradient(var(--color-bg-light), var(--color-white));
-
-					color: var(--_color);
+					background-image: linear-gradient(var(--color-bg-light), var(--color-white));
+					color: var(--color-darkgray);
 				}
 			}
 
 			&[aria-current] {
-				--_border-width: 2px;
-				--_border-color: var(--color-red);
+				--_link-border-width: 2px;
+
+				border-block-end: var(--_link-border-width) solid var(--color-red);
 
 				&:focus {
-					--_border-width: 3px; /* フォーカスリングとの関係 */
+					--_link-border-width: 3px; /* フォーカスリングとの関係 */
 				}
 			}
 		}

--- a/frontend/style/foundation/_base.css
+++ b/frontend/style/foundation/_base.css
@@ -186,25 +186,25 @@ x-popover {
 	}
 
 	&::part(hide-button) {
-		--_border-color: var(--color-white);
 		--_background-color: transparent;
 
 		position: absolute;
 		inset-block-start: 1px;
 		inset-inline-end: 1px;
 		outline-offset: -1px;
-		border: 1px solid var(--_border-color);
+		border-style: none;
 		border-radius: var(--border-radius-normal);
-		background: var(--_background-color);
+		background-color: var(--_background-color);
 		padding: var(--_hide-button-padding);
+	}
+
+	&::part(hide-button):hover {
+		--_background-color: var(--color-bg-superlight);
+
+		outline: 1px solid var(--color-bg-light);
 	}
 
 	&::part(hide-button):focus {
 		outline: var(--outline-width-bold) solid var(--outline-color);
-	}
-
-	&::part(hide-button):hover {
-		--_border-color: var(--color-bg-light);
-		--_background-color: var(--color-bg-superlight);
 	}
 }


### PR DESCRIPTION
border の transparent が一部ブラウザの強制ダークテーマで白塗りになってしまうのを解消する。

ただしフォームのチェックボックスとステップコンポーネントのみ今回は作業対象外とする。
