### PR TITLE
Stylelint 17.9.1 にアップデート

### DIFF
--- a/frontend/stylelint.config.js
+++ b/frontend/stylelint.config.js
@@ -4,7 +4,6 @@
 export default {
 	extends: ['@w0s/stylelint-config'],
 	rules: {
-		'selector-no-deprecated': null, // https://github.com/stylelint/stylelint/issues/9221
 		'max-nesting-depth': [
 			5,
 			{

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"prettier-plugin-astro": "0.14.1",
 		"prettier-plugin-ejs": "1.0.3",
 		"rimraf": "6.1.3",
-		"stylelint": "17.8.0",
+		"stylelint": "17.9.1",
 		"stylelint-attribute-case-sensitivity": "3.0.1",
 		"stylelint-config-concentric-order": "5.5.0",
 		"stylelint-config-standard": "40.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 3.13.0(markuplint@4.18.1(typescript@5.9.3))
       '@w0s/stylelint-config':
         specifier: 4.21.0
-        version: 4.21.0(stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.8.0(typescript@5.9.3)))(stylelint-config-concentric-order@5.5.0(stylelint@17.8.0(typescript@5.9.3)))(stylelint-config-standard@40.0.0(stylelint@17.8.0(typescript@5.9.3)))(stylelint-no-default-viewport@2.0.1(stylelint@17.8.0(typescript@5.9.3)))(stylelint-plugin-defensive-css@2.9.1(stylelint@17.8.0(typescript@5.9.3)))(stylelint-plugin-logical-css@2.1.0(stylelint@17.8.0(typescript@5.9.3)))(stylelint-root-colors@3.0.1(stylelint@17.8.0(typescript@5.9.3)))(stylelint@17.8.0(typescript@5.9.3))
+        version: 4.21.0(stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.9.1(typescript@5.9.3)))(stylelint-config-concentric-order@5.5.0(stylelint@17.9.1(typescript@5.9.3)))(stylelint-config-standard@40.0.0(stylelint@17.9.1(typescript@5.9.3)))(stylelint-no-default-viewport@2.0.1(stylelint@17.9.1(typescript@5.9.3)))(stylelint-plugin-defensive-css@2.9.1(stylelint@17.9.1(typescript@5.9.3)))(stylelint-plugin-logical-css@2.1.0(stylelint@17.9.1(typescript@5.9.3)))(stylelint-root-colors@3.0.1(stylelint@17.9.1(typescript@5.9.3)))(stylelint@17.9.1(typescript@5.9.3))
       '@w0s/tsconfig':
         specifier: 2.0.1
         version: 2.0.1(typescript@5.9.3)
@@ -61,29 +61,29 @@ importers:
         specifier: 6.1.3
         version: 6.1.3
       stylelint:
-        specifier: 17.8.0
-        version: 17.8.0(typescript@5.9.3)
+        specifier: 17.9.1
+        version: 17.9.1(typescript@5.9.3)
       stylelint-attribute-case-sensitivity:
         specifier: 3.0.1
-        version: 3.0.1(stylelint@17.8.0(typescript@5.9.3))
+        version: 3.0.1(stylelint@17.9.1(typescript@5.9.3))
       stylelint-config-concentric-order:
         specifier: 5.5.0
-        version: 5.5.0(stylelint@17.8.0(typescript@5.9.3))
+        version: 5.5.0(stylelint@17.9.1(typescript@5.9.3))
       stylelint-config-standard:
         specifier: 40.0.0
-        version: 40.0.0(stylelint@17.8.0(typescript@5.9.3))
+        version: 40.0.0(stylelint@17.9.1(typescript@5.9.3))
       stylelint-no-default-viewport:
         specifier: 2.0.1
-        version: 2.0.1(stylelint@17.8.0(typescript@5.9.3))
+        version: 2.0.1(stylelint@17.9.1(typescript@5.9.3))
       stylelint-plugin-defensive-css:
         specifier: 2.9.1
-        version: 2.9.1(stylelint@17.8.0(typescript@5.9.3))
+        version: 2.9.1(stylelint@17.9.1(typescript@5.9.3))
       stylelint-plugin-logical-css:
         specifier: 2.1.0
-        version: 2.1.0(stylelint@17.8.0(typescript@5.9.3))
+        version: 2.1.0(stylelint@17.9.1(typescript@5.9.3))
       stylelint-root-colors:
         specifier: 3.0.1
-        version: 3.0.1(stylelint@17.8.0(typescript@5.9.3))
+        version: 3.0.1(stylelint@17.9.1(typescript@5.9.3))
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -207,7 +207,7 @@ importers:
         version: 14.0.0(postcss@8.5.10)
       stylelint-config-html:
         specifier: 1.1.0
-        version: 1.1.0(postcss-html@1.8.1)(stylelint@17.8.0(typescript@5.9.3))
+        version: 1.1.0(postcss-html@1.8.1)(stylelint@17.9.1(typescript@5.9.3))
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@types/node@24.10.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@7.3.2(@types/node@24.10.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -4267,8 +4267,8 @@ packages:
     peerDependencies:
       stylelint: ^16.0.0 || ^17.0.0
 
-  stylelint@17.8.0:
-    resolution: {integrity: sha512-oHkld9T60LDSaUQ4CSVc+tlt9eUoDlxhaGWShsUCKyIL14boZfmK5bSphZqx64aiC5tCqX+BsQMTMoSz8D1zIg==}
+  stylelint@17.9.1:
+    resolution: {integrity: sha512-THTmnAPJTrg/JhkTWZlSyrO+HUYMx6ELthIHeMyD2WOKqXIJUFQv2Yxn91bvUrZdbBJaW2dUuQdPST2wcQ6C3g==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -6287,16 +6287,16 @@ snapshots:
 
   '@w0s/string-convert@3.0.3': {}
 
-  '@w0s/stylelint-config@4.21.0(stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.8.0(typescript@5.9.3)))(stylelint-config-concentric-order@5.5.0(stylelint@17.8.0(typescript@5.9.3)))(stylelint-config-standard@40.0.0(stylelint@17.8.0(typescript@5.9.3)))(stylelint-no-default-viewport@2.0.1(stylelint@17.8.0(typescript@5.9.3)))(stylelint-plugin-defensive-css@2.9.1(stylelint@17.8.0(typescript@5.9.3)))(stylelint-plugin-logical-css@2.1.0(stylelint@17.8.0(typescript@5.9.3)))(stylelint-root-colors@3.0.1(stylelint@17.8.0(typescript@5.9.3)))(stylelint@17.8.0(typescript@5.9.3))':
+  '@w0s/stylelint-config@4.21.0(stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.9.1(typescript@5.9.3)))(stylelint-config-concentric-order@5.5.0(stylelint@17.9.1(typescript@5.9.3)))(stylelint-config-standard@40.0.0(stylelint@17.9.1(typescript@5.9.3)))(stylelint-no-default-viewport@2.0.1(stylelint@17.9.1(typescript@5.9.3)))(stylelint-plugin-defensive-css@2.9.1(stylelint@17.9.1(typescript@5.9.3)))(stylelint-plugin-logical-css@2.1.0(stylelint@17.9.1(typescript@5.9.3)))(stylelint-root-colors@3.0.1(stylelint@17.9.1(typescript@5.9.3)))(stylelint@17.9.1(typescript@5.9.3))':
     dependencies:
-      stylelint: 17.8.0(typescript@5.9.3)
-      stylelint-attribute-case-sensitivity: 3.0.1(stylelint@17.8.0(typescript@5.9.3))
-      stylelint-config-concentric-order: 5.5.0(stylelint@17.8.0(typescript@5.9.3))
-      stylelint-config-standard: 40.0.0(stylelint@17.8.0(typescript@5.9.3))
-      stylelint-no-default-viewport: 2.0.1(stylelint@17.8.0(typescript@5.9.3))
-      stylelint-plugin-defensive-css: 2.9.1(stylelint@17.8.0(typescript@5.9.3))
-      stylelint-plugin-logical-css: 2.1.0(stylelint@17.8.0(typescript@5.9.3))
-      stylelint-root-colors: 3.0.1(stylelint@17.8.0(typescript@5.9.3))
+      stylelint: 17.9.1(typescript@5.9.3)
+      stylelint-attribute-case-sensitivity: 3.0.1(stylelint@17.9.1(typescript@5.9.3))
+      stylelint-config-concentric-order: 5.5.0(stylelint@17.9.1(typescript@5.9.3))
+      stylelint-config-standard: 40.0.0(stylelint@17.9.1(typescript@5.9.3))
+      stylelint-no-default-viewport: 2.0.1(stylelint@17.9.1(typescript@5.9.3))
+      stylelint-plugin-defensive-css: 2.9.1(stylelint@17.9.1(typescript@5.9.3))
+      stylelint-plugin-logical-css: 2.1.0(stylelint@17.9.1(typescript@5.9.3))
+      stylelint-root-colors: 3.0.1(stylelint@17.9.1(typescript@5.9.3))
 
   '@w0s/table-cell-ditto@4.1.1':
     dependencies:
@@ -9526,54 +9526,54 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
       postcss-selector-parser: 7.1.1
-      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint: 17.9.1(typescript@5.9.3)
 
-  stylelint-config-concentric-order@5.5.0(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-config-concentric-order@5.5.0(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
-      stylelint-order: 7.0.1(stylelint@17.8.0(typescript@5.9.3))
+      stylelint-order: 7.0.1(stylelint@17.9.1(typescript@5.9.3))
     transitivePeerDependencies:
       - stylelint
 
-  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
-      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint: 17.9.1(typescript@5.9.3)
 
-  stylelint-config-recommended@18.0.0(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-config-recommended@18.0.0(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint: 17.9.1(typescript@5.9.3)
 
-  stylelint-config-standard@40.0.0(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-config-standard@40.0.0(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@5.9.3)
-      stylelint-config-recommended: 18.0.0(stylelint@17.8.0(typescript@5.9.3))
+      stylelint: 17.9.1(typescript@5.9.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.9.1(typescript@5.9.3))
 
-  stylelint-no-default-viewport@2.0.1(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-no-default-viewport@2.0.1(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint: 17.9.1(typescript@5.9.3)
 
-  stylelint-order@7.0.1(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-order@7.0.1(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.10
       postcss-sorting: 9.1.0(postcss@8.5.10)
-      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint: 17.9.1(typescript@5.9.3)
 
-  stylelint-plugin-defensive-css@2.9.1(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-plugin-defensive-css@2.9.1(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint: 17.9.1(typescript@5.9.3)
 
-  stylelint-plugin-logical-css@2.1.0(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-plugin-logical-css@2.1.0(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint: 17.9.1(typescript@5.9.3)
 
-  stylelint-root-colors@3.0.1(stylelint@17.8.0(typescript@5.9.3)):
+  stylelint-root-colors@3.0.1(stylelint@17.9.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint: 17.9.1(typescript@5.9.3)
 
-  stylelint@17.8.0(typescript@5.9.3):
+  stylelint@17.9.1(typescript@5.9.3):
     dependencies:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)


### PR DESCRIPTION
selector-no-deprecated の暫定無効化を解除