### PR TITLE
`Astro.slots.render()` を使用したコンポーネントでは `<slot>` ではなく `set:html` を使うようにする

### DIFF
--- a/astro/src/components/+phrasing/Label.astro
+++ b/astro/src/components/+phrasing/Label.astro
@@ -7,7 +7,9 @@ interface Props {
 
 const { label } = Astro.props;
 
-const $ = cheerio.load(await Astro.slots.render('default'));
+const content = await Astro.slots.render('default');
+
+const $ = cheerio.load(content);
 
 const checkboxCtrl = $('input[type="checkbox"]').length !== 0;
 const radioCtrl = $('input[type="radio"]').length !== 0;
@@ -15,11 +17,11 @@ const switchCtrl = $('w0s-input-switch').length !== 0;
 ---
 
 <label class:list={['label', checkboxCtrl ? '-checkbox' : undefined, radioCtrl ? '-radio' : undefined]}>
-	{(checkboxCtrl || radioCtrl || switchCtrl) && <slot />}
+	{(checkboxCtrl || radioCtrl || switchCtrl) && <Fragment set:html={content} />}
 
 	<span class="text">{label}</span>
 
-	{!checkboxCtrl && !radioCtrl && !switchCtrl && <slot />}
+	{!checkboxCtrl && !radioCtrl && !switchCtrl && <Fragment set:html={content} />}
 </label>
 
 <style>

--- a/astro/src/components/+phrasing/Label.test.ts
+++ b/astro/src/components/+phrasing/Label.test.ts
@@ -1,0 +1,100 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { parse } from 'node-html-parser';
+import { expect, test } from 'vitest';
+// @ts-ignore: ts(2307)
+import Label from './Label.astro';
+
+test('text', async () => {
+	const container = await AstroContainer.create();
+	const result = await container.renderToString(Label, {
+		props: {
+			label: 'label',
+		},
+		slots: {
+			default: '<input type="text">',
+		},
+	});
+
+	const root = parse(result);
+
+	const children = root.firstElementChild?.children;
+
+	const label = children?.at(0);
+	const ctrl = children?.at(1);
+
+	expect(label?.tagName.toLowerCase()).toBe('span');
+	expect(label?.textContent).toBe('label');
+	expect(ctrl?.tagName.toLowerCase()).toBe('input');
+	expect(ctrl?.getAttribute('type')).toBe('text');
+});
+
+test('checkbox', async () => {
+	const container = await AstroContainer.create();
+	const result = await container.renderToString(Label, {
+		props: {
+			label: 'label',
+		},
+		slots: {
+			default: '<input type="checkbox">',
+		},
+	});
+
+	const root = parse(result);
+
+	const children = root.firstElementChild?.children;
+
+	const ctrl = children?.at(0);
+	const label = children?.at(1);
+
+	expect(ctrl?.tagName.toLowerCase()).toBe('input');
+	expect(ctrl?.getAttribute('type')).toBe('checkbox');
+	expect(label?.tagName.toLowerCase()).toBe('span');
+	expect(label?.textContent).toBe('label');
+});
+
+test('radio', async () => {
+	const container = await AstroContainer.create();
+	const result = await container.renderToString(Label, {
+		props: {
+			label: 'label',
+		},
+		slots: {
+			default: '<input type="radio">',
+		},
+	});
+
+	const root = parse(result);
+
+	const children = root.firstElementChild?.children;
+
+	const ctrl = children?.at(0);
+	const label = children?.at(1);
+
+	expect(ctrl?.tagName.toLowerCase()).toBe('input');
+	expect(ctrl?.getAttribute('type')).toBe('radio');
+	expect(label?.tagName.toLowerCase()).toBe('span');
+	expect(label?.textContent).toBe('label');
+});
+
+test('switch', async () => {
+	const container = await AstroContainer.create();
+	const result = await container.renderToString(Label, {
+		props: {
+			label: 'label',
+		},
+		slots: {
+			default: '<w0s-input-switch></w0s-input-switch>',
+		},
+	});
+
+	const root = parse(result);
+
+	const children = root.firstElementChild?.children;
+
+	const ctrl = children?.at(0);
+	const label = children?.at(1);
+
+	expect(ctrl?.tagName.toLowerCase()).toBe('w0s-input-switch');
+	expect(label?.tagName.toLowerCase()).toBe('span');
+	expect(label?.textContent).toBe('label');
+});

--- a/astro/src/components/ListOrder.astro
+++ b/astro/src/components/ListOrder.astro
@@ -1,14 +1,14 @@
 ---
 import * as cheerio from 'cheerio';
 
-const $ = cheerio.load(await Astro.slots.render('default'));
+const content = await Astro.slots.render('default');
+
+const $ = cheerio.load(content);
 
 const itemDigit = $('body > li').length.toString().length;
 ---
 
-<ol class="list" data-digit={itemDigit}>
-	<slot />
-</ol>
+<ol class="list" data-digit={itemDigit} set:html={content} />
 
 <style>
 	@layer component {

--- a/astro/src/components/ListOrder.test.ts
+++ b/astro/src/components/ListOrder.test.ts
@@ -1,0 +1,43 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { parse } from 'node-html-parser';
+import { expect, test } from 'vitest';
+// @ts-ignore: ts(2307)
+import ListOrder from './ListOrder.astro';
+
+test('digit 1', async () => {
+	const container = await AstroContainer.create();
+	const result = await container.renderToString(ListOrder, {
+		props: {
+			label: 'label',
+		},
+		slots: {
+			default: '<li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li>',
+		},
+	});
+
+	const root = parse(result);
+
+	const ol = root.firstElementChild;
+
+	expect(ol?.tagName.toLowerCase()).toBe('ol');
+	expect(ol?.getAttribute('data-digit')).toBe('1');
+});
+
+test('digit 2', async () => {
+	const container = await AstroContainer.create();
+	const result = await container.renderToString(ListOrder, {
+		props: {
+			label: 'label',
+		},
+		slots: {
+			default: '<li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li><li></li>',
+		},
+	});
+
+	const root = parse(result);
+
+	const ol = root.firstElementChild;
+
+	expect(ol?.tagName.toLowerCase()).toBe('ol');
+	expect(ol?.getAttribute('data-digit')).toBe('2');
+});


### PR DESCRIPTION
dev 画面でコンポーネント用の CSS が読み込まれないため