### PR TITLE
中国語の `<cite>` 要素が斜字になるのをリセットする

### DIFF
--- a/frontend/style/foundation/_base.css
+++ b/frontend/style/foundation/_base.css
@@ -79,6 +79,10 @@ small {
 	font-weight: var(--font-weight-normal);
 }
 
+cite:lang(zh) {
+	font-style: unset;
+}
+
 dfn {
 	&::before {
 		content: var(--_open, "“");


### PR DESCRIPTION
base.css でのリセットは日本語のみが対象なので、こちらで独自にリセットする。韓国語は今のところ存在しないので指定しない。