### PR TITLE
見出しスタイルの手動設定を廃止し、セクション階層に応じた自動設定のみに統一する

### DIFF
--- a/astro/src/components/Flex.astro
+++ b/astro/src/components/Flex.astro
@@ -1,12 +1,4 @@
----
-interface Props {
-	headingType?: 'a' | 'b' | 'c' | 'd';
-}
-
-const { headingType } = Astro.props;
----
-
-<div class:list={['flex', headingType !== undefined ? `-hdg-${headingType}` : undefined]}>
+<div class="flex">
 	<slot />
 </div>
 
@@ -19,18 +11,6 @@ const { headingType } = Astro.props;
 			display: block flex;
 			flex-wrap: wrap;
 			gap: var(--_gap-row) var(--_gap-col);
-
-			&.-hdg-a {
-				--_gap-row: 4.5rem;
-			}
-
-			&.-hdg-b {
-				--_gap-row: 3.75rem;
-			}
-
-			&.-hdg-c {
-				--_gap-row: 3rem;
-			}
 		}
 	}
 </style>

--- a/astro/src/components/Grid.astro
+++ b/astro/src/components/Grid.astro
@@ -1,13 +1,12 @@
 ---
 interface Props {
-	column: 'wide' | 'medium' | 'narrow' | number;
-	headingType?: 'a' | 'b' | 'c' | 'd';
+	column: 'wide' | 'medium' | 'narrow';
 }
 
-const { column, headingType } = Astro.props;
+const { column } = Astro.props;
 ---
 
-<div class:list={['grid', typeof column === 'string' ? `-${column}` : undefined, headingType !== undefined ? `-hdg-${headingType}` : undefined]} style={typeof column === 'number' ? `--_min-inline-size: ${column}px` : undefined}>
+<div class:list={['grid', `-${column}`]}>
 	<slot />
 </div>
 
@@ -35,18 +34,6 @@ const { column, headingType } = Astro.props;
 			/* 4カラム */
 			&.-narrow {
 				--_min-inline-size: 180px;
-			}
-
-			&.-hdg-a {
-				--_gap-row: 4.5rem;
-			}
-
-			&.-hdg-b {
-				--_gap-row: 3.75rem;
-			}
-
-			&.-hdg-c {
-				--_gap-row: 3rem;
 			}
 		}
 	}

--- a/astro/src/components/Section.astro
+++ b/astro/src/components/Section.astro
@@ -2,19 +2,36 @@
 import type GithubSlugger from 'github-slugger';
 import SelfLink from './+phrasing/SelfLink.astro';
 
+type Depth = 1 | 2 | 3;
+type HeadingType = 'a' | 'b' | 'c';
+
 interface Props {
 	slugger?: GithubSlugger;
 	id?: string;
-	depth?: number;
-	headingType?: 'a' | 'b' | 'c' | 'd';
+	depth?: Depth;
+	headingType?: HeadingType;
 	box?: boolean;
 	autofocus?: boolean;
 	class?: string;
 }
 
-const { slugger, id, depth = 1, headingType = 'a', box = false, autofocus = false, class: className } = Astro.props;
+const { slugger, id, depth = 1, headingType, box = false, autofocus = false, class: className } = Astro.props;
 
 const headingHtml = await Astro.slots.render('heading');
+
+const getHeadingType = (depth: Depth, headingType: HeadingType | undefined): HeadingType => {
+	if (headingType !== undefined) {
+		return headingType;
+	}
+
+	return (
+		new Map<Depth, HeadingType>([
+			[1, 'a'],
+			[2, 'b'],
+			[3, 'c'],
+		]).get(depth) ?? 'a'
+	);
+};
 
 let sectionId = '';
 if (id !== undefined) {
@@ -30,12 +47,11 @@ if (id !== undefined) {
 }
 ---
 
-<section autofocus={autofocus} tabindex={autofocus ? -1 : undefined} class:list={['section', `-${headingType}`, { '-box': box }, className]} id={sectionId}>
+<section autofocus={autofocus} tabindex={autofocus ? -1 : undefined} class:list={['section', `-${getHeadingType(depth, headingType)}`, { '-box': box }, className]} id={sectionId}>
 	<div class="hdg">
 		{depth === 1 && <h2 set:html={headingHtml} />}
 		{depth === 2 && <h3 set:html={headingHtml} />}
 		{depth === 3 && <h4 set:html={headingHtml} />}
-		{depth === 4 && <h5 set:html={headingHtml} />}
 		<p class="self-link"><SelfLink id={sectionId} /></p>
 	</div>
 

--- a/astro/src/components/Section.astro
+++ b/astro/src/components/Section.astro
@@ -106,10 +106,6 @@ if (id !== undefined) {
 				--_margin-block: 3rem;
 			}
 
-			&.-d {
-				--_margin-block: 2rem;
-			}
-
 			&.-box {
 				border: 1px solid var(--color-border-dark);
 				border-radius: var(--border-radius-normal);

--- a/astro/src/components/Section.astro
+++ b/astro/src/components/Section.astro
@@ -17,17 +17,14 @@ const { id, depth = 1, box = false, autofocus = false, class: className } = Astr
 
 const headingHtml = await Astro.slots.render('heading');
 
-const getHeadingType = (depth: Depth): HeadingType => {
-	return (
-		new Map<Depth, HeadingType>([
-			[1, 'a'],
-			[2, 'b'],
-			[3, 'c'],
-		]).get(depth) ?? 'a'
-	);
-};
+const getHeadingType = (): HeadingType =>
+	new Map<Depth, HeadingType>([
+		[1, 'a'],
+		[2, 'b'],
+		[3, 'c'],
+	]).get(depth) ?? 'a';
 
-const getSectionId = (id: string | GithubSlugger, headingHtml: string): string => {
+const getSectionId = (): string => {
 	if (typeof id === 'string') {
 		return id;
 	}
@@ -37,10 +34,10 @@ const getSectionId = (id: string | GithubSlugger, headingHtml: string): string =
 	return id.slug(headingText);
 };
 
-const sectionId = getSectionId(id, headingHtml);
+const sectionId = getSectionId();
 ---
 
-<section autofocus={autofocus} tabindex={autofocus ? -1 : undefined} class:list={['section', `-${getHeadingType(depth)}`, { '-box': box }, className]} id={sectionId}>
+<section autofocus={autofocus} tabindex={autofocus ? -1 : undefined} class:list={['section', `-${getHeadingType()}`, { '-box': box }, className]} id={sectionId}>
 	<div class="hdg">
 		{depth === 1 && <h2 set:html={headingHtml} />}
 		{depth === 2 && <h3 set:html={headingHtml} />}

--- a/astro/src/components/Section.astro
+++ b/astro/src/components/Section.astro
@@ -6,15 +6,14 @@ type Depth = 1 | 2 | 3;
 type HeadingType = 'a' | 'b' | 'c';
 
 interface Props {
-	slugger?: GithubSlugger;
-	id?: string;
+	id: string | GithubSlugger;
 	depth?: Depth;
 	box?: boolean;
 	autofocus?: boolean;
 	class?: string;
 }
 
-const { slugger, id, depth = 1, box = false, autofocus = false, class: className } = Astro.props;
+const { id, depth = 1, box = false, autofocus = false, class: className } = Astro.props;
 
 const headingHtml = await Astro.slots.render('heading');
 
@@ -28,18 +27,17 @@ const getHeadingType = (depth: Depth): HeadingType => {
 	);
 };
 
-let sectionId = '';
-if (id !== undefined) {
-	sectionId = id;
-} else {
+const getSectionId = (id: string | GithubSlugger, headingHtml: string): string => {
+	if (typeof id === 'string') {
+		return id;
+	}
+
 	const headingText = headingHtml.replaceAll(/<.+?>/gv, '');
 
-	if (slugger !== undefined) {
-		sectionId = slugger.slug(headingText);
-	} else {
-		console.warn('The `slugger` property is not specified.', headingText);
-	}
-}
+	return id.slug(headingText);
+};
+
+const sectionId = getSectionId(id, headingHtml);
 ---
 
 <section autofocus={autofocus} tabindex={autofocus ? -1 : undefined} class:list={['section', `-${getHeadingType(depth)}`, { '-box': box }, className]} id={sectionId}>

--- a/astro/src/components/Section.astro
+++ b/astro/src/components/Section.astro
@@ -9,21 +9,16 @@ interface Props {
 	slugger?: GithubSlugger;
 	id?: string;
 	depth?: Depth;
-	headingType?: HeadingType;
 	box?: boolean;
 	autofocus?: boolean;
 	class?: string;
 }
 
-const { slugger, id, depth = 1, headingType, box = false, autofocus = false, class: className } = Astro.props;
+const { slugger, id, depth = 1, box = false, autofocus = false, class: className } = Astro.props;
 
 const headingHtml = await Astro.slots.render('heading');
 
-const getHeadingType = (depth: Depth, headingType: HeadingType | undefined): HeadingType => {
-	if (headingType !== undefined) {
-		return headingType;
-	}
-
+const getHeadingType = (depth: Depth): HeadingType => {
 	return (
 		new Map<Depth, HeadingType>([
 			[1, 'a'],
@@ -47,7 +42,7 @@ if (id !== undefined) {
 }
 ---
 
-<section autofocus={autofocus} tabindex={autofocus ? -1 : undefined} class:list={['section', `-${getHeadingType(depth, headingType)}`, { '-box': box }, className]} id={sectionId}>
+<section autofocus={autofocus} tabindex={autofocus ? -1 : undefined} class:list={['section', `-${getHeadingType(depth)}`, { '-box': box }, className]} id={sectionId}>
 	<div class="hdg">
 		{depth === 1 && <h2 set:html={headingHtml} />}
 		{depth === 2 && <h3 set:html={headingHtml} />}
@@ -144,7 +139,7 @@ if (id !== undefined) {
 			}
 
 			.section.-b > & {
-				font-size: calc(100% * pow(var(--font-ratio), 4));
+				font-size: calc(100% * pow(var(--font-ratio), 3));
 			}
 
 			.section.-b > &::before {

--- a/astro/src/components/Section.test.ts
+++ b/astro/src/components/Section.test.ts
@@ -1,0 +1,132 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import GithubSlugger from 'github-slugger';
+import { parse } from 'node-html-parser';
+import { describe, expect, test } from 'vitest';
+// @ts-ignore: ts(2307)
+import Section from './Section.astro';
+
+const container = await AstroContainer.create();
+
+test('base', async () => {
+	const result = await container.renderToString(Section, {
+		props: {
+			slugger: new GithubSlugger(),
+		},
+		slots: {
+			default: '<p>text</p>',
+			heading: '<span>heading</span>',
+		},
+	});
+
+	const root = parse(result);
+
+	const section = root.querySelector('section');
+	const h2 = root.querySelector('.hdg > h2');
+	const h3 = root.querySelector('.hdg > h3');
+	const h4 = root.querySelector('.hdg > h4');
+	const h5 = root.querySelector('.hdg > h5');
+	const selfLink = root.querySelector('.hdg > .self-link > a');
+
+	expect(section?.getAttribute('autofocus')).toBeUndefined();
+	expect(section?.getAttribute('tabindex')).toBeUndefined();
+	expect(section?.classList.contains('section')).toBeTruthy();
+	expect(section?.classList.contains('-a')).toBeTruthy();
+	expect(section?.classList.contains('-box')).toBeFalsy();
+	expect(section?.id).toBe('heading');
+	expect(h2?.innerHTML).toBe('<span>heading</span>');
+	expect(h3).toBeNull();
+	expect(h4).toBeNull();
+	expect(h5).toBeNull();
+	expect(selfLink?.getAttribute('href')).toBe('#heading');
+});
+
+test('id', async () => {
+	const result = await container.renderToString(Section, {
+		props: {
+			id: 'id',
+		},
+	});
+
+	const root = parse(result);
+
+	const section = root.querySelector('section');
+
+	expect(section?.id).toBe('id');
+});
+
+test('depth', async () => {
+	const result = await container.renderToString(Section, {
+		props: {
+			id: 'id',
+			depth: 2,
+		},
+	});
+
+	const root = parse(result);
+
+	const h = root.querySelector('.hdg > h3');
+
+	expect(h).not.toBeNull();
+});
+
+test('headingType', async () => {
+	const result = await container.renderToString(Section, {
+		props: {
+			id: 'id',
+			headingType: 'b',
+		},
+	});
+
+	const root = parse(result);
+
+	const section = root.querySelector('section');
+
+	expect(section?.classList.contains('-a')).toBeFalsy();
+	expect(section?.classList.contains('-b')).toBeTruthy();
+});
+
+test('box', async () => {
+	const result = await container.renderToString(Section, {
+		props: {
+			id: 'id',
+			box: true,
+		},
+	});
+
+	const root = parse(result);
+
+	const section = root.querySelector('section');
+
+	expect(section?.classList.contains('-box')).toBeTruthy();
+});
+
+test('autofocus', async () => {
+	const result = await container.renderToString(Section, {
+		props: {
+			id: 'id',
+			autofocus: true,
+		},
+	});
+
+	const root = parse(result);
+
+	const section = root.querySelector('section');
+
+	expect(section?.getAttribute('autofocus')).toBe('');
+	expect(section?.getAttribute('tabindex')).toBe('-1');
+});
+
+test('class', async () => {
+	const result = await container.renderToString(Section, {
+		props: {
+			id: 'id',
+			class: 'foo',
+		},
+	});
+
+	const root = parse(result);
+
+	const section = root.querySelector('section');
+
+	expect(section?.classList.contains('foo')).toBeTruthy();
+});

--- a/astro/src/components/Section.test.ts
+++ b/astro/src/components/Section.test.ts
@@ -72,22 +72,6 @@ test('depth', async () => {
 	expect(h).not.toBeNull();
 });
 
-test('headingType', async () => {
-	const result = await container.renderToString(Section, {
-		props: {
-			id: 'id',
-			headingType: 'b',
-		},
-	});
-
-	const root = parse(result);
-
-	const section = root.querySelector('section');
-
-	expect(section?.classList.contains('-a')).toBeFalsy();
-	expect(section?.classList.contains('-b')).toBeTruthy();
-});
-
 test('box', async () => {
 	const result = await container.renderToString(Section, {
 		props: {

--- a/astro/src/components/Section.test.ts
+++ b/astro/src/components/Section.test.ts
@@ -10,7 +10,7 @@ const container = await AstroContainer.create();
 test('base', async () => {
 	const result = await container.renderToString(Section, {
 		props: {
-			slugger: new GithubSlugger(),
+			id: new GithubSlugger(),
 		},
 		slots: {
 			default: '<p>text</p>',

--- a/astro/src/components/Section.test.ts
+++ b/astro/src/components/Section.test.ts
@@ -1,7 +1,7 @@
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import GithubSlugger from 'github-slugger';
 import { parse } from 'node-html-parser';
-import { describe, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 // @ts-ignore: ts(2307)
 import Section from './Section.astro';
 
@@ -64,8 +64,11 @@ test('depth', async () => {
 
 	const root = parse(result);
 
+	const section = root.querySelector('section');
 	const h = root.querySelector('.hdg > h3');
 
+	expect(section?.classList.contains('-a')).toBeFalsy();
+	expect(section?.classList.contains('-b')).toBeTruthy();
 	expect(h).not.toBeNull();
 });
 

--- a/astro/src/pages/admin/crawler-news/index.astro
+++ b/astro/src/pages/admin/crawler-news/index.astro
@@ -133,7 +133,7 @@ const reviseData = requestParamNewsId !== undefined ? await dao.getReviseData(re
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">データ登録</Fragment>
 
 		<form action={reviseData === undefined && updateActionResult === undefined ? actions.crawlernews.newsinsert : actions.crawlernews.newsupdate} method="post">
@@ -233,7 +233,7 @@ const reviseData = requestParamNewsId !== undefined ? await dao.getReviseData(re
 
 	{
 		[...newsPageList].map(([categoryName, newsPageOfCategory]) => (
-			<Section slugger={slugger}>
+			<Section id={slugger}>
 				<Fragment slot="heading">{categoryName}</Fragment>
 
 				<Table scroll={true}>

--- a/astro/src/pages/admin/crawler-resource/index.astro
+++ b/astro/src/pages/admin/crawler-resource/index.astro
@@ -132,7 +132,7 @@ const reviseData = requestParamUrl !== undefined ? await dao.getReviseData(reque
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">データ登録</Fragment>
 
 		<form action={reviseData === undefined && updateActionResult === undefined ? actions.crawlerresource.insert : actions.crawlerresource.update} method="post">
@@ -218,7 +218,7 @@ const reviseData = requestParamUrl !== undefined ? await dao.getReviseData(reque
 
 	{
 		[...resourcePageList].map(([categoryName, resourcePageOfCategory]) => (
-			<Section slugger={slugger}>
+			<Section id={slugger}>
 				<Fragment slot="heading">{categoryName}</Fragment>
 
 				<Table scroll={true}>

--- a/astro/src/pages/info.astro
+++ b/astro/src/pages/info.astro
@@ -158,7 +158,7 @@ const structuredData: StructuredData = {
 	<Section id="write">
 		<Fragment slot="heading">著書、寄稿</Fragment>
 
-		<Section id="write-tokyu" depth={2} headingType="b">
+		<Section id="write-tokyu" depth={2}>
 			<Fragment slot="heading">東急電車</Fragment>
 
 			<Grid column="wide">
@@ -196,7 +196,7 @@ const structuredData: StructuredData = {
 				</GridItem>
 			</Grid>
 		</Section>
-		<Section id="write-kumeta" depth={2} headingType="b">
+		<Section id="write-kumeta" depth={2}>
 			<Fragment slot="heading">久米田康治作品</Fragment>
 
 			<Grid column="wide">

--- a/astro/src/pages/kumeta/anime/zetsubou/diff.astro
+++ b/astro/src/pages/kumeta/anime/zetsubou/diff.astro
@@ -62,14 +62,14 @@ const structuredData: StructuredData = {
 	<Section id="1">
 		<Fragment slot="heading">第1期『<cite>さよなら絶望先生</cite>』</Fragment>
 
-		<Section id="1-1" depth={2} headingType="b">
+		<Section id="1-1" depth={2}>
 			<Fragment slot="heading">一話「<cite>さよなら絶望先生</cite>」</Fragment>
 
 			<ListNote>
 				<li><Anchor href="https://www.amazon.co.jp/dp/B000T6FGA4/">DVD 第一集</Anchor>には映像特典として「<cite>前田君オンエアver.</cite>」が収録されていますが、実際の放送時の映像とは異なり、パッケージ用に変更されたバージョンに対して前田君のハメコミ部分のみを再現したものとなります。</li>
 			</ListNote>
 
-			<Section id="1-1-avan" depth={3} headingType="c">
+			<Section id="1-1-avan" depth={3}>
 				<Fragment slot="heading">アバン</Fragment>
 
 				<VideoDiff>
@@ -79,13 +79,13 @@ const structuredData: StructuredData = {
 				</VideoDiff>
 			</Section>
 
-			<Section id="1-1-op" depth={3} headingType="c">
+			<Section id="1-1-op" depth={3}>
 				<Fragment slot="heading">オープニング</Fragment>
 
 				<p>変更点なし</p>
 			</Section>
 
-			<Section id="1-1-a" depth={3} headingType="c">
+			<Section id="1-1-a" depth={3}>
 				<Fragment slot="heading">A パート</Fragment>
 
 				<VideoDiff>
@@ -243,7 +243,7 @@ const structuredData: StructuredData = {
 				</VideoDiff>
 			</Section>
 
-			<Section id="1-1-b" depth={3} headingType="c">
+			<Section id="1-1-b" depth={3}>
 				<Fragment slot="heading">B パート</Fragment>
 
 				<VideoDiff>
@@ -544,7 +544,7 @@ const structuredData: StructuredData = {
 				</VideoDiff>
 			</Section>
 
-			<Section id="1-1-ed" depth={3} headingType="c">
+			<Section id="1-1-ed" depth={3}>
 				<Fragment slot="heading">エンディング</Fragment>
 
 				<VideoDiff>

--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -30,7 +30,7 @@ const slugger = new GithubSlugger();
 		<Fragment slot="nav">
 			<TopNavText heading="サイトコンテンツ">
 				<Fragment slot="main">
-					<Grid column="wide" headingType="b">
+					<Grid column="wide">
 						<GridItem>
 							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">漫画</Fragment>

--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -32,7 +32,7 @@ const slugger = new GithubSlugger();
 				<Fragment slot="main">
 					<Grid column="wide">
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">漫画</Fragment>
 
 								<ListLink index={true}>
@@ -46,7 +46,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">メディア紹介</Fragment>
 
 								<ListLink index={true}>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">アニメ</Fragment>
 
 								<ListLink index={true}>
@@ -70,7 +70,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">久米田先生</Fragment>
 
 								<ListLink index={true}>
@@ -83,7 +83,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">よもやま</Fragment>
 
 								<ListLink index={true}>
@@ -97,7 +97,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">最新ニュース</Fragment>
 
 								<KumetaTopService>

--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -32,7 +32,7 @@ const slugger = new GithubSlugger();
 				<Fragment slot="main">
 					<Grid column="wide" headingType="b">
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">漫画</Fragment>
 
 								<ListLink index={true}>
@@ -46,7 +46,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">メディア紹介</Fragment>
 
 								<ListLink index={true}>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">アニメ</Fragment>
 
 								<ListLink index={true}>
@@ -70,7 +70,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">久米田先生</Fragment>
 
 								<ListLink index={true}>
@@ -83,7 +83,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">よもやま</Fragment>
 
 								<ListLink index={true}>
@@ -97,7 +97,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">最新ニュース</Fragment>
 
 								<KumetaTopService>

--- a/astro/src/pages/kumeta/kumeta/interview.astro
+++ b/astro/src/pages/kumeta/kumeta/interview.astro
@@ -22,7 +22,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">書籍</Fragment>
 
 		<Table>
@@ -736,7 +736,7 @@ const slugger = new GithubSlugger();
 			</tbody>
 		</Table>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">Web</Fragment>
 
 		<Table>
@@ -809,7 +809,7 @@ const slugger = new GithubSlugger();
 			</tbody>
 		</Table>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">新聞</Fragment>
 
 		<Table>
@@ -837,7 +837,7 @@ const slugger = new GithubSlugger();
 			</tbody>
 		</Table>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">冊子</Fragment>
 
 		<Table>

--- a/astro/src/pages/kumeta/kumeta/media.astro
+++ b/astro/src/pages/kumeta/kumeta/media.astro
@@ -32,7 +32,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">ラジオ</Fragment>
 
 		<Table>
@@ -97,7 +97,7 @@ const slugger = new GithubSlugger();
 		<p>さて、『<cite>さよなら絶望放送</cite>』では久米田先生のゲスト出演は最後までありませんでしたが、最終回を目前にした<Anchor href="https://web.archive.org/web/20110811003749/http://www.animate.tv/radio/details.php?id=szbh#player">第200回</Anchor>では放送開始当初にカセットテープに録音していた（という体の）音声が公開され、生前葬のビデオメッセージなどでお馴染みの<q>みなさんがこのテープを聞いているということは……</q>の挨拶で笑いを誘いました。この時のメッセージはひじょうに短く、そのこと自体がツッコミ待ちの感があるものでしたが、<Anchor href="https://web.archive.org/web/20110902021239/http://www.animate.tv/radio/details.php?id=szbh#player">最終回</Anchor>ではその続きが流され、パーソナリティーへの絶望的な労いの言葉で長きにわたる番組を締めるものとなりました。</p>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">テレビ</Fragment>
 
 		<Table>

--- a/astro/src/pages/kumeta/kumeta/x.astro
+++ b/astro/src/pages/kumeta/kumeta/x.astro
@@ -52,7 +52,7 @@ const slugger = new GithubSlugger();
 		<li><Anchor href="https://x.com/3doO4OZ07IlQnOo">久米田先生の X アカウント</Anchor></li>
 	</ListLink>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">アイコン履歴<small>（新しい順）</small></Fragment>
 
 		<Grid column="narrow">

--- a/astro/src/pages/kumeta/kumeta/x.astro
+++ b/astro/src/pages/kumeta/kumeta/x.astro
@@ -55,154 +55,154 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<Fragment slot="heading">アイコン履歴<small>（新しい順）</small></Fragment>
 
-		<Grid column={102}>
+		<Grid column="narrow">
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1408410553228267521_TjA8u78P} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1408410553228267521_TjA8u78P} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2021年6月25日 〜</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1400351001018658816_qy5arqJH} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1400351001018658816_qy5arqJH} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2021年6月3日 〜 6月25日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1400348572097257473_e66MA7rG} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1400348572097257473_e66MA7rG} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2021年6月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1399911791325433857_v2gkYm9q} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1399911791325433857_v2gkYm9q} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2021年6月2日 〜 6月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1394152318157811713_oQ3JY4iy} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1394152318157811713_oQ3JY4iy} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2021年5月17日 〜 6月2日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1363740344886550529_QhDX9Hl1} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1363740344886550529_QhDX9Hl1} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2021年2月22日 〜 5月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1327851470780198913_Ye4TmCa} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1327851470780198913_Ye4TmCa} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年11月15日 〜 2021年2月22日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1287298632341848064_1VBcrVKq} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1287298632341848064_1VBcrVKq} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年7月26日 〜 11月15日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1284006685846233088_2ikV7Vsa} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1284006685846233088_2ikV7Vsa} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年7月17日 〜 7月26日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1264894156867948544_l3CY7neV} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1264894156867948544_l3CY7neV} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年5月25日 〜 7月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1245619057593700352_U1LMLxDn} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1245619057593700352_U1LMLxDn} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年4月2日 〜 5月25日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1240915754943262720_He1PQtk9} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1240915754943262720_He1PQtk9} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年3月20日 〜 4月2日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1223990059491160064_6d49eucZ} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1223990059491160064_6d49eucZ} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年2月3日 〜 3月20日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1222732605214183424_H79FeE20} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1222732605214183424_H79FeE20} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年1月30日 〜 2月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1222730357000138754_KmGpTlaZ} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1222730357000138754_KmGpTlaZ} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年1月30日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1219488655745548288_3SJhKPZ} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1219488655745548288_3SJhKPZ} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2020年1月21日 〜 1月30日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1201788717888704513_NGubWw_s} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1201788717888704513_NGubWw_s} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2019年12月3日 〜 2020年1月21日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1201784483592032256_6TRDw9cm} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1201784483592032256_6TRDw9cm} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2019年12月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1201778194950418432_WWx0YFb8} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1201778194950418432_WWx0YFb8} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2019年12月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1200300079791235074_8sEA4dWH} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1200300079791235074_8sEA4dWH} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2019年11月29日 〜 12月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1184690518933958656_5Qz57WpT} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1184690518933958656_5Qz57WpT} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2019年10月17日 〜 11月29日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1184672977167642624_JFdn0ynC} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1184672977167642624_JFdn0ynC} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2019年10月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1184653198239260672_GQN5feI} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1184653198239260672_GQN5feI} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2019年10月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1184428125045702656_ri24lRB9} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1184428125045702656_ri24lRB9} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">2019年10月16日 〜 10月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
 				<Embedded border={true}>
-					<MyImage image={image_profile_images_1180045807350763520_cN1I7jBs} alt="アイコン画像" width={100} height={100} link={true} slot="media" />
+					<MyImage image={image_profile_images_1180045807350763520_cN1I7jBs} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
 					<Fragment slot="caption">〜 2019年10月16日</Fragment>
 				</Embedded>
 			</GridItem>

--- a/astro/src/pages/kumeta/library/book.astro
+++ b/astro/src/pages/kumeta/library/book.astro
@@ -34,7 +34,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1993年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="鉄道ジャーナル 1993年3月号（No.317）" release="1993-01-21">
@@ -55,7 +55,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1994年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="『俺たちのフィールド』8巻" release="1994-01" amazonAsin="B00BEPF0YG" amazonImageId="71BPfxJFf3L" amazonImageWidth={104} amazonImageHeight={160}>
@@ -64,7 +64,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1996年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="モダンリビング 1996年11月号（No.109）" release="1996-10-07">
@@ -73,7 +73,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1997年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="熱筆!まんが学園!!　上巻" release="1997-06" amazonAsin="4091248616" amazonImageId="61iLXAoqPOL" amazonImageWidth={114} amazonImageHeight={160}>
@@ -85,7 +85,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1998年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="インモラル壱号" release="1998-04" amazonAsin="B08MTL3ZGN" amazonImageId="71b2wzVUNJL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -105,7 +105,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1999年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="制服大征服" release="1999" amazonAsin="B08MTDLJTG" amazonImageId="712xgOXp5gL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -119,7 +119,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2000年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="コミック・ファン 2000年8号" release="2000-03-15" tags={['インタビュー']}>
@@ -144,7 +144,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2001年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="『SALAD DAYS』13巻" release="2001-02" isbn="4-09-126093-4" amazonAsin="B009JZGP6A" amazonImageId="71NtTPlETyL" amazonImageWidth={99} amazonImageHeight={160}>
@@ -158,7 +158,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2002年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="『吼えろペン』4巻" release="2002-04" isbn="4-09-157024-0" amazonAsin="B00BEPFQHW" amazonImageId="816za-Yj5TL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -173,7 +173,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2003年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="ガンダムグッズエース（ガンダムエース2003年9月号増刊）" release="2003-07-15" tags={['インタビュー']} amazonAsin="B00X65OCO6" amazonImageId="21nkU7WtY+L" amazonImageWidth={119} amazonImageHeight={160}>
@@ -204,7 +204,7 @@ const slugger = new GithubSlugger();
 			<p>『<cite>かってに改蔵</cite>』公式ファンブック</p>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2004年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="サイゾー 2004年3月号" release="2004-02-18">
@@ -227,7 +227,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2005年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="空想科学「漫画」読本 4" release="2005-03" isbn="4-537-25266-9" amazonAsin="4537252669" amazonImageId="51CEW7KBXFL" amazonImageWidth={108} amazonImageHeight={160}>
@@ -249,7 +249,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2006年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="『ハヤテのごとく!』5巻" release="2006-01-14" tags={['畑健二郎']} isbn="4-09-120030-3" amazonAsin="B010F9NK2K" amazonImageId="51asAezAGcL" amazonImageWidth={102} amazonImageHeight={160}>
@@ -306,7 +306,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2007年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="季刊エス 18号（2007年春号）" release="2007-03-15" tags={['インタビュー']} amazonAsin="B000NQRURM" amazonImageId="61AGdzNgJiL" amazonImageWidth={117} amazonImageHeight={160}>
@@ -532,7 +532,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2008年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="マンガ・エロティクス・エフ Vol.49" release="2008-01-09" tags={['描き下ろし']} isbn="978-4-7783-2052-2" amazonAsin="4778320522" amazonImageId="51Lc-T6DdEL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -880,7 +880,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2009年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="『もう、しませんから。』8巻" release="2009-03-17" isbn="978-4-06-384116-9" amazonAsin="B00LIN3UTQ" amazonImageId="510zWwPwDrL" amazonImageWidth={107} amazonImageHeight={160}>
@@ -1165,7 +1165,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2010年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="プリンスアニメージュ 2010年winter" release="2010-02-02" tags={['アニメ']} isbn="978-4-19-720293-5" amazonAsin="4197202938" amazonImageId="61L5V29tIqL" amazonImageWidth={127} amazonImageHeight={160}>
@@ -1262,7 +1262,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2011年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="明日の夜は千の眼を持つ" release="2011-01-29" isbn="978-4-04-726941-5" amazonAsin="4047269417" amazonImageId="61HPckgvbuL" amazonImageWidth={108} amazonImageHeight={160}>
@@ -1417,7 +1417,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2012年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="女性自身 2012年2月14日号" release="2012">
@@ -1579,7 +1579,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2013年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="アニメスタイル 003（2013.03）" release="2013-03-27" tags={['アニメ']} isbn="978-4-89610-543-8" amazonAsin="4896105435" amazonImageId="51mamzDin2L" amazonImageWidth={114} amazonImageHeight={160}>
@@ -1680,7 +1680,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2014年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="りぽぐら!" release="2014-01-06" tags={['描き下ろし']} isbn="978-4-06-182897-1" amazonAsin="4061828975" amazonImageId="51gDfTzdCbL" amazonImageWidth={98} amazonImageHeight={160}>
@@ -1744,7 +1744,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2015年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="少年サンデー '90セレクション　前期" release="2015-04-24" tags={['インタビュー']} isbn="978-4-09-119762-7" amazonAsin="4091197620" amazonImageId="61daM9GirgL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -1857,7 +1857,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2016年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="人気マンガ・アニメのトラウマ最終回100　極限編" release="2016-02-25" isbn="978-4-86537-052-2" amazonAsin="4865370528" amazonImageId="91iEj5qALwL" amazonImageWidth={112} amazonImageHeight={160}>
@@ -1945,7 +1945,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2017年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="人気マンガ・アニメのトラウマ最終回100　総集編" release="2017-01" isbn="978-4-86537-070-6" amazonAsin="4865370706" amazonImageId="71NRy9r0A+L" amazonImageWidth={113} amazonImageHeight={160}>
@@ -2008,7 +2008,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2018年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="佐倉綾音写真集「さくらのおと」" release="2018-01-29" tags={['描き下ろし']} isbn="978-4-06-511169-7" amazonAsin="4065111692" amazonImageId="41ke-WT5XDL" amazonImageWidth={120} amazonImageHeight={160}>
@@ -2019,7 +2019,7 @@ const slugger = new GithubSlugger();
 			<p>装画を担当</p>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2019年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="新房昭之×シャフト　クロニクル" release="2019-11-23" tags={['インタビュー']} isbn="978-4-8354-5701-7" amazonAsin="4835457013" amazonImageId="510waYsj0oL" amazonImageWidth={119} amazonImageHeight={160}>
@@ -2028,7 +2028,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2020年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="月刊ニュータイプ 2020年4月号" release="2020-03-10" tags={['アニメ', '版権イラスト']} amazonAsin="B084Z4K32C" amazonImageId="61l7I7Gbr7L" amazonImageWidth={127} amazonImageHeight={160}>
@@ -2104,7 +2104,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2021年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="Manga Day To Day(下)" release="2021-03-25" tags={['描き下ろし']} isbn="978-4-06-522020-7" amazonAsin="B08Z3K8RD1" amazonImageId="51IAR1045vL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -2173,7 +2173,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2022年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="人気マンガ・アニメのトラウマ最終回　総集編" release="2022-01-14" isbn="978-4-86537-229-8" amazonAsin="4865372296" amazonImageId="81brfnqPUaL" amazonImageWidth={111} amazonImageHeight={160}>
@@ -2214,7 +2214,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2023年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="私は元気です　病める時も健やかなる時も腐る時もイキる時も泣いた時も病める時も。" release="2023-09-12" tags={['アニメ', '音楽']} isbn="978-4-16-391738-2" amazonAsin="B0CHDWNGK6" amazonImageId="81JoxecsP0L" amazonImageWidth={111} amazonImageHeight={160}>
@@ -2245,7 +2245,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2024年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="うる星やつら公式ファンブック Dancing Star" release="2024-12-18" isbn="978-4-09-179466-6" amazonAsin="B0CXNBX7WQ" amazonImageId="717xipB+joL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -2254,7 +2254,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2025年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="アニメージュ 2025年10月号" release="2025-09-10" tags={['アニメ']} amazonAsin="B0FM4KLCDY" amazonImageId="81sx1WFZVqL" amazonImageWidth={127} amazonImageHeight={160}>
@@ -2269,7 +2269,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2026年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="『シルバーマウンテン』3巻" release="2026-02-18" isbn="978-4-09-854453-0" amazonAsin="B0GJS1L7BJ" amazonImageId="81U-7PedNIL" amazonImageWidth={102} amazonImageHeight={160}>
@@ -2287,7 +2287,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">調査中</Fragment>
 
 		<List>

--- a/astro/src/pages/kumeta/library/freepaper.astro
+++ b/astro/src/pages/kumeta/library/freepaper.astro
@@ -33,7 +33,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2003年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="きゃらびぃ Vol.70" distribution="2003-12-01">
@@ -49,7 +49,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2007年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="A-STATION 2007年8月号" distribution="2007-07-30" tags={['アニメ']}>
@@ -91,7 +91,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2008年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="スタチャマニア？！ Vol.17 夏号" distribution="2008-08-15" tags={['アニメ']}>
@@ -107,7 +107,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2009年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="スタチャマニア？！ Vol.21 夏号" distribution="2009-08-14" tags={['アニメ']}>
@@ -132,7 +132,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2011年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="スタチャマニア？！ 2011 Spring Vol.28" distribution="2011" tags={['アニメ']}>
@@ -143,7 +143,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2012年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="きゃらびぃTV Vol.8" distribution="2012-06-10" tags={['アニメ']}>
@@ -181,7 +181,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2017年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="きゃらびぃ Vol.392" distribution="2017-05-05" tags={['描き下ろし']}>
@@ -191,7 +191,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2020年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="きゃらびぃ Vol.457" distribution="2020-01-20" tags={['アニメ']}>
@@ -201,7 +201,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2022年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="異質力奇譚" distribution="2020-03" tags={['描き下ろし']}>
@@ -215,7 +215,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2023年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="WAKO UNIVERSITY 2024" distribution="2023-05" tags={['描き下ろし', 'インタビュー']}>
@@ -232,7 +232,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2024年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="GCLマガジン（ゲームクリエイターズラボマガジン）" distribution="2024-09-26" tags={['描き下ろし', 'インタビュー']}>

--- a/astro/src/pages/kumeta/library/manga.astro
+++ b/astro/src/pages/kumeta/library/manga.astro
@@ -34,7 +34,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1979年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年キング 1979年6月4日号" release="1979-05-04">
@@ -49,7 +49,7 @@ const slugger = new GithubSlugger();
 		</LibBook>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1988年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1988年30号" release="1988-06-22">
@@ -76,7 +76,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1989年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1989年25号" release="1989-05-24">
@@ -91,7 +91,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1990年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1990年49号" release="1990-11-07">
@@ -129,7 +129,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1991年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1991年10号" release="1991-02-13" tags={['表紙']}>
@@ -184,7 +184,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1992年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1992年7号" release="1992-01-22" tags={['表紙', 'カラー']}>
@@ -244,7 +244,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1993年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1993年13号" release="1993-03-03" tags={['カラー']}>
@@ -342,7 +342,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1994年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1994年12号" release="1994-02-23" tags={['表紙', 'カラー']}>
@@ -422,7 +422,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1995年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1995年5・6号" release="1995-01-05" tags={['年賀状']}>
@@ -496,7 +496,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1996年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1996年5・6号" release="1996-01-05" tags={['年賀状']}>
@@ -567,7 +567,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1997年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1997年5・6号" release="1997-01-04" tags={['年賀状']}>
@@ -606,7 +606,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1998年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1998年21・22号" release="1998-04-22" tags={['表紙']}>
@@ -647,7 +647,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">1999年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 1999年7号" release="1999-01-13" tags={['企画']}>
@@ -699,7 +699,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2000年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2000年6号" release="2000-01-04" tags={['表紙']}>
@@ -778,7 +778,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2001年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2001年16号" release="2001-03">
@@ -812,7 +812,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2002年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2002年19号" release="2002-04-10" tags={['表紙']}>
@@ -875,7 +875,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2003年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2003年9号" release="2003-01">
@@ -965,7 +965,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2004年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2004年16号" release="2004-03" tags={['表紙']}>
@@ -1029,7 +1029,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2005年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年マガジン 2005年21号" release="2005-04-20">
@@ -1095,7 +1095,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2006年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年マガジン 2006年25号" release="2006-05-24" tags={['表紙', 'カラー']}>
@@ -1118,7 +1118,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2007年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2007年6号" release="2007-01-10" tags={['畑健二郎']}>
@@ -1247,7 +1247,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2008年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年マガジン 2008年6号" release="2008-01-09" tags={['カラー', 'アニメ']}>
@@ -1343,7 +1343,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2009年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="マガジンドラゴン 2009年新春" release="2009-01-07" tags={['表紙', '読切', '企画']} amazonAsin="B001O5OGU0" amazonImageId="61xfpxd0SjL" amazonImageWidth={110} amazonImageHeight={160}>
@@ -1438,7 +1438,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2010年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="別冊少年マガジン 2010年2月号" release="2010-01" tags={['表紙', 'カラー']} amazonAsin="B00315IMGA" amazonImageId="61QerU2yvqL" amazonImageWidth={110} amazonImageHeight={160}>
@@ -1519,7 +1519,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2011年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="別冊少年マガジン 2011年2月号" release="2011-01-08" tags={['表紙']} amazonAsin="B004GI13FS" amazonImageId="6120TLYNhPL" amazonImageWidth={111} amazonImageHeight={160}>
@@ -1595,7 +1595,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2012年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="別冊少年マガジン 2012年2月号" release="2012-01-07" tags={['表紙']} amazonAsin="B006MI8JQQ" amazonImageId="61FnrnVD7-L" amazonImageWidth={112} amazonImageHeight={160}>
@@ -1688,7 +1688,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2013年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="別冊少年マガジン 2013年3月号" release="2013-02" tags={['表紙']}>
@@ -1770,7 +1770,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2014年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="マガジン SPECIAL 2014年2号" release="2014-01-20">
@@ -1889,7 +1889,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2015年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="ヤングマガジン 2015年6号" release="2015-01-05" tags={['表紙', '読切']} amazonAsin="B00R3BMQKQ" amazonImageId="61K6W2O9nYL" amazonImageWidth={110} amazonImageHeight={160}>
@@ -1957,7 +1957,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2016年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="月刊少年マガジン 2016年2月号" release="2016-01-06" tags={['表紙']} amazonAsin="B019W1P54I" amazonImageId="61zCxNqAjML" amazonImageWidth={111} amazonImageHeight={160}>
@@ -2113,7 +2113,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2017年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="ヤングマガジンサード 2017年 Vol.4" release="2017-03-06" tags={['表紙']} amazonAsin="B06XCLXR8V" amazonImageId="61INdouKcWL" amazonImageWidth={111} amazonImageHeight={160}>
@@ -2154,7 +2154,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2018年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="月刊少年マガジン 2018年3月号" release="2018-02-06">
@@ -2216,7 +2216,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2019年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="ヤングマガジンサード 2019年 Vol.4" release="2019-03-06">
@@ -2265,7 +2265,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2020年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="楽園 Le Paradis 32号" release="2020-02-29">
@@ -2310,7 +2310,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2021年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2021年9号" release="2021-01-27" tags={['畑健二郎']}>
@@ -2404,7 +2404,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2022年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2022年16号" release="2022-03-16" tags={['表紙']}>
@@ -2437,7 +2437,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2023年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2023年16号" release="2023-03-15" tags={['表紙']}>
@@ -2484,7 +2484,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2024年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2024年7号" release="2024-01-10" tags={['企画']}>
@@ -2586,7 +2586,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2025年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="ゲッサン 2025年2月号　別冊付録「あだち充画業55周年記念!」" release="2025-01-10" tags={['描き下ろし']}>
@@ -2645,7 +2645,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2026年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="週刊少年サンデー 2026年9号" release="2026-01-28">
@@ -2694,7 +2694,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">調査中</Fragment>
 
 		<List>

--- a/astro/src/pages/kumeta/library/newspaper.astro
+++ b/astro/src/pages/kumeta/library/newspaper.astro
@@ -34,7 +34,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2002年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="読売新聞" release="2002-03-23" npClass="夕刊">
@@ -44,7 +44,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2006年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="朝日新聞" release="2006-04-16" npClass="朝刊">
@@ -54,7 +54,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2007年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="読売新聞" release="2007-01-31" npClass="夕刊">
@@ -110,7 +110,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2008年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="アニカン" release="2008-01-02" npClass="Vol.49 2008年新年号" tags={['アニメ']}>
@@ -151,7 +151,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2009年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="東京新聞" release="2009-01-01" npClass="朝刊">
@@ -185,7 +185,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2010年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="アニカンR" release="2010-04-28" npClass="Vol.43" tags={['ラジオ']}>
@@ -217,7 +217,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2011年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="アニカンR" release="2011-06-01" npClass="Vol.129" tags={['アニメ']}>
@@ -237,7 +237,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2012年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="朝日新聞" release="2012-01-26" npClass="夕刊">
@@ -259,7 +259,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2015年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="読売新聞" release="2015-07-27" npClass="夕刊">
@@ -286,7 +286,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2017年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="読売新聞（熊本版）" release="2017-09-08" npClass="朝刊">
@@ -302,7 +302,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2020年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="読売新聞" release="2020-04-19" npClass="夕刊" tags={['インタビュー']}>
@@ -330,7 +330,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2021年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="読売新聞" release="2021-03-21" tags={['音楽']}>
@@ -380,7 +380,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2023年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="日本経済新聞" release="2023-03-28" npClass="夕刊">
@@ -390,7 +390,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2024年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="朝日新聞" release="2024-04-30" npClass="朝刊">
@@ -515,7 +515,7 @@ const slugger = new GithubSlugger();
 		</LibNewspaper>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">調査中</Fragment>
 
 		<List>

--- a/astro/src/pages/kumeta/library/web.astro
+++ b/astro/src/pages/kumeta/library/web.astro
@@ -344,7 +344,7 @@ const slugger = new GithubSlugger();
 			</tbody>
 		</Table>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">生前葬</Fragment>
 
 			<Table>
@@ -371,10 +371,10 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">『<cite>劇場編集版 かくしごと ―ひめごとはなんですか―</cite>』舞台挨拶</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">2021年7月10日　祝！公開記念舞台挨拶<small>（久米田康治&amp;村野裕太）</small></Fragment>
 
 				<ListLink>
@@ -386,7 +386,7 @@ const slugger = new GithubSlugger();
 				</ListLink>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">2021年7月11日　Girlsday<small>（久米田康治、村野佑太、高橋李依、安野希世乃、小澤亜李、本渡楓、和氣あず未）</small></Fragment>
 
 				<ListLink>
@@ -408,7 +408,7 @@ const slugger = new GithubSlugger();
 				</ListLink>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">2021年7月17日　「G-PRO」day<small>（久米田康治、村野佑太、神谷浩史、八代拓、安野希世乃、佐倉綾音）</small></Fragment>
 
 				<ListLink>

--- a/astro/src/pages/kumeta/library/web.astro
+++ b/astro/src/pages/kumeta/library/web.astro
@@ -30,7 +30,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">インタビュー&amp;コメント</Fragment>
 
 		<Table>
@@ -286,7 +286,7 @@ const slugger = new GithubSlugger();
 		</Table>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">イベントレポート</Fragment>
 
 		<Table>
@@ -344,7 +344,7 @@ const slugger = new GithubSlugger();
 			</tbody>
 		</Table>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">生前葬</Fragment>
 
 			<Table>
@@ -371,10 +371,10 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">『<cite>劇場編集版 かくしごと ―ひめごとはなんですか―</cite>』舞台挨拶</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">2021年7月10日　祝！公開記念舞台挨拶<small>（久米田康治&amp;村野裕太）</small></Fragment>
 
 				<ListLink>
@@ -386,7 +386,7 @@ const slugger = new GithubSlugger();
 				</ListLink>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">2021年7月11日　Girlsday<small>（久米田康治、村野佑太、高橋李依、安野希世乃、小澤亜李、本渡楓、和氣あず未）</small></Fragment>
 
 				<ListLink>
@@ -408,7 +408,7 @@ const slugger = new GithubSlugger();
 				</ListLink>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">2021年7月17日　「G-PRO」day<small>（久米田康治、村野佑太、神谷浩史、八代拓、安野希世乃、佐倉綾音）</small></Fragment>
 
 				<ListLink>
@@ -434,7 +434,7 @@ const slugger = new GithubSlugger();
 		</Section>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">その他</Fragment>
 
 		<Table>

--- a/astro/src/pages/kumeta/manga/comment.astro
+++ b/astro/src/pages/kumeta/manga/comment.astro
@@ -23,13 +23,13 @@ const slugger = new GithubSlugger();
 
 		<p>すべて「<cite>週刊少年サンデー</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1991年</Fragment>
 
 			<p>巻末コメントなし。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1992年</Fragment>
 
 			<Table>
@@ -285,7 +285,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1993年</Fragment>
 
 			<Table>
@@ -541,7 +541,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1994年</Fragment>
 
 			<Table>
@@ -846,7 +846,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1995年</Fragment>
 
 			<Table>
@@ -1151,7 +1151,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1996年</Fragment>
 
 			<Table>
@@ -1366,7 +1366,7 @@ const slugger = new GithubSlugger();
 
 		<p>連載中断前（1994年〜1996年）は「<cite>週刊少年サンデー増刊号</cite>」「<cite>週刊少年サンデー超</cite>」掲載ですがコメント欄なしのため、「<cite>週刊少年サンデー</cite>」にて連載再開した後の2回分のみ記載します。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2002年</Fragment>
 
 			<Table>
@@ -1401,7 +1401,7 @@ const slugger = new GithubSlugger();
 
 		<p>すべて「<cite>週刊少年サンデー</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1996年</Fragment>
 
 			<Table>
@@ -1502,7 +1502,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1997年</Fragment>
 
 			<Table>
@@ -1699,7 +1699,7 @@ const slugger = new GithubSlugger();
 
 		<p>特記のないものは「<cite>週刊少年サンデー</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1998年</Fragment>
 
 			<Table>
@@ -1898,7 +1898,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1999年</Fragment>
 
 			<Table>
@@ -2203,7 +2203,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2000年</Fragment>
 
 			<Table>
@@ -2518,7 +2518,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2001年</Fragment>
 
 			<Table>
@@ -2825,7 +2825,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2002年</Fragment>
 
 			<Table>
@@ -3124,7 +3124,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2003年</Fragment>
 
 			<Table>
@@ -3429,7 +3429,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2004年</Fragment>
 
 			<Table>
@@ -3632,7 +3632,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2011年</Fragment>
 
 			<Table>
@@ -3653,7 +3653,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2018年</Fragment>
 
 			<Table>
@@ -3682,7 +3682,7 @@ const slugger = new GithubSlugger();
 
 		<p>特記のないものは「<cite>週刊少年マガジン</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2005年</Fragment>
 
 			<Table>
@@ -3848,7 +3848,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2006年</Fragment>
 
 			<Table>
@@ -4104,7 +4104,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2007年</Fragment>
 
 			<Table>
@@ -4360,7 +4360,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2008年</Fragment>
 
 			<Table>
@@ -4621,7 +4621,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2009年</Fragment>
 
 			<Table>
@@ -4884,7 +4884,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年</Fragment>
 
 			<Table>
@@ -5140,7 +5140,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2011年</Fragment>
 
 			<Table>
@@ -5401,7 +5401,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2012年</Fragment>
 
 			<Table>
@@ -5831,7 +5831,7 @@ const slugger = new GithubSlugger();
 
 		<p>特記のないものは「<cite>週刊少年マガジン</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年</Fragment>
 
 			<Table>
@@ -5867,7 +5867,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2014年</Fragment>
 
 			<Table>
@@ -6128,7 +6128,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2015年</Fragment>
 
 			<Table>
@@ -6837,7 +6837,7 @@ const slugger = new GithubSlugger();
 
 		<p>すべて「<cite>週刊少年サンデー</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2021年</Fragment>
 
 			<Table>
@@ -6884,7 +6884,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2022年</Fragment>
 
 			<p>調査中</p>

--- a/astro/src/pages/kumeta/manga/comment.astro
+++ b/astro/src/pages/kumeta/manga/comment.astro
@@ -23,13 +23,13 @@ const slugger = new GithubSlugger();
 
 		<p>すべて「<cite>週刊少年サンデー</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1991年</Fragment>
 
 			<p>巻末コメントなし。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1992年</Fragment>
 
 			<Table>
@@ -285,7 +285,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1993年</Fragment>
 
 			<Table>
@@ -541,7 +541,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1994年</Fragment>
 
 			<Table>
@@ -846,7 +846,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1995年</Fragment>
 
 			<Table>
@@ -1151,7 +1151,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1996年</Fragment>
 
 			<Table>
@@ -1366,7 +1366,7 @@ const slugger = new GithubSlugger();
 
 		<p>連載中断前（1994年〜1996年）は「<cite>週刊少年サンデー増刊号</cite>」「<cite>週刊少年サンデー超</cite>」掲載ですがコメント欄なしのため、「<cite>週刊少年サンデー</cite>」にて連載再開した後の2回分のみ記載します。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2002年</Fragment>
 
 			<Table>
@@ -1401,7 +1401,7 @@ const slugger = new GithubSlugger();
 
 		<p>すべて「<cite>週刊少年サンデー</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1996年</Fragment>
 
 			<Table>
@@ -1502,7 +1502,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1997年</Fragment>
 
 			<Table>
@@ -1699,7 +1699,7 @@ const slugger = new GithubSlugger();
 
 		<p>特記のないものは「<cite>週刊少年サンデー</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1998年</Fragment>
 
 			<Table>
@@ -1898,7 +1898,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1999年</Fragment>
 
 			<Table>
@@ -2203,7 +2203,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2000年</Fragment>
 
 			<Table>
@@ -2518,7 +2518,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2001年</Fragment>
 
 			<Table>
@@ -2825,7 +2825,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2002年</Fragment>
 
 			<Table>
@@ -3124,7 +3124,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2003年</Fragment>
 
 			<Table>
@@ -3429,7 +3429,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2004年</Fragment>
 
 			<Table>
@@ -3632,7 +3632,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2011年</Fragment>
 
 			<Table>
@@ -3653,7 +3653,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2018年</Fragment>
 
 			<Table>
@@ -3682,7 +3682,7 @@ const slugger = new GithubSlugger();
 
 		<p>特記のないものは「<cite>週刊少年マガジン</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2005年</Fragment>
 
 			<Table>
@@ -3848,7 +3848,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2006年</Fragment>
 
 			<Table>
@@ -4104,7 +4104,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2007年</Fragment>
 
 			<Table>
@@ -4360,7 +4360,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2008年</Fragment>
 
 			<Table>
@@ -4621,7 +4621,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2009年</Fragment>
 
 			<Table>
@@ -4884,7 +4884,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年</Fragment>
 
 			<Table>
@@ -5140,7 +5140,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2011年</Fragment>
 
 			<Table>
@@ -5401,7 +5401,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2012年</Fragment>
 
 			<Table>
@@ -5831,7 +5831,7 @@ const slugger = new GithubSlugger();
 
 		<p>特記のないものは「<cite>週刊少年マガジン</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年</Fragment>
 
 			<Table>
@@ -5867,7 +5867,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2014年</Fragment>
 
 			<Table>
@@ -6128,7 +6128,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2015年</Fragment>
 
 			<Table>
@@ -6837,7 +6837,7 @@ const slugger = new GithubSlugger();
 
 		<p>すべて「<cite>週刊少年サンデー</cite>」掲載。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2021年</Fragment>
 
 			<Table>
@@ -6884,7 +6884,7 @@ const slugger = new GithubSlugger();
 			</Table>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2022年</Fragment>
 
 			<p>調査中</p>

--- a/astro/src/pages/kumeta/manga/convenience.astro
+++ b/astro/src/pages/kumeta/manga/convenience.astro
@@ -78,7 +78,7 @@ const structuredData: StructuredData = {
 			<AmazonItem asin="409162779X" title="Vol.5" imageId="91rXhSbdonL" imageWidth={120} imageHeight={160} />
 		</Amazon>
 
-		<Section id="kaizo1" depth={2} headingType="b">
+		<Section id="kaizo1" depth={2}>
 			<Fragment slot="heading">第1巻　虎馬改造人間</Fragment>
 
 			<p><Date value="2011-11-16" />発行</p>
@@ -121,7 +121,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="kaizo2" depth={2} headingType="b">
+		<Section id="kaizo2" depth={2}>
 			<Fragment slot="heading">第2巻　地丹という男</Fragment>
 
 			<p><Date value="2011-12-18" />発行</p>
@@ -169,7 +169,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="kaizo3" depth={2} headingType="b">
+		<Section id="kaizo3" depth={2}>
 			<Fragment slot="heading">第3巻　羽美の場合</Fragment>
 
 			<p><Date value="2012-01-18" />発行</p>
@@ -231,7 +231,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="kaizo4" depth={2} headingType="b">
+		<Section id="kaizo4" depth={2}>
 			<Fragment slot="heading">第4巻　彩園すず（博士?）</Fragment>
 
 			<p><Date value="2012-02-18" />発行</p>
@@ -279,7 +279,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="kaizo5" depth={2} headingType="b">
+		<Section id="kaizo5" depth={2}>
 			<Fragment slot="heading">第5巻　幸せって何だっけ!?</Fragment>
 
 			<p><Date value="2012-03-18" />発行</p>
@@ -337,7 +337,7 @@ const structuredData: StructuredData = {
 			<AmazonItem asin="4091077110" title="Vol.4" imageId="A1oZ07bQXAL" imageWidth={111} imageHeight={160} />
 		</Amazon>
 
-		<Section id="kumeta1" depth={2} headingType="b">
+		<Section id="kumeta1" depth={2}>
 			<Fragment slot="heading">第1巻　夢の共演実現!!</Fragment>
 
 			<p><Date value="2012-04-18" />発行</p>
@@ -376,7 +376,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="kumeta2" depth={2} headingType="b">
+		<Section id="kumeta2" depth={2}>
 			<Fragment slot="heading">第2巻　改蔵は忘れた頃にやってくる!!</Fragment>
 
 			<p><Date value="2012-05-18" />発行</p>
@@ -409,7 +409,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="kumeta3" depth={2} headingType="b">
+		<Section id="kumeta3" depth={2}>
 			<Fragment slot="heading">第3巻　改蔵の夏</Fragment>
 
 			<p><Date value="2012-06-18" />発行</p>
@@ -441,7 +441,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="kumeta4" depth={2} headingType="b">
+		<Section id="kumeta4" depth={2}>
 			<Fragment slot="heading">第4巻　夏なのにお別れですか?</Fragment>
 
 			<p><Date value="2012-07-18" />発行</p>
@@ -484,7 +484,7 @@ const structuredData: StructuredData = {
 			<AmazonItem asin="4091198457" title="後期" imageId="81BKHaHMc0L" imageWidth={110} imageHeight={160} />
 		</Amazon>
 
-		<Section id="sunday-90selection90-1" depth={2} headingType="b">
+		<Section id="sunday-90selection90-1" depth={2}>
 			<Fragment slot="heading">前期</Fragment>
 
 			<p><Date value="2015-04-29" />発行</p>
@@ -503,7 +503,7 @@ const structuredData: StructuredData = {
 				<li>『<cite>名探偵コナン</cite>』セクション</li>
 			</List>
 		</Section>
-		<Section id="sunday-90selection90-2" depth={2} headingType="b">
+		<Section id="sunday-90selection90-2" depth={2}>
 			<Fragment slot="heading">後期</Fragment>
 
 			<p><Date value="2015-08-05" />発行</p>

--- a/astro/src/pages/kumeta/manga/list.astro
+++ b/astro/src/pages/kumeta/manga/list.astro
@@ -134,10 +134,10 @@ const structuredData: StructuredData = {
 			<li>連載開始日は予告編を含まず、読み切り掲載分を含みます。</li>
 		</ListNote>
 
-		<Section id="rensai-special" depth={2} headingType="b">
+		<Section id="rensai-special" depth={2}>
 			<Fragment slot="heading">連載作品の特別編、予告など</Fragment>
 
-			<Section id="rensai-special-nangoku" depth={3} headingType="c">
+			<Section id="rensai-special-nangoku" depth={3}>
 				<Fragment slot="heading"><cite>行け!!南国アイスホッケー部</cite></Fragment>
 
 				<Table>
@@ -169,7 +169,7 @@ const structuredData: StructuredData = {
 				</Table>
 			</Section>
 
-			<Section id="rensai-special-kaizo" depth={3} headingType="c">
+			<Section id="rensai-special-kaizo" depth={3}>
 				<Fragment slot="heading"><cite>かってに改蔵</cite></Fragment>
 
 				<Table>
@@ -242,7 +242,7 @@ const structuredData: StructuredData = {
 				</Table>
 			</Section>
 
-			<Section id="rensai-special-zetsubou" depth={3} headingType="c">
+			<Section id="rensai-special-zetsubou" depth={3}>
 				<Fragment slot="heading"><cite>さよなら絶望先生</cite></Fragment>
 
 				<Table>
@@ -352,7 +352,7 @@ const structuredData: StructuredData = {
 				</Table>
 			</Section>
 
-			<Section id="rensai-special-jyoshiraku" depth={3} headingType="c">
+			<Section id="rensai-special-jyoshiraku" depth={3}>
 				<Fragment slot="heading"><cite>じょしらく</cite></Fragment>
 
 				<Table>
@@ -413,7 +413,7 @@ const structuredData: StructuredData = {
 				</Table>
 			</Section>
 
-			<Section id="rensai-special-sekadoro" depth={3} headingType="c">
+			<Section id="rensai-special-sekadoro" depth={3}>
 				<Fragment slot="heading"><cite>せっかち伯爵と時間どろぼう</cite></Fragment>
 
 				<Table>
@@ -463,7 +463,7 @@ const structuredData: StructuredData = {
 				</Table>
 			</Section>
 
-			<Section id="rensai-special-kakushigoto" depth={3} headingType="c">
+			<Section id="rensai-special-kakushigoto" depth={3}>
 				<Fragment slot="heading"><cite>かくしごと</cite></Fragment>
 
 				<Table>
@@ -538,7 +538,7 @@ const structuredData: StructuredData = {
 				</Table>
 			</Section>
 
-			<Section id="rensai-special-shibuya" depth={3} headingType="c">
+			<Section id="rensai-special-shibuya" depth={3}>
 				<Fragment slot="heading"><cite>シブヤニアファミリー</cite></Fragment>
 
 				<Table>

--- a/astro/src/pages/kumeta/yomoyama/kuigaten.astro
+++ b/astro/src/pages/kumeta/yomoyama/kuigaten.astro
@@ -28,7 +28,7 @@ const slugger = new GithubSlugger();
 		<AmazonItem asin="406364992X" title="久米田康治画集　悔画展" imageId="51m9Oqxw9kL" imageWidth={112} imageHeight={160} />
 	</Amazon>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">収録イラスト一覧</Fragment>
 
 		<Table>
@@ -1054,7 +1054,7 @@ const slugger = new GithubSlugger();
 		<NoteRefContent id="youngsunday1996-07">悔画展ではなぜが初出年が抜けている。</NoteRefContent>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">主な非収録イラスト</Fragment>
 
 		<ListNote>

--- a/astro/src/pages/kumeta/yomoyama/pulp_daidanen.astro
+++ b/astro/src/pages/kumeta/yomoyama/pulp_daidanen.astro
@@ -20,7 +20,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">大団円イラスト</Fragment>
 
 		<Toggle>
@@ -32,10 +32,10 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Toggle>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">登場キャラクター一覧</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading"><cite>行け!!南国アイスホッケー部</cite></Fragment>
 
 			<List>
@@ -50,7 +50,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading"><cite>育ってダーリン!!</cite></Fragment>
 
 			<List>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading"><cite>太陽の戦士ポカポカ</cite></Fragment>
 
 			<List>
@@ -69,7 +69,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading"><cite>かってに改蔵</cite></Fragment>
 
 			<List>
@@ -106,7 +106,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading"><cite>さよなら絶望先生</cite></Fragment>
 
 			<List>
@@ -152,7 +152,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading"><cite>せっかち伯爵と時間どろぼう</cite></Fragment>
 
 			<List>
@@ -167,7 +167,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading"><cite>スタジオパルプ</cite></Fragment>
 
 			<List>
@@ -177,7 +177,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading"><cite>かくしごと</cite></Fragment>
 
 			<List>

--- a/astro/src/pages/kumeta/yomoyama/pulp_daidanen.astro
+++ b/astro/src/pages/kumeta/yomoyama/pulp_daidanen.astro
@@ -35,7 +35,7 @@ const slugger = new GithubSlugger();
 	<Section slugger={slugger}>
 		<Fragment slot="heading">登場キャラクター一覧</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading"><cite>行け!!南国アイスホッケー部</cite></Fragment>
 
 			<List>
@@ -50,7 +50,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading"><cite>育ってダーリン!!</cite></Fragment>
 
 			<List>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading"><cite>太陽の戦士ポカポカ</cite></Fragment>
 
 			<List>
@@ -69,7 +69,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading"><cite>かってに改蔵</cite></Fragment>
 
 			<List>
@@ -106,7 +106,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading"><cite>さよなら絶望先生</cite></Fragment>
 
 			<List>
@@ -152,7 +152,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading"><cite>せっかち伯爵と時間どろぼう</cite></Fragment>
 
 			<List>
@@ -167,7 +167,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading"><cite>スタジオパルプ</cite></Fragment>
 
 			<List>
@@ -177,7 +177,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading"><cite>かくしごと</cite></Fragment>
 
 			<List>

--- a/astro/src/pages/kumeta/yomoyama/zetsubou_web.astro
+++ b/astro/src/pages/kumeta/yomoyama/zetsubou_web.astro
@@ -20,7 +20,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">公式サイト一覧</Fragment>
 
 		<Table>
@@ -91,12 +91,12 @@ const slugger = new GithubSlugger();
 			</li>
 		</ListNote>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading"><cite>さよなら絶望先生</cite></Fragment>
 
 		<YouTube id="J3J4b_wuxsM" title="『さよなら絶望先生』公式サイト閲覧の様子" />
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading"><cite>俗・さよなら絶望先生</cite></Fragment>
 
 		<YouTube id="kDSBb4UD5CQ" title="『俗・さよなら絶望先生』公式サイト閲覧の様子" />
@@ -105,7 +105,7 @@ const slugger = new GithubSlugger();
 			<li>裏ページ内の神谷浩史コメント動画は直接<Anchor href="https://king-cr.jp/special/zetsubou2/ura/kamiya_com.flv">動画ファイル（Flash Video 形式）</Anchor>をダウンロードして閲覧ください。</li>
 		</ListNote>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading"><cite>懺・さよなら絶望先生</cite></Fragment>
 
 		<YouTube id="t4j7jg8_GZQ" title="『懺・さよなら絶望先生』公式サイト閲覧の様子" />

--- a/astro/src/pages/madoka/dojin/pictorial6.astro
+++ b/astro/src/pages/madoka/dojin/pictorial6.astro
@@ -117,7 +117,7 @@ const slugger = new GithubSlugger();
 
 		<p>本の発行後に判明した差分データです。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">Chapter 10</Fragment>
 
 			<List>
@@ -126,7 +126,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">Chapter 25</Fragment>
 
 			<List>
@@ -134,7 +134,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">Chapter 27</Fragment>
 
 			<List>
@@ -143,7 +143,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">Chapter 28</Fragment>
 
 			<List>

--- a/astro/src/pages/madoka/dojin/pictorial6.astro
+++ b/astro/src/pages/madoka/dojin/pictorial6.astro
@@ -117,7 +117,7 @@ const slugger = new GithubSlugger();
 
 		<p>本の発行後に判明した差分データです。</p>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">Chapter 10</Fragment>
 
 			<List>
@@ -126,7 +126,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">Chapter 25</Fragment>
 
 			<List>
@@ -134,7 +134,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">Chapter 27</Fragment>
 
 			<List>
@@ -143,7 +143,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">Chapter 28</Fragment>
 
 			<List>

--- a/astro/src/pages/madoka/dojin/pictorial7.astro
+++ b/astro/src/pages/madoka/dojin/pictorial7.astro
@@ -155,7 +155,7 @@ const slugger = new GithubSlugger();
 
 		<p>本の発行後に判明した差分データです。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第1話</Fragment>
 
 			<List>
@@ -165,7 +165,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第3話</Fragment>
 
 			<List>
@@ -173,7 +173,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第6話</Fragment>
 
 			<List>
@@ -183,7 +183,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第7話</Fragment>
 
 			<List>
@@ -204,7 +204,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第8話</Fragment>
 
 			<List>
@@ -232,7 +232,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第9話</Fragment>
 
 			<List>
@@ -245,7 +245,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第10話</Fragment>
 
 			<List>
@@ -271,7 +271,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第11話</Fragment>
 
 			<List>
@@ -282,7 +282,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第12話</Fragment>
 
 			<List>

--- a/astro/src/pages/madoka/dojin/pictorial7.astro
+++ b/astro/src/pages/madoka/dojin/pictorial7.astro
@@ -155,7 +155,7 @@ const slugger = new GithubSlugger();
 
 		<p>本の発行後に判明した差分データです。</p>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第1話</Fragment>
 
 			<List>
@@ -165,7 +165,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第3話</Fragment>
 
 			<List>
@@ -173,7 +173,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第6話</Fragment>
 
 			<List>
@@ -183,7 +183,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第7話</Fragment>
 
 			<List>
@@ -204,7 +204,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第8話</Fragment>
 
 			<List>
@@ -232,7 +232,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第9話</Fragment>
 
 			<List>
@@ -245,7 +245,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第10話</Fragment>
 
 			<List>
@@ -271,7 +271,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第11話</Fragment>
 
 			<List>
@@ -282,7 +282,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第12話</Fragment>
 
 			<List>

--- a/astro/src/pages/madoka/index.astro
+++ b/astro/src/pages/madoka/index.astro
@@ -29,7 +29,7 @@ const slugger = new GithubSlugger();
 				<Fragment slot="main">
 					<Grid column="wide">
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">映像</Fragment>
 
 								<ListLink index={true}>
@@ -42,7 +42,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">メディア紹介</Fragment>
 
 								<ListLink index={true}>
@@ -54,7 +54,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">イベント</Fragment>
 
 								<ListLink index={true}>
@@ -70,7 +70,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">よもやま</Fragment>
 
 								<ListLink index={true}>
@@ -85,7 +85,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2}>
+							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">同人誌</Fragment>
 
 								<ListLink index={true}>

--- a/astro/src/pages/madoka/index.astro
+++ b/astro/src/pages/madoka/index.astro
@@ -29,7 +29,7 @@ const slugger = new GithubSlugger();
 				<Fragment slot="main">
 					<Grid column="wide" headingType="b">
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">映像</Fragment>
 
 								<ListLink index={true}>
@@ -42,7 +42,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">メディア紹介</Fragment>
 
 								<ListLink index={true}>
@@ -54,7 +54,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">イベント</Fragment>
 
 								<ListLink index={true}>
@@ -70,7 +70,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">よもやま</Fragment>
 
 								<ListLink index={true}>
@@ -85,7 +85,7 @@ const slugger = new GithubSlugger();
 							</Section>
 						</GridItem>
 						<GridItem>
-							<Section slugger={slugger} depth={2} headingType="b">
+							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">同人誌</Fragment>
 
 								<ListLink index={true}>

--- a/astro/src/pages/madoka/index.astro
+++ b/astro/src/pages/madoka/index.astro
@@ -27,7 +27,7 @@ const slugger = new GithubSlugger();
 		<Fragment slot="nav">
 			<TopNavText heading="サイトコンテンツ">
 				<Fragment slot="main">
-					<Grid column="wide" headingType="b">
+					<Grid column="wide">
 						<GridItem>
 							<Section slugger={slugger} depth={2}>
 								<Fragment slot="heading">映像</Fragment>

--- a/astro/src/pages/madoka/library/book.astro
+++ b/astro/src/pages/madoka/library/book.astro
@@ -31,7 +31,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2011年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="@2.5" release="2011-03-31" isbn="978-4-04-894080-1" amazonAsin="4048940805" amazonImageId="51+ojV0aDoL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -105,7 +105,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2012年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="平成23年度[第15回]文化庁メディア芸術祭受賞作品集" release="2012-02-01">
@@ -204,7 +204,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2013年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="魔法少女まどか☆マギカ　KEY ANIMATION NOTE extra 始まりの物語／永遠の物語" release="2013-02-28" amazonAsin="4896106768" amazonImageId="51X1+Ul732L" amazonImageWidth={111} amazonImageHeight={160}>
@@ -273,7 +273,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2014年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="劇場版魔法少女まどか☆マギカ [新編]叛逆の物語　公式ガイドブック　only you." release="2014-04-12" isbn="978-4-8322-4429-0" amazonAsin="4832244299" amazonImageId="61oIrxBA5xL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -314,7 +314,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2015年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="いま、幸福について語ろう　宮台真司「幸福学」対談集" release="2015-02-25" isbn="978-4-86436-599-4" amazonAsin="4864365997" amazonImageId="51Gd9zGrLpL" amazonImageWidth={107} amazonImageHeight={160}>
@@ -355,7 +355,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2016年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="「MADOGATARI展」図録" release="2016-09-22" amazonAsin="B01LZLCCFB" amazonImageId="51jKmWdTPXL" amazonImageWidth={112} amazonImageHeight={160}>
@@ -377,7 +377,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2017年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="PRO-VISION English Communication Ⅰ NEW EDITION" release="2017-02-25" isbn="978-4-342-04122-8" amazonAsin="4342041227" amazonImageId="510muQzSkYL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -394,7 +394,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2018年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="ホビージャパン フィギュアJAPANマニアックス（ホビージャパンムック 857）" release="2018-04-03" isbn="978-4-7986-1667-4" amazonAsin="4798616672" amazonImageId="51eIq9wMQYL" amazonImageWidth={113} amazonImageHeight={160}>
@@ -435,7 +435,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2019年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="谷口淳一郎　アニメーション画集" release="2019-01-19" isbn="978-4-902948-25-7" amazonAsin="4902948257" amazonImageId="511cGO68yuL" amazonImageWidth={118} amazonImageHeight={160}>

--- a/astro/src/pages/madoka/library/magazine.astro
+++ b/astro/src/pages/madoka/library/magazine.astro
@@ -31,7 +31,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2010年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="メガミマガジン　2010年12月号" release="2010-10-30" amazonAsin="B00474KL90" amazonImageId="61XR55tA6hL" amazonImageWidth={124} amazonImageHeight={160}>
@@ -125,7 +125,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2011年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="オトナアニメ　Vol.19" release="2011-01-08" isbn="978-4-86248-679-0" amazonAsin="4862486797" amazonImageId="61nmwSf8AWL" amazonImageWidth={115} amazonImageHeight={160}>
@@ -679,7 +679,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2012年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="アニメディア　2012年2月号" release="2012-01-10" amazonAsin="B006OAKCHG" amazonImageId="61QI+eiV6NL" amazonImageWidth={125} amazonImageHeight={160}>
@@ -1232,7 +1232,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2013年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="月刊ニュータイプ　2013年2月号" release="2013-01-10" amazonAsin="B00ARJ2ESK" amazonImageId="51IfYsvmWUL" amazonImageWidth={124} amazonImageHeight={160}>
@@ -1669,7 +1669,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2014年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="月刊ニュータイプ　2014年2月号" release="2014-01-10" amazonAsin="B00HFD3P0M" amazonImageId="61t0wA+LD3L" amazonImageWidth={124} amazonImageHeight={160}>
@@ -1802,7 +1802,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2015年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="まんがタイムきらら☆マギカ　Vol.18　2015年3月号" release="2015-02-10" amazonAsin="B00S9X6I88" amazonImageId="61FGoVstVoL" amazonImageWidth={111} amazonImageHeight={160}>
@@ -1913,7 +1913,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2016年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="ゲームラボ　2016年2月号" release="2016-01-16" amazonAsin="B000DZID9C" amazonImageId="616KMBlvFNL" amazonImageWidth={114} amazonImageHeight={160}>
@@ -1999,7 +1999,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2017年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="まんがタイムきらら☆マギカ　Vol.30　2017年3月号" release="2017-02-09" amazonAsin="B01N382U5A" amazonImageId="51ouabljNLL" amazonImageWidth={112} amazonImageHeight={160}>
@@ -2084,7 +2084,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2018年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="コンプティーク　2018年2月号" release="2018-01-10" amazonAsin="B0788XQ6WR" amazonImageId="61AhnR30wkL" amazonImageWidth={112} amazonImageHeight={160}>
@@ -2148,7 +2148,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2019年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="月刊ニュータイプ　2019年4月号" release="2019-03-09" amazonAsin="B07NRF18Y5" amazonImageId="510BJziYb7L" amazonImageWidth={127} amazonImageHeight={160}>
@@ -2200,7 +2200,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2020年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="月刊ニュータイプ　2020年2月号" release="2020-01-10" amazonAsin="B082PPJCM6" amazonImageId="51Ginn8ofbL" amazonImageWidth={127} amazonImageHeight={160}>
@@ -2306,7 +2306,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibBook>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2021年</Fragment>
 
 		<LibBook slugger={slugger} headingLevel={3} title="リスアニ!　Vol.43.1「ClariS音楽大全“クラリスアニ！”」" release="2021-02-17" isbn="978-4-7897-7320-1" amazonAsin="4789773205" amazonImageId="515eM01TpCL" amazonImageWidth={113} amazonImageHeight={160}>

--- a/astro/src/pages/madoka/library/newspaper.astro
+++ b/astro/src/pages/madoka/library/newspaper.astro
@@ -31,7 +31,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2011年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="毎日新聞" release="2011-01-21">
@@ -189,7 +189,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibNewspaper>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2012年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="中日新聞" release="2012-03-16" npClass="朝刊">
@@ -265,7 +265,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibNewspaper>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2013年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="朝日新聞（名古屋）" release="2013-03-27" npClass="朝刊">
@@ -332,7 +332,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibNewspaper>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2014年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="読売新聞" release="2014-02-21" npClass="朝刊">
@@ -407,7 +407,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibNewspaper>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2015年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="産経新聞（東京）" release="2015-01-08" npClass="朝刊">
@@ -470,7 +470,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibNewspaper>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2016年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="Frankfurter Allgemeine" release="2016-01-15">
@@ -613,7 +613,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibNewspaper>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2017年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="fumufumu J（新潟日報社のこども新聞）" release="2017-02-12" npClass="vol.43">
@@ -676,7 +676,7 @@ const slugger = new GithubSlugger();
 			</LibContent>
 		</LibNewspaper>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2018年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="読売新聞" release="2018-10-29" npClass="朝刊">
@@ -699,7 +699,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</LibNewspaper>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">2019年</Fragment>
 
 		<LibNewspaper slugger={slugger} headingLevel={3} title="日刊スポーツ" release="2019-01-19">

--- a/astro/src/pages/madoka/video/concept-movie.astro
+++ b/astro/src/pages/madoka/video/concept-movie.astro
@@ -354,7 +354,7 @@ const structuredData: StructuredData = {
 
 		<p>金沢の「<cite>MADOGATARI GALLERY</cite>」は通常のスクリーンでしたが、様々な作品の映像が22分に渡って流れるものとなりました。</p>
 
-		<Section id="theater-sapporo" depth={2} headingType="b">
+		<Section id="theater-sapporo" depth={2}>
 			<Fragment slot="heading">札幌会場<small>（2016年2月）</small></Fragment>
 
 			<List>
@@ -365,7 +365,7 @@ const structuredData: StructuredData = {
 				<li>コンセプトムービー</li>
 			</List>
 		</Section>
-		<Section id="theater-nagoya" depth={2} headingType="b">
+		<Section id="theater-nagoya" depth={2}>
 			<Fragment slot="heading">名古屋会場<small>（2016年5月）</small></Fragment>
 
 			<List>
@@ -375,7 +375,7 @@ const structuredData: StructuredData = {
 				<li>コンセプトムービー</li>
 			</List>
 		</Section>
-		<Section id="theater-tokyo-encore" depth={2} headingType="b">
+		<Section id="theater-tokyo-encore" depth={2}>
 			<Fragment slot="heading">東京アンコール会場<small>（2016年9月）</small></Fragment>
 
 			<List>
@@ -387,7 +387,7 @@ const structuredData: StructuredData = {
 				<li><Anchor href="https://www.youtube.com/watch?v=zsZHGftgsXI">『マギアレコード 魔法少女まどか☆マギカ外伝』PV第1弾</Anchor></li>
 			</List>
 		</Section>
-		<Section id="theater-kanazawa" depth={2} headingType="b">
+		<Section id="theater-kanazawa" depth={2}>
 			<Fragment slot="heading">金沢会場（<cite>MADOGATARI GALLERY</cite>）<small>（2016年12月）</small></Fragment>
 
 			<List>

--- a/astro/src/pages/madoka/video/connect.astro
+++ b/astro/src/pages/madoka/video/connect.astro
@@ -492,7 +492,7 @@ const slugger = new GithubSlugger();
 	<Section id="c009">
 		<Fragment slot="heading">#OP-C009　寝起きまどか</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">部屋を見上げる</Fragment>
 
 			<Grid column="medium">
@@ -524,7 +524,7 @@ const slugger = new GithubSlugger();
 				<li>劇場版後編で部屋の装飾や家具の形状が大幅に変更。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">シーツに潜る</Fragment>
 
 			<Grid column="medium">
@@ -563,7 +563,7 @@ const slugger = new GithubSlugger();
 				<li>（前シーンと同様）劇場版後編で部屋の装飾や家具の形状が大幅に変更。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">ごろごろ</Fragment>
 
 			<Grid column="medium">
@@ -596,7 +596,7 @@ const slugger = new GithubSlugger();
 				<li>（前シーンと同様）劇場版後編で部屋の装飾や家具の形状が大幅に変更。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">まどか不在</Fragment>
 
 			<Grid column="medium">
@@ -612,7 +612,7 @@ const slugger = new GithubSlugger();
 				<li>4話までは、次カットへ切り替わる直前に一瞬だけまどかが消えて布団とキュゥべえだけになるコマが存在していたが、5話で修正。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">もたれかかる</Fragment>
 
 			<Grid column="medium">
@@ -709,7 +709,7 @@ const slugger = new GithubSlugger();
 	<Section id="c012">
 		<Fragment slot="heading">#OP-C012　まどか変身</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">分身登場</Fragment>
 
 			<Grid column="medium">
@@ -769,7 +769,7 @@ const slugger = new GithubSlugger();
 				<li>劇場版後編で動く魔女文字がくっきりとなり、色も変更。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">変身開始</Fragment>
 
 			<Grid column="medium">

--- a/astro/src/pages/madoka/video/connect.astro
+++ b/astro/src/pages/madoka/video/connect.astro
@@ -492,7 +492,7 @@ const slugger = new GithubSlugger();
 	<Section id="c009">
 		<Fragment slot="heading">#OP-C009　寝起きまどか</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">部屋を見上げる</Fragment>
 
 			<Grid column="medium">
@@ -524,7 +524,7 @@ const slugger = new GithubSlugger();
 				<li>劇場版後編で部屋の装飾や家具の形状が大幅に変更。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">シーツに潜る</Fragment>
 
 			<Grid column="medium">
@@ -563,7 +563,7 @@ const slugger = new GithubSlugger();
 				<li>（前シーンと同様）劇場版後編で部屋の装飾や家具の形状が大幅に変更。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">ごろごろ</Fragment>
 
 			<Grid column="medium">
@@ -596,7 +596,7 @@ const slugger = new GithubSlugger();
 				<li>（前シーンと同様）劇場版後編で部屋の装飾や家具の形状が大幅に変更。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">まどか不在</Fragment>
 
 			<Grid column="medium">
@@ -612,7 +612,7 @@ const slugger = new GithubSlugger();
 				<li>4話までは、次カットへ切り替わる直前に一瞬だけまどかが消えて布団とキュゥべえだけになるコマが存在していたが、5話で修正。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">もたれかかる</Fragment>
 
 			<Grid column="medium">
@@ -709,7 +709,7 @@ const slugger = new GithubSlugger();
 	<Section id="c012">
 		<Fragment slot="heading">#OP-C012　まどか変身</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">分身登場</Fragment>
 
 			<Grid column="medium">
@@ -769,7 +769,7 @@ const slugger = new GithubSlugger();
 				<li>劇場版後編で動く魔女文字がくっきりとなり、色も変更。</li>
 			</List>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">変身開始</Fragment>
 
 			<Grid column="medium">

--- a/astro/src/pages/madoka/yomoyama/aj2017_magireco_jiho.astro
+++ b/astro/src/pages/madoka/yomoyama/aj2017_magireco_jiho.astro
@@ -67,7 +67,7 @@ const slugger = new GithubSlugger();
 	<Section id="14:00">
 		<Fragment slot="heading">14:00　キュゥべえ</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">3月25日バージョン</Fragment>
 
 			<Box>
@@ -76,7 +76,7 @@ const slugger = new GithubSlugger();
 				<p>3時の時報は鹿目まどかだよ。</p>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">3月26日バージョン</Fragment>
 
 			<Box>

--- a/astro/src/pages/madoka/yomoyama/aj2017_magireco_jiho.astro
+++ b/astro/src/pages/madoka/yomoyama/aj2017_magireco_jiho.astro
@@ -67,7 +67,7 @@ const slugger = new GithubSlugger();
 	<Section id="14:00">
 		<Fragment slot="heading">14:00　キュゥべえ</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">3月25日バージョン</Fragment>
 
 			<Box>
@@ -76,7 +76,7 @@ const slugger = new GithubSlugger();
 				<p>3時の時報は鹿目まどかだよ。</p>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">3月26日バージョン</Fragment>
 
 			<Box>

--- a/astro/src/pages/madoka/yomoyama/kumeta_joshiraku.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_joshiraku.astro
@@ -44,7 +44,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">特別編　壱／権利衛狸</Fragment>
 
 			<p>2013年2月8日　単行本「第伍巻」発売</p>
@@ -67,7 +67,7 @@ const slugger = new GithubSlugger();
 	<Section id="anime">
 		<Fragment slot="heading">アニメ</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第十席</Fragment>
 
 			<p><time datetime="2012-09-07">2012年9月6日深夜</time>　MBS放送</p>
@@ -85,7 +85,7 @@ const slugger = new GithubSlugger();
 			</Amazon>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">OAD<small>（単行本第伍巻・限定版付属）</small></Fragment>
 
 			<p>2013年2月8日発売</p>
@@ -109,7 +109,7 @@ const slugger = new GithubSlugger();
 				<AmazonItem asin="4063584151" title="単行本 第伍巻（限定版）" date="2013-02-08" imageId="51MFgzd%2Bx%2BL" imageWidth={113} imageHeight={160} />
 			</Amazon>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">Blu-ray / DVD　第壱巻　特典CD</Fragment>
 
 			<p>二次限無 Girl's Side</p>
@@ -133,7 +133,7 @@ const slugger = new GithubSlugger();
 	<Section id="radio">
 		<Fragment slot="heading">ラジオ<small>（<cite>【ガールズ落語ラジオ】じょしらじ</cite>）</small></Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第9回　くされ講釈</Fragment>
 
 			<p>2012年9月12日配信</p>
@@ -152,7 +152,7 @@ const slugger = new GithubSlugger();
 				<li>覆面キャラの声は悠木碧さん。アニメでは第一席から登場しているが、セリフがあったのは第八席が初。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第20回　小別れ</Fragment>
 
 			<p>2012年12月26日配信</p>
@@ -168,7 +168,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">DJCD　ガールズ落語ラジオ　じょしらじ　其之壱</Fragment>
 
 			<p>2012年10月19日発売</p>

--- a/astro/src/pages/madoka/yomoyama/kumeta_joshiraku.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_joshiraku.astro
@@ -44,7 +44,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">特別編　壱／権利衛狸</Fragment>
 
 			<p>2013年2月8日　単行本「第伍巻」発売</p>
@@ -67,7 +67,7 @@ const slugger = new GithubSlugger();
 	<Section id="anime">
 		<Fragment slot="heading">アニメ</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第十席</Fragment>
 
 			<p><time datetime="2012-09-07">2012年9月6日深夜</time>　MBS放送</p>
@@ -85,7 +85,7 @@ const slugger = new GithubSlugger();
 			</Amazon>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">OAD<small>（単行本第伍巻・限定版付属）</small></Fragment>
 
 			<p>2013年2月8日発売</p>
@@ -109,7 +109,7 @@ const slugger = new GithubSlugger();
 				<AmazonItem asin="4063584151" title="単行本 第伍巻（限定版）" date="2013-02-08" imageId="51MFgzd%2Bx%2BL" imageWidth={113} imageHeight={160} />
 			</Amazon>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">Blu-ray / DVD　第壱巻　特典CD</Fragment>
 
 			<p>二次限無 Girl's Side</p>
@@ -133,7 +133,7 @@ const slugger = new GithubSlugger();
 	<Section id="radio">
 		<Fragment slot="heading">ラジオ<small>（<cite>【ガールズ落語ラジオ】じょしらじ</cite>）</small></Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第9回　くされ講釈</Fragment>
 
 			<p>2012年9月12日配信</p>
@@ -152,7 +152,7 @@ const slugger = new GithubSlugger();
 				<li>覆面キャラの声は悠木碧さん。アニメでは第一席から登場しているが、セリフがあったのは第八席が初。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第20回　小別れ</Fragment>
 
 			<p>2012年12月26日配信</p>
@@ -168,7 +168,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">DJCD　ガールズ落語ラジオ　じょしらじ　其之壱</Fragment>
 
 			<p>2012年10月19日発売</p>

--- a/astro/src/pages/madoka/yomoyama/kumeta_kaizo.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_kaizo.astro
@@ -44,7 +44,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">特別番外編　損して得とれない</Fragment>
 
 			<p>2011年4月27日　「週刊少年マガジン2011年22・23合併号」掲載</p>
@@ -74,14 +74,14 @@ const slugger = new GithubSlugger();
 
 		<p>全12回配信 + DJCD1枚。パーソナリティは斎藤千和（坪内地丹 役）で、初回と最終回を除きゲストを迎えた2名体制で送られた。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第4回　いつかギリギリトークする日…!?</Fragment>
 
 			<p>2011年7月27日配信</p>
 
 			<p>ゲスト: 喜多村英梨（名取羽美 役）</p>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>水を差す人がいます</cite>」</Fragment>
 
 				<Box>
@@ -91,7 +91,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>とらうま高校だれとく部</cite>」</Fragment>
 
 				<Box>
@@ -102,7 +102,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">Webサイト掲載の次回予告</Fragment>
 
 				<Box>
@@ -111,14 +111,14 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第8回　結局はオレの出番だよ。</Fragment>
 
 			<p>2011年9月21日配信</p>
 
 			<p>ゲスト: 櫻井孝宏（勝改蔵 役）</p>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>理論上は可能なんです!</cite>」</Fragment>
 
 				<Box>
@@ -129,14 +129,14 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第11回　スレスレ★サービス</Fragment>
 
 			<p>2011年11月2日配信</p>
 
 			<p>ゲスト: 喜多村英梨（名取羽美 役）</p>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">Webサイト掲載の次回予告</Fragment>
 
 				<Box>
@@ -149,14 +149,14 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">DJCD かってに改蔵ラジオしてもいいぜ 〜地丹をうけたらサヨウナラ〜</Fragment>
 
 			<p>2011年10月26日発売</p>
 
 			<p>ゲスト: 櫻井孝宏（勝改蔵 役）</p>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>とらうま高校だれとく部（前半）</cite>」</Fragment>
 
 				<Box>
@@ -187,7 +187,7 @@ const slugger = new GithubSlugger();
 					</List>
 				</Box>
 			</Section>
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>とらうま高校だれとく部（後半）</cite>」</Fragment>
 
 				<Box>

--- a/astro/src/pages/madoka/yomoyama/kumeta_kaizo.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_kaizo.astro
@@ -44,7 +44,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">特別番外編　損して得とれない</Fragment>
 
 			<p>2011年4月27日　「週刊少年マガジン2011年22・23合併号」掲載</p>
@@ -74,14 +74,14 @@ const slugger = new GithubSlugger();
 
 		<p>全12回配信 + DJCD1枚。パーソナリティは斎藤千和（坪内地丹 役）で、初回と最終回を除きゲストを迎えた2名体制で送られた。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第4回　いつかギリギリトークする日…!?</Fragment>
 
 			<p>2011年7月27日配信</p>
 
 			<p>ゲスト: 喜多村英梨（名取羽美 役）</p>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>水を差す人がいます</cite>」</Fragment>
 
 				<Box>
@@ -91,7 +91,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>とらうま高校だれとく部</cite>」</Fragment>
 
 				<Box>
@@ -102,7 +102,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">Webサイト掲載の次回予告</Fragment>
 
 				<Box>
@@ -111,14 +111,14 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第8回　結局はオレの出番だよ。</Fragment>
 
 			<p>2011年9月21日配信</p>
 
 			<p>ゲスト: 櫻井孝宏（勝改蔵 役）</p>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>理論上は可能なんです!</cite>」</Fragment>
 
 				<Box>
@@ -129,14 +129,14 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第11回　スレスレ★サービス</Fragment>
 
 			<p>2011年11月2日配信</p>
 
 			<p>ゲスト: 喜多村英梨（名取羽美 役）</p>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">Webサイト掲載の次回予告</Fragment>
 
 				<Box>
@@ -149,14 +149,14 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">DJCD かってに改蔵ラジオしてもいいぜ 〜地丹をうけたらサヨウナラ〜</Fragment>
 
 			<p>2011年10月26日発売</p>
 
 			<p>ゲスト: 櫻井孝宏（勝改蔵 役）</p>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>とらうま高校だれとく部（前半）</cite>」</Fragment>
 
 				<Box>
@@ -187,7 +187,7 @@ const slugger = new GithubSlugger();
 					</List>
 				</Box>
 			</Section>
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">コーナー「<cite>とらうま高校だれとく部（後半）</cite>」</Fragment>
 
 				<Box>

--- a/astro/src/pages/madoka/yomoyama/kumeta_kakushigoto.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_kakushigoto.astro
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第36号　採ってもラッキーマン</Fragment>
 
 			<p>2019年11月15日　単行本「第10巻」発売</p>

--- a/astro/src/pages/madoka/yomoyama/kumeta_kakushigoto.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_kakushigoto.astro
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第36号　採ってもラッキーマン</Fragment>
 
 			<p>2019年11月15日　単行本「第10巻」発売</p>

--- a/astro/src/pages/madoka/yomoyama/kumeta_sekadoro.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_sekadoro.astro
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">00′03″　かわいそうな伯爵</Fragment>
 
 			<p>2014年2月17日　単行本「第1巻」発売</p>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 			</Amazon>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">00′29″　かしこい葦</Fragment>
 
 			<p>2014年9月17日　単行本「第4巻」発売</p>

--- a/astro/src/pages/madoka/yomoyama/kumeta_sekadoro.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_sekadoro.astro
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">00′03″　かわいそうな伯爵</Fragment>
 
 			<p>2014年2月17日　単行本「第1巻」発売</p>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 			</Amazon>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">00′29″　かしこい葦</Fragment>
 
 			<p>2014年9月17日　単行本「第4巻」発売</p>

--- a/astro/src/pages/madoka/yomoyama/kumeta_zetsubou.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_zetsubou.astro
@@ -46,7 +46,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第二百五十六話　出でよ、オツベルと象!</Fragment>
 
 			<p>2011年7月15日　単行本「第二六集」発売</p>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第二百五十九話　アウェイなる一族</Fragment>
 
 			<p>2011年7月15日　単行本「第二六集」発売</p>
@@ -72,7 +72,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第二百六十一話　春は曙。やうやう難くなりゆくやめ際。</Fragment>
 
 			<p>2011年10月17日　単行本「第二七集」発売</p>
@@ -85,7 +85,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第二百六十六話　笹の上のメモ</Fragment>
 
 			<p>2011年10月17日　単行本「第二七集」発売</p>
@@ -98,7 +98,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第二百七十四話　善いサマリア人ね。善いサマリア人は善いね。</Fragment>
 
 			<p>2012年2月17日　単行本「第二八集」発売</p>
@@ -111,7 +111,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第二百七十六話　悲しき絶対</Fragment>
 
 			<p>2012年2月17日　単行本「第二八集」発売</p>
@@ -124,7 +124,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第二百七十八話　似勢物語</Fragment>
 
 			<p>2012年2月17日　単行本「第二八集」発売</p>
@@ -142,7 +142,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第二百九十七話　（あと）五回の憂鬱</Fragment>
 
 			<p>2012年8月17日　単行本「第三十集」発売</p>
@@ -172,7 +172,7 @@ const slugger = new GithubSlugger();
 
 		<p>全203回配信 + DJCD16枚、その他DJDVDや携帯版、オールナイトニッポンRでの放送など。パーソナリティは神谷浩史（糸色望 役）と新谷良子（日塔奈美 役）。</p>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第166回　ティモシー・アーチャーの変声</Fragment>
 
 			<p>2010年11月24日配信</p>
@@ -189,7 +189,7 @@ const slugger = new GithubSlugger();
 				<li>放送前の制作発表へのメッセージ。絶望先生のアニメは三期の放送から1年が過ぎた時期。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第175回　フェッセンデンの普通</Fragment>
 
 			<p>2011年2月2日配信</p>
@@ -206,7 +206,7 @@ const slugger = new GithubSlugger();
 				<li>氷川へきる先生が第2話の予告イラストを担当されたことに対する言及。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第177回　春季の祭典</Fragment>
 
 			<p>2011年2月16日配信</p>
@@ -223,7 +223,7 @@ const slugger = new GithubSlugger();
 				<li>再び予告イラストへの言及。「さのすけ」は第31回で誕生した絶望放送発祥のマスコットキャラクター（CV: 神谷浩史）だが、後に久米田作品はもとより様々な漫画、アニメに登場している。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第179回　はしごからの眺め</Fragment>
 
 			<p>2011年3月2日配信</p>
@@ -248,7 +248,7 @@ const slugger = new GithubSlugger();
 				<li><q>このラジオはフィクションであり……</q>のくだりは毎回読まれるものであるが、標語のネタ元に合わせて組織名の後の単語（今回で言えば<q>マスコット</q>、<q>契約</q>）は差し替えられる。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第182回　猫のネタに釘を打て</Fragment>
 
 			<p>2011年3月25日配信</p>
@@ -261,7 +261,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第184回　真・さよなら絶望放送</Fragment>
 
 			<p>2011年4月13日配信</p>
@@ -303,7 +303,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第190回　妻という名の魔女子たち</Fragment>
 
 			<p>2011年6月1日配信</p>
@@ -318,7 +318,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第191回　五十歩万歩の男</Fragment>
 
 			<p>2011年6月8日配信</p>
@@ -333,7 +333,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">第201回　幻想と解禁</Fragment>
 
 			<p>2011年8月17日配信</p>
@@ -350,7 +350,7 @@ const slugger = new GithubSlugger();
 				<li><q>公演回</q>、<q>エノデンの回</q>とは、『<cite>懺・さよなら絶望先生</cite>』第8話 Cパートの「<cite>最後の、そして始まりのエノデン</cite>」のことで、全編にわたってイヌカレー空間による表現となった異色回。登場キャラクターは『<cite>まどか☆マギカ</cite>』でも多用された、切り絵風の表現となっている。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">携帯版　第190回　誰か注意してあげて下さい!!</Fragment>
 
 			<p>2011年6月1日配信</p>
@@ -370,7 +370,7 @@ const slugger = new GithubSlugger();
 				<AmazonItem asin="B005XOK9N6" title="DJCD さよなら絶望放送 携帯盤SZ-04K" date="2011-12-21" imageId="51%2B2i1YWMNL" imageWidth={160} imageHeight={136} />
 			</Amazon>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">DJCD　さよなら絶望放送　第十巻</Fragment>
 
 			<p>2011年10月26日発売</p>
@@ -389,7 +389,7 @@ const slugger = new GithubSlugger();
 				<AmazonItem asin="B005I065Z6" title="DJCD　さよなら絶望放送　第十巻" date="2011-10-26" imageId="51zEn8RzOML" imageWidth={160} imageHeight={159} />
 			</Amazon>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">糸色望のオールナイトニッポンR</Fragment>
 
 			<p>2011年10月15日放送</p>

--- a/astro/src/pages/madoka/yomoyama/kumeta_zetsubou.astro
+++ b/astro/src/pages/madoka/yomoyama/kumeta_zetsubou.astro
@@ -46,7 +46,7 @@ const slugger = new GithubSlugger();
 	<Section id="manga">
 		<Fragment slot="heading">漫画</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第二百五十六話　出でよ、オツベルと象!</Fragment>
 
 			<p>2011年7月15日　単行本「第二六集」発売</p>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第二百五十九話　アウェイなる一族</Fragment>
 
 			<p>2011年7月15日　単行本「第二六集」発売</p>
@@ -72,7 +72,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第二百六十一話　春は曙。やうやう難くなりゆくやめ際。</Fragment>
 
 			<p>2011年10月17日　単行本「第二七集」発売</p>
@@ -85,7 +85,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第二百六十六話　笹の上のメモ</Fragment>
 
 			<p>2011年10月17日　単行本「第二七集」発売</p>
@@ -98,7 +98,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第二百七十四話　善いサマリア人ね。善いサマリア人は善いね。</Fragment>
 
 			<p>2012年2月17日　単行本「第二八集」発売</p>
@@ -111,7 +111,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第二百七十六話　悲しき絶対</Fragment>
 
 			<p>2012年2月17日　単行本「第二八集」発売</p>
@@ -124,7 +124,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第二百七十八話　似勢物語</Fragment>
 
 			<p>2012年2月17日　単行本「第二八集」発売</p>
@@ -142,7 +142,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第二百九十七話　（あと）五回の憂鬱</Fragment>
 
 			<p>2012年8月17日　単行本「第三十集」発売</p>
@@ -172,7 +172,7 @@ const slugger = new GithubSlugger();
 
 		<p>全203回配信 + DJCD16枚、その他DJDVDや携帯版、オールナイトニッポンRでの放送など。パーソナリティは神谷浩史（糸色望 役）と新谷良子（日塔奈美 役）。</p>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第166回　ティモシー・アーチャーの変声</Fragment>
 
 			<p>2010年11月24日配信</p>
@@ -189,7 +189,7 @@ const slugger = new GithubSlugger();
 				<li>放送前の制作発表へのメッセージ。絶望先生のアニメは三期の放送から1年が過ぎた時期。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第175回　フェッセンデンの普通</Fragment>
 
 			<p>2011年2月2日配信</p>
@@ -206,7 +206,7 @@ const slugger = new GithubSlugger();
 				<li>氷川へきる先生が第2話の予告イラストを担当されたことに対する言及。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第177回　春季の祭典</Fragment>
 
 			<p>2011年2月16日配信</p>
@@ -223,7 +223,7 @@ const slugger = new GithubSlugger();
 				<li>再び予告イラストへの言及。「さのすけ」は第31回で誕生した絶望放送発祥のマスコットキャラクター（CV: 神谷浩史）だが、後に久米田作品はもとより様々な漫画、アニメに登場している。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第179回　はしごからの眺め</Fragment>
 
 			<p>2011年3月2日配信</p>
@@ -248,7 +248,7 @@ const slugger = new GithubSlugger();
 				<li><q>このラジオはフィクションであり……</q>のくだりは毎回読まれるものであるが、標語のネタ元に合わせて組織名の後の単語（今回で言えば<q>マスコット</q>、<q>契約</q>）は差し替えられる。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第182回　猫のネタに釘を打て</Fragment>
 
 			<p>2011年3月25日配信</p>
@@ -261,7 +261,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第184回　真・さよなら絶望放送</Fragment>
 
 			<p>2011年4月13日配信</p>
@@ -303,7 +303,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第190回　妻という名の魔女子たち</Fragment>
 
 			<p>2011年6月1日配信</p>
@@ -318,7 +318,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第191回　五十歩万歩の男</Fragment>
 
 			<p>2011年6月8日配信</p>
@@ -333,7 +333,7 @@ const slugger = new GithubSlugger();
 				</List>
 			</Box>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">第201回　幻想と解禁</Fragment>
 
 			<p>2011年8月17日配信</p>
@@ -350,7 +350,7 @@ const slugger = new GithubSlugger();
 				<li><q>公演回</q>、<q>エノデンの回</q>とは、『<cite>懺・さよなら絶望先生</cite>』第8話 Cパートの「<cite>最後の、そして始まりのエノデン</cite>」のことで、全編にわたってイヌカレー空間による表現となった異色回。登場キャラクターは『<cite>まどか☆マギカ</cite>』でも多用された、切り絵風の表現となっている。</li>
 			</ListNote>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">携帯版　第190回　誰か注意してあげて下さい!!</Fragment>
 
 			<p>2011年6月1日配信</p>
@@ -370,7 +370,7 @@ const slugger = new GithubSlugger();
 				<AmazonItem asin="B005XOK9N6" title="DJCD さよなら絶望放送 携帯盤SZ-04K" date="2011-12-21" imageId="51%2B2i1YWMNL" imageWidth={160} imageHeight={136} />
 			</Amazon>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">DJCD　さよなら絶望放送　第十巻</Fragment>
 
 			<p>2011年10月26日発売</p>
@@ -389,7 +389,7 @@ const slugger = new GithubSlugger();
 				<AmazonItem asin="B005I065Z6" title="DJCD　さよなら絶望放送　第十巻" date="2011-10-26" imageId="51zEn8RzOML" imageWidth={160} imageHeight={159} />
 			</Amazon>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">糸色望のオールナイトニッポンR</Fragment>
 
 			<p>2011年10月15日放送</p>

--- a/astro/src/pages/madoka/yomoyama/monoga-modoka.astro
+++ b/astro/src/pages/madoka/yomoyama/monoga-modoka.astro
@@ -91,35 +91,35 @@ const structuredData: StructuredData = {
 
 		<p><ruby>惑語<rp>（</rp><rt>マドガタリ</rt><rp>）</rp></ruby> 魔法少女ものが☆モドカ。僕と契約して魔法少女になって欲しいんだ。</p>
 
-		<Section id="reading-hitagi" depth={2} headingType="c">
+		<Section id="reading-hitagi" depth={2}>
 			<Fragment slot="heading">戦場ヶ原ひたぎ<small>（重力の魔法少女）</small></Fragment>
 
 			<p>質量という概念から解放されたこの魔法少女は、攻撃した物体の重さを奪うんだ。奪えば奪うほどハンマーは重さを増し強化される。魔法を失った時、持ち主は押し潰される宿命ってわけだね。</p>
 
 			<p>ハンマーにはサイコメトリーの機能もあるんだけれど、残念ながら使いこなせていないみたいだよ。</p>
 		</Section>
-		<Section id="reading-mayoi" depth={2} headingType="c">
+		<Section id="reading-mayoi" depth={2}>
 			<Fragment slot="heading">八九寺真宵<small>（迷宮の魔法少女）</small></Fragment>
 
 			<p>防御力に秀でた魔法少女だ。あらゆる攻撃が道に迷ったように彼女を避ける。ただし、こちらからの攻撃も当たらなくなるので注意が必要だ。</p>
 
 			<p>なので手にしたドリルは攻撃用ではなく、道なき道を造るための道路工事用のアイテムだよ。それだって魔女結界の逃走経路を作る役にしか立たないけどね。</p>
 		</Section>
-		<Section id="reading-suruga" depth={2} headingType="c">
+		<Section id="reading-suruga" depth={2}>
 			<Fragment slot="heading">神原駿河<small>（先駆の魔法少女）</small></Fragment>
 
 			<p>バイクと一体化した魔法少女に変身したのは、普段自転車に乗れない彼女のコンプレックスの表れかもね。願いの純度が高すぎて、もしも誰かに追い抜かれたらその瞬間に魔女化する。</p>
 
 			<p>いくらスピードが欲しいからって、そんなことまで最速で達成しなくてもいいのにな。わけが分からないよ。</p>
 		</Section>
-		<Section id="reading-nadeko" depth={2} headingType="c">
+		<Section id="reading-nadeko" depth={2}>
 			<Fragment slot="heading">千石撫子<small>（俯伏の魔法少女）</small></Fragment>
 
 			<p>世にも珍しい地を這う姿の魔法少女だ。</p>
 
 			<p>人見知りという性格がそのまま反映されているのは、さながらほふく前進のような移動手段のみならず、彼女の周囲に敷き詰められた地雷という武器においてもまた然りだ。うっかり自分で踏んじゃうことも多々あるのが興味深い。</p>
 		</Section>
-		<Section id="reading-tsubasa" depth={2} headingType="c">
+		<Section id="reading-tsubasa" depth={2}>
 			<Fragment slot="heading">羽川翼<small>（記憶の魔法少女）</small></Fragment>
 
 			<p>重力の魔法少女のサイコメトリーとは逆で、この魔法少女は何かを燃やすたびに自身の記憶を失う。</p>
@@ -128,7 +128,7 @@ const structuredData: StructuredData = {
 
 			<p>とはいえ、魔法少女のままで世界を燃やし尽くしてくれるなら、そのおぞましいまでの熱量はこちらとしても望ましいまでなんだ。</p>
 		</Section>
-		<Section id="reading-shinobu" depth={2} headingType="c">
+		<Section id="reading-shinobu" depth={2}>
 			<Fragment slot="heading">忍野忍<small>（不死の魔法少女）</small></Fragment>
 
 			<p>彼女の願いは残念ながら叶わなかった。代わりに不死身の化け物を大量虐殺できる力を手に入れたよ。殺した化物はそのまま魔法少女の養分となる。結果ますます長生きすることになったのはなんとも皮肉だよ。まあそもそも600歳だからこの吸血鬼、別に思春期の女の子でも何でもないしね。</p>

--- a/astro/src/pages/madoka/yomoyama/monoga-modoka.astro
+++ b/astro/src/pages/madoka/yomoyama/monoga-modoka.astro
@@ -142,14 +142,14 @@ const structuredData: StructuredData = {
 	<Section id="tenji">
 		<Fragment slot="heading">「<cite>MADOGATARI展</cite>」会場ごとの展示の様子</Fragment>
 
-		<Section id="tenji-tokyo-encore" depth={2} headingType="b">
+		<Section id="tenji-tokyo-encore" depth={2}>
 			<Fragment slot="heading">東京アンコール会場<small>（2016年9月）</small></Fragment>
 
 			<p>『<cite>〈物語〉シリーズ</cite>』ゾーンの最後の方に巨大なディスプレイがあり、エンドレスで映像が放映されました。</p>
 
 			<p>神原駿河を除く5人の写真がスポーツ報知の記事<Anchor href="https://web.archive.org/web/20160922044103/http://www.hochi.co.jp/entertainment/20160922-OHT1T50082.html">「ＭＡＤＯＧＡＴＡＲＩ展」東京アンコール展が開幕…「名セリフ投票」も実施</Anchor>に掲載されています。</p>
 		</Section>
-		<Section id="tenji-kanazawa" depth={2} headingType="b">
+		<Section id="tenji-kanazawa" depth={2}>
 			<Fragment slot="heading">金沢会場（MADOGATARI GALLERY）<small>（2016年12月）</small></Fragment>
 
 			<p>展示エリア内の「<cite>シャフトシアター</cite>」にて、他作品と一緒に上映されました。上映リストは以下のとおりです。</p>

--- a/astro/src/pages/madoka/yomoyama/namae.astro
+++ b/astro/src/pages/madoka/yomoyama/namae.astro
@@ -28,7 +28,7 @@ const structuredData: StructuredData = {
 	<Section id="table">
 		<Fragment slot="heading">呼称統計</Fragment>
 
-		<Section id="table-madoka" depth={2} headingType="b">
+		<Section id="table-madoka" depth={2}>
 			<Fragment slot="heading">鹿目まどか</Fragment>
 
 			<Table full={true} font="small">
@@ -430,7 +430,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-ultimatemadoka" depth={2} headingType="b">
+		<Section id="table-ultimatemadoka" depth={2}>
 			<Fragment slot="heading">アルティメットまどか</Fragment>
 
 			<Table full={true} font="small">
@@ -478,7 +478,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-homura" depth={2} headingType="b">
+		<Section id="table-homura" depth={2}>
 			<Fragment slot="heading">暁美ほむら</Fragment>
 
 			<Table full={true} font="small">
@@ -838,7 +838,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-meganehomura" depth={2} headingType="b">
+		<Section id="table-meganehomura" depth={2}>
 			<Fragment slot="heading">暁美ほむら（眼鏡）</Fragment>
 
 			<Table full={true} font="small">
@@ -997,7 +997,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-akumahomura" depth={2} headingType="b">
+		<Section id="table-akumahomura" depth={2}>
 			<Fragment slot="heading">暁美ほむら（悪魔）</Fragment>
 
 			<Table full={true} font="small">
@@ -1137,7 +1137,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-mami" depth={2} headingType="b">
+		<Section id="table-mami" depth={2}>
 			<Fragment slot="heading">巴マミ</Fragment>
 
 			<Table full={true} font="small">
@@ -1389,7 +1389,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-sayaka" depth={2} headingType="b">
+		<Section id="table-sayaka" depth={2}>
 			<Fragment slot="heading">美樹さやか</Fragment>
 
 			<Table full={true} font="small">
@@ -1825,7 +1825,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-kyoko" depth={2} headingType="b">
+		<Section id="table-kyoko" depth={2}>
 			<Fragment slot="heading">佐倉杏子</Fragment>
 
 			<Table full={true} font="small">
@@ -2167,12 +2167,12 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-nagisa" depth={2} headingType="b">
+		<Section id="table-nagisa" depth={2}>
 			<Fragment slot="heading">百江なぎさ</Fragment>
 
 			<p>なし</p>
 		</Section>
-		<Section id="table-bebe" depth={2} headingType="b">
+		<Section id="table-bebe" depth={2}>
 			<Fragment slot="heading">ベベ</Fragment>
 
 			<Table full={true} font="small">
@@ -2258,7 +2258,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-kyubey" depth={2} headingType="b">
+		<Section id="table-kyubey" depth={2}>
 			<Fragment slot="heading">キュゥべえ</Fragment>
 
 			<Table full={true} font="small">
@@ -2564,7 +2564,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-hitomi" depth={2} headingType="b">
+		<Section id="table-hitomi" depth={2}>
 			<Fragment slot="heading">志筑仁美</Fragment>
 
 			<Table full={true} font="small">
@@ -2704,7 +2704,7 @@ const structuredData: StructuredData = {
 				</tbody>
 			</Table>
 		</Section>
-		<Section id="table-etc" depth={2} headingType="b">
+		<Section id="table-etc" depth={2}>
 			<Fragment slot="heading">その他のキャラクター</Fragment>
 
 			<Table full={true} font="small">
@@ -3285,7 +3285,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第1話　夢の中で逢った、ような……</h3></Fragment>
 
-			<Section id="talk-tv1-1" depth={3} headingType="c">
+			<Section id="talk-tv1-1" depth={3}>
 				<Fragment slot="heading">黒髪の少女</Fragment>
 
 				<Table full={true}>
@@ -3317,7 +3317,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv1-3" depth={3} headingType="c">
+			<Section id="talk-tv1-3" depth={3}>
 				<Fragment slot="heading">朝の団欒</Fragment>
 
 				<Table full={true}>
@@ -3381,7 +3381,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv1-4" depth={3} headingType="c">
+			<Section id="talk-tv1-4" depth={3}>
 				<Fragment slot="heading">黒髪の転校生</Fragment>
 
 				<Table full={true}>
@@ -3445,7 +3445,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv1-5" depth={3} headingType="c">
+			<Section id="talk-tv1-5" depth={3}>
 				<Fragment slot="heading">謎の忠告</Fragment>
 
 				<Table full={true}>
@@ -3517,7 +3517,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv1-7" depth={3} headingType="c">
+			<Section id="talk-tv1-7" depth={3}>
 				<Fragment slot="heading">放課後のひととき</Fragment>
 
 				<Table full={true}>
@@ -3565,7 +3565,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv1-8" depth={3} headingType="c">
+			<Section id="talk-tv1-8" depth={3}>
 				<Fragment slot="heading">誰かの呼ぶ声が</Fragment>
 
 				<Table full={true}>
@@ -3589,7 +3589,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv1-9" depth={3} headingType="c">
+			<Section id="talk-tv1-9" depth={3}>
 				<Fragment slot="heading">不思議な出会い</Fragment>
 
 				<Table full={true}>
@@ -3653,7 +3653,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv1-10" depth={3} headingType="c">
+			<Section id="talk-tv1-10" depth={3}>
 				<Fragment slot="heading">異形の花園</Fragment>
 
 				<Table full={true}>
@@ -3693,7 +3693,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv1-11" depth={3} headingType="c">
+			<Section id="talk-tv1-11" depth={3}>
 				<Fragment slot="heading">僕の名はキュゥべえ</Fragment>
 
 				<Table full={true}>
@@ -3730,7 +3730,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第2話　それはとっても嬉しいなって</h3></Fragment>
 
-			<Section id="talk-tv2-1" depth={3} headingType="c">
+			<Section id="talk-tv2-1" depth={3}>
 				<Fragment slot="heading">魔法少女・巴マミ</Fragment>
 
 				<Table full={true}>
@@ -3754,7 +3754,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-3" depth={3} headingType="c">
+			<Section id="talk-tv2-3" depth={3}>
 				<Fragment slot="heading">ソウルジェムの輝き</Fragment>
 
 				<Table full={true}>
@@ -3794,7 +3794,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-4" depth={3} headingType="c">
+			<Section id="talk-tv2-4" depth={3}>
 				<Fragment slot="heading">祈りと呪いと</Fragment>
 
 				<Table full={true}>
@@ -3842,7 +3842,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-5" depth={3} headingType="c">
+			<Section id="talk-tv2-5" depth={3}>
 				<Fragment slot="heading">いつもと違う朝</Fragment>
 
 				<Table full={true}>
@@ -3882,7 +3882,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-6" depth={3} headingType="c">
+			<Section id="talk-tv2-6" depth={3}>
 				<Fragment slot="heading">転校生の狙いは?</Fragment>
 
 				<Table full={true}>
@@ -3938,7 +3938,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-7" depth={3} headingType="c">
+			<Section id="talk-tv2-7" depth={3}>
 				<Fragment slot="heading">幸せすぎて…</Fragment>
 
 				<Table full={true}>
@@ -4002,7 +4002,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-8" depth={3} headingType="c">
+			<Section id="talk-tv2-8" depth={3}>
 				<Fragment slot="heading">魔女捜し</Fragment>
 
 				<Table full={true}>
@@ -4050,7 +4050,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-9" depth={3} headingType="c">
+			<Section id="talk-tv2-9" depth={3}>
 				<Fragment slot="heading">突入</Fragment>
 
 				<Table full={true}>
@@ -4090,7 +4090,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-10" depth={3} headingType="c">
+			<Section id="talk-tv2-10" depth={3}>
 				<Fragment slot="heading">華麗なる射手</Fragment>
 
 				<Table full={true}>
@@ -4114,7 +4114,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv2-11" depth={3} headingType="c">
+			<Section id="talk-tv2-11" depth={3}>
 				<Fragment slot="heading">一件落着</Fragment>
 
 				<Table full={true}>
@@ -4159,7 +4159,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第3話　もう何も恐くない</h3></Fragment>
 
-			<Section id="talk-tv3-1" depth={3} headingType="c">
+			<Section id="talk-tv3-1" depth={3}>
 				<Fragment slot="heading">幼馴染み</Fragment>
 
 				<Table full={true}>
@@ -4191,7 +4191,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv3-3" depth={3} headingType="c">
+			<Section id="talk-tv3-3" depth={3}>
 				<Fragment slot="heading">願い事は誰のため?</Fragment>
 
 				<Table full={true}>
@@ -4263,7 +4263,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv3-4" depth={3} headingType="c">
+			<Section id="talk-tv3-4" depth={3}>
 				<Fragment slot="heading">ママの生き方</Fragment>
 
 				<Table full={true}>
@@ -4311,7 +4311,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv3-5" depth={3} headingType="c">
+			<Section id="talk-tv3-5" depth={3}>
 				<Fragment slot="heading">交渉決裂</Fragment>
 
 				<Table full={true}>
@@ -4359,7 +4359,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv3-6" depth={3} headingType="c">
+			<Section id="talk-tv3-6" depth={3}>
 				<Fragment slot="heading">病院に迫る魔の手</Fragment>
 
 				<Table full={true}>
@@ -4407,7 +4407,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv3-7" depth={3} headingType="c">
+			<Section id="talk-tv3-7" depth={3}>
 				<Fragment slot="heading">結界の中へ</Fragment>
 
 				<Table full={true}>
@@ -4463,7 +4463,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv3-8" depth={3} headingType="c">
+			<Section id="talk-tv3-8" depth={3}>
 				<Fragment slot="heading">まどかの願い</Fragment>
 
 				<Table full={true}>
@@ -4535,7 +4535,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv3-9" depth={3} headingType="c">
+			<Section id="talk-tv3-9" depth={3}>
 				<Fragment slot="heading">魔弾の舞踏</Fragment>
 
 				<Table full={true}>
@@ -4559,7 +4559,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv3-11" depth={3} headingType="c">
+			<Section id="talk-tv3-11" depth={3}>
 				<Fragment slot="heading">魔法少女の運命</Fragment>
 
 				<Table full={true}>
@@ -4588,7 +4588,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第4話　奇跡も、魔法も、あるんだよ</h3></Fragment>
 
-			<Section id="talk-tv4-3" depth={3} headingType="c">
+			<Section id="talk-tv4-3" depth={3}>
 				<Fragment slot="heading">生き延びた朝に</Fragment>
 
 				<Table full={true}>
@@ -4628,7 +4628,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv4-4" depth={3} headingType="c">
+			<Section id="talk-tv4-4" depth={3}>
 				<Fragment slot="heading">夢の終わり</Fragment>
 
 				<Table full={true}>
@@ -4684,7 +4684,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv4-6" depth={3} headingType="c">
+			<Section id="talk-tv4-6" depth={3}>
 				<Fragment slot="heading">戦いの宿命</Fragment>
 
 				<Table full={true}>
@@ -4772,7 +4772,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv4-7" depth={3} headingType="c">
+			<Section id="talk-tv4-7" depth={3}>
 				<Fragment slot="heading">絶望に抗って</Fragment>
 
 				<Table full={true}>
@@ -4812,7 +4812,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv4-8" depth={3} headingType="c">
+			<Section id="talk-tv4-8" depth={3}>
 				<Fragment slot="heading">夜の放浪者</Fragment>
 
 				<Table full={true}>
@@ -4868,7 +4868,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv4-9" depth={3} headingType="c">
+			<Section id="talk-tv4-9" depth={3}>
 				<Fragment slot="heading">おぞましき宴</Fragment>
 
 				<Table full={true}>
@@ -4900,7 +4900,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv4-10" depth={3} headingType="c">
+			<Section id="talk-tv4-10" depth={3}>
 				<Fragment slot="heading">電影の魔手</Fragment>
 
 				<Table full={true}>
@@ -4924,7 +4924,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv4-11" depth={3} headingType="c">
+			<Section id="talk-tv4-11" depth={3}>
 				<Fragment slot="heading">新たなる魔法少女たち</Fragment>
 
 				<Table full={true}>
@@ -4985,7 +4985,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第5話　後悔なんて、あるわけない</h3></Fragment>
 
-			<Section id="talk-tv5-1" depth={3} headingType="c">
+			<Section id="talk-tv5-1" depth={3}>
 				<Fragment slot="heading">さやか契約</Fragment>
 
 				<Table full={true}>
@@ -5017,7 +5017,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv5-3" depth={3} headingType="c">
+			<Section id="talk-tv5-3" depth={3}>
 				<Fragment slot="heading">気分爽快</Fragment>
 
 				<Table full={true}>
@@ -5073,7 +5073,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv5-4" depth={3} headingType="c">
+			<Section id="talk-tv5-4" depth={3}>
 				<Fragment slot="heading">アヴェマリア</Fragment>
 
 				<Table full={true}>
@@ -5137,7 +5137,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv5-5" depth={3} headingType="c">
+			<Section id="talk-tv5-5" depth={3}>
 				<Fragment slot="heading">新参者を巡って</Fragment>
 
 				<Table full={true}>
@@ -5201,7 +5201,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv5-6" depth={3} headingType="c">
+			<Section id="talk-tv5-6" depth={3}>
 				<Fragment slot="heading">ふたりで一緒に</Fragment>
 
 				<Table full={true}>
@@ -5273,7 +5273,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv5-8" depth={3} headingType="c">
+			<Section id="talk-tv5-8" depth={3}>
 				<Fragment slot="heading">紅蓮の槍</Fragment>
 
 				<Table full={true}>
@@ -5332,7 +5332,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv5-9" depth={3} headingType="c">
+			<Section id="talk-tv5-9" depth={3}>
 				<Fragment slot="heading">死闘の果てに</Fragment>
 
 				<Table full={true}>
@@ -5401,7 +5401,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第6話　こんなの絶対おかしいよ</h3></Fragment>
 
-			<Section id="talk-tv6-1" depth={3} headingType="c">
+			<Section id="talk-tv6-1" depth={3}>
 				<Fragment slot="heading">謎のイレギュラー</Fragment>
 
 				<Table full={true}>
@@ -5497,7 +5497,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv6-3" depth={3} headingType="c">
+			<Section id="talk-tv6-3" depth={3}>
 				<Fragment slot="heading">才能と経験</Fragment>
 
 				<Table full={true}>
@@ -5521,7 +5521,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv6-4" depth={3} headingType="c">
+			<Section id="talk-tv6-4" depth={3}>
 				<Fragment slot="heading">利害の一致</Fragment>
 
 				<Table full={true}>
@@ -5577,7 +5577,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv6-5" depth={3} headingType="c">
+			<Section id="talk-tv6-5" depth={3}>
 				<Fragment slot="heading">さやかの正義</Fragment>
 
 				<Table full={true}>
@@ -5649,7 +5649,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv6-6" depth={3} headingType="c">
+			<Section id="talk-tv6-6" depth={3}>
 				<Fragment slot="heading">間違えるということ</Fragment>
 
 				<Table full={true}>
@@ -5681,7 +5681,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv6-7" depth={3} headingType="c">
+			<Section id="talk-tv6-7" depth={3}>
 				<Fragment slot="heading">杏子の挑発</Fragment>
 
 				<Table full={true}>
@@ -5737,7 +5737,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv6-8" depth={3} headingType="c">
+			<Section id="talk-tv6-8" depth={3}>
 				<Fragment slot="heading">まどかの決断</Fragment>
 
 				<Table full={true}>
@@ -5825,7 +5825,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv6-9" depth={3} headingType="c">
+			<Section id="talk-tv6-9" depth={3}>
 				<Fragment slot="heading">明かされた真相</Fragment>
 
 				<Table full={true}>
@@ -5878,7 +5878,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第7話　本当の気持ちと向き合えますか?</h3></Fragment>
 
-			<Section id="talk-tv7-1" depth={3} headingType="c">
+			<Section id="talk-tv7-1" depth={3}>
 				<Fragment slot="heading">契約の真実</Fragment>
 
 				<Table full={true}>
@@ -5918,7 +5918,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv7-3" depth={3} headingType="c">
+			<Section id="talk-tv7-3" depth={3}>
 				<Fragment slot="heading">さやかのいない午後</Fragment>
 
 				<Table full={true}>
@@ -5958,7 +5958,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv7-4" depth={3} headingType="c">
+			<Section id="talk-tv7-4" depth={3}>
 				<Fragment slot="heading">意外な来訪</Fragment>
 
 				<Table full={true}>
@@ -5990,7 +5990,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv7-8" depth={3} headingType="c">
+			<Section id="talk-tv7-8" depth={3}>
 				<Fragment slot="heading">擦れ違う想い</Fragment>
 
 				<Table full={true}>
@@ -6078,7 +6078,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv7-9" depth={3} headingType="c">
+			<Section id="talk-tv7-9" depth={3}>
 				<Fragment slot="heading">恭介、復帰</Fragment>
 
 				<Table full={true}>
@@ -6134,7 +6134,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv7-10" depth={3} headingType="c">
+			<Section id="talk-tv7-10" depth={3}>
 				<Fragment slot="heading">恋をする資格</Fragment>
 
 				<Table full={true}>
@@ -6246,7 +6246,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv7-11" depth={3} headingType="c">
+			<Section id="talk-tv7-11" depth={3}>
 				<Fragment slot="heading">痛みすら忘れて</Fragment>
 
 				<Table full={true}>
@@ -6299,7 +6299,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第8話　あたしって、ほんとバカ</h3></Fragment>
 
-			<Section id="talk-tv8-1" depth={3} headingType="c">
+			<Section id="talk-tv8-1" depth={3}>
 				<Fragment slot="heading">傷だらけの勝利</Fragment>
 
 				<Table full={true}>
@@ -6339,7 +6339,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv8-3" depth={3} headingType="c">
+			<Section id="talk-tv8-3" depth={3}>
 				<Fragment slot="heading">冷たい雨に打たれて</Fragment>
 
 				<Table full={true}>
@@ -6419,7 +6419,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv8-4" depth={3} headingType="c">
+			<Section id="talk-tv8-4" depth={3}>
 				<Fragment slot="heading">戦略会議</Fragment>
 
 				<Table full={true}>
@@ -6467,7 +6467,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv8-5" depth={3} headingType="c">
+			<Section id="talk-tv8-5" depth={3}>
 				<Fragment slot="heading">恋の終わり</Fragment>
 
 				<Table full={true}>
@@ -6499,7 +6499,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv8-6" depth={3} headingType="c">
+			<Section id="talk-tv8-6" depth={3}>
 				<Fragment slot="heading">憧れた正義のカタチ</Fragment>
 
 				<Table full={true}>
@@ -6563,7 +6563,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv8-7" depth={3} headingType="c">
+			<Section id="talk-tv8-7" depth={3}>
 				<Fragment slot="heading">夜行列車にて</Fragment>
 
 				<Table full={true}>
@@ -6611,7 +6611,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv8-8" depth={3} headingType="c">
+			<Section id="talk-tv8-8" depth={3}>
 				<Fragment slot="heading">赤い瞳の誘い</Fragment>
 
 				<Table full={true}>
@@ -6707,7 +6707,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv8-9" depth={3} headingType="c">
+			<Section id="talk-tv8-9" depth={3}>
 				<Fragment slot="heading">孵卵器は語る</Fragment>
 
 				<Table full={true}>
@@ -6787,7 +6787,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv8-10" depth={3} headingType="c">
+			<Section id="talk-tv8-10" depth={3}>
 				<Fragment slot="heading">人魚の涙</Fragment>
 
 				<Table full={true}>
@@ -6838,7 +6838,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第9話　そんなの、あたしが許さない</h3></Fragment>
 
-			<Section id="talk-tv9-1" depth={3} headingType="c">
+			<Section id="talk-tv9-1" depth={3}>
 				<Fragment slot="heading">変貌</Fragment>
 
 				<Table full={true}>
@@ -6892,7 +6892,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-3" depth={3} headingType="c">
+			<Section id="talk-tv9-3" depth={3}>
 				<Fragment slot="heading">分岐線路</Fragment>
 
 				<Table full={true}>
@@ -6940,7 +6940,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-4" depth={3} headingType="c">
+			<Section id="talk-tv9-4" depth={3}>
 				<Fragment slot="heading">キュゥべえの釈明</Fragment>
 
 				<Table full={true}>
@@ -7004,7 +7004,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-5" depth={3} headingType="c">
+			<Section id="talk-tv9-5" depth={3}>
 				<Fragment slot="heading">杏子の決意</Fragment>
 
 				<Table full={true}>
@@ -7036,7 +7036,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-6" depth={3} headingType="c">
+			<Section id="talk-tv9-6" depth={3}>
 				<Fragment slot="heading">気まずい朝</Fragment>
 
 				<Table full={true}>
@@ -7092,7 +7092,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-7" depth={3} headingType="c">
+			<Section id="talk-tv9-7" depth={3}>
 				<Fragment slot="heading">奇妙な共闘</Fragment>
 
 				<Table full={true}>
@@ -7116,7 +7116,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-8" depth={3} headingType="c">
+			<Section id="talk-tv9-8" depth={3}>
 				<Fragment slot="heading">魔女の演奏会</Fragment>
 
 				<Table full={true}>
@@ -7172,7 +7172,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-9" depth={3} headingType="c">
+			<Section id="talk-tv9-9" depth={3}>
 				<Fragment slot="heading">祈りを刃に託して</Fragment>
 
 				<Table full={true}>
@@ -7260,7 +7260,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-10" depth={3} headingType="c">
+			<Section id="talk-tv9-10" depth={3}>
 				<Fragment slot="heading">願わくは二人で共に</Fragment>
 
 				<Table full={true}>
@@ -7300,7 +7300,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv9-11" depth={3} headingType="c">
+			<Section id="talk-tv9-11" depth={3}>
 				<Fragment slot="heading">残るは一人</Fragment>
 
 				<Table full={true}>
@@ -7329,7 +7329,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第10話　もう誰にも頼らない</h3></Fragment>
 
-			<Section id="talk-tv10-1" depth={3} headingType="c">
+			<Section id="talk-tv10-1" depth={3}>
 				<Fragment slot="heading">二つ編みの転校生</Fragment>
 
 				<Table full={true}>
@@ -7385,7 +7385,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-2" depth={3} headingType="c">
+			<Section id="talk-tv10-2" depth={3}>
 				<Fragment slot="heading">救いの主は同級生</Fragment>
 
 				<Table full={true}>
@@ -7409,7 +7409,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-3" depth={3} headingType="c">
+			<Section id="talk-tv10-3" depth={3}>
 				<Fragment slot="heading">長い旅の始まり</Fragment>
 
 				<Table full={true}>
@@ -7529,7 +7529,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-4" depth={3} headingType="c">
+			<Section id="talk-tv10-4" depth={3}>
 				<Fragment slot="heading">転校生、再び</Fragment>
 
 				<Table full={true}>
@@ -7561,7 +7561,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-5" depth={3} headingType="c">
+			<Section id="talk-tv10-5" depth={3}>
 				<Fragment slot="heading">魔女を狩る者たち</Fragment>
 
 				<Table full={true}>
@@ -7601,7 +7601,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-6" depth={3} headingType="c">
+			<Section id="talk-tv10-6" depth={3}>
 				<Fragment slot="heading">伝わらない言葉</Fragment>
 
 				<Table full={true}>
@@ -7649,7 +7649,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-7" depth={3} headingType="c">
+			<Section id="talk-tv10-7" depth={3}>
 				<Fragment slot="heading">残酷な真実の前に</Fragment>
 
 				<Table full={true}>
@@ -7697,7 +7697,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-8" depth={3} headingType="c">
+			<Section id="talk-tv10-8" depth={3}>
 				<Fragment slot="heading">約束</Fragment>
 
 				<Table full={true}>
@@ -7753,7 +7753,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-9" depth={3} headingType="c">
+			<Section id="talk-tv10-9" depth={3}>
 				<Fragment slot="heading">孤高の破壊者</Fragment>
 
 				<Table full={true}>
@@ -7791,7 +7791,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv10-10" depth={3} headingType="c">
+			<Section id="talk-tv10-10" depth={3}>
 				<Fragment slot="heading">終焉の世界で</Fragment>
 
 				<Table full={true}>
@@ -7820,7 +7820,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第11話　最後に残った道しるべ</h3></Fragment>
 
-			<Section id="talk-tv11-1" depth={3} headingType="c">
+			<Section id="talk-tv11-1" depth={3}>
 				<Fragment slot="heading">因果の集束</Fragment>
 
 				<Table full={true}>
@@ -7900,7 +7900,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv11-3" depth={3} headingType="c">
+			<Section id="talk-tv11-3" depth={3}>
 				<Fragment slot="heading">雨の中の葬列</Fragment>
 
 				<Table full={true}>
@@ -7948,7 +7948,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv11-4" depth={3} headingType="c">
+			<Section id="talk-tv11-4" depth={3}>
 				<Fragment slot="heading">悠久の歴史の秘密</Fragment>
 
 				<Table full={true}>
@@ -7972,7 +7972,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv11-5" depth={3} headingType="c">
+			<Section id="talk-tv11-5" depth={3}>
 				<Fragment slot="heading">大人の弱音</Fragment>
 
 				<Table full={true}>
@@ -8004,7 +8004,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv11-6" depth={3} headingType="c">
+			<Section id="talk-tv11-6" depth={3}>
 				<Fragment slot="heading">ほむらの部屋へ</Fragment>
 
 				<Table full={true}>
@@ -8060,7 +8060,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv11-7" depth={3} headingType="c">
+			<Section id="talk-tv11-7" depth={3}>
 				<Fragment slot="heading">告白</Fragment>
 
 				<Table full={true}>
@@ -8132,7 +8132,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv11-10" depth={3} headingType="c">
+			<Section id="talk-tv11-10" depth={3}>
 				<Fragment slot="heading">母と娘</Fragment>
 
 				<Table full={true}>
@@ -8228,7 +8228,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv11-11" depth={3} headingType="c">
+			<Section id="talk-tv11-11" depth={3}>
 				<Fragment slot="heading">絶望の中で</Fragment>
 
 				<Table full={true}>
@@ -8281,7 +8281,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>第12話　わたしの、最高の友達</h3></Fragment>
 
-			<Section id="talk-tv12-1" depth={3} headingType="c">
+			<Section id="talk-tv12-1" depth={3}>
 				<Fragment slot="heading">契約のとき</Fragment>
 
 				<Table full={true}>
@@ -8369,7 +8369,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv12-2" depth={3} headingType="c">
+			<Section id="talk-tv12-2" depth={3}>
 				<Fragment slot="heading">光の矢</Fragment>
 
 				<Table full={true}>
@@ -8425,7 +8425,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv12-4" depth={3} headingType="c">
+			<Section id="talk-tv12-4" depth={3}>
 				<Fragment slot="heading">最後の因果</Fragment>
 
 				<Table full={true}>
@@ -8457,7 +8457,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv12-5" depth={3} headingType="c">
+			<Section id="talk-tv12-5" depth={3}>
 				<Fragment slot="heading">ひとときの別れ</Fragment>
 
 				<Table full={true}>
@@ -8593,7 +8593,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv12-6" depth={3} headingType="c">
+			<Section id="talk-tv12-6" depth={3}>
 				<Fragment slot="heading">満場の拍手の影で</Fragment>
 
 				<Table full={true}>
@@ -8633,7 +8633,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv12-7" depth={3} headingType="c">
+			<Section id="talk-tv12-7" depth={3}>
 				<Fragment slot="heading">たったひとつの奇跡</Fragment>
 
 				<Table full={true}>
@@ -8657,7 +8657,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv12-8" depth={3} headingType="c">
+			<Section id="talk-tv12-8" depth={3}>
 				<Fragment slot="heading">家族の肖像</Fragment>
 
 				<Table full={true}>
@@ -8689,7 +8689,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-tv12-9" depth={3} headingType="c">
+			<Section id="talk-tv12-9" depth={3}>
 				<Fragment slot="heading">夜を駈ける者たち</Fragment>
 
 				<Table full={true}>
@@ -8742,7 +8742,7 @@ const structuredData: StructuredData = {
 		<Toggle>
 			<Fragment slot="summary"><h3>[新編]叛逆の物語</h3></Fragment>
 
-			<Section id="talk-shinpen-chapter2" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter2" depth={3}>
 				<Fragment slot="heading">Chapter 2</Fragment>
 
 				<Table full={true}>
@@ -8798,7 +8798,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter4" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter4" depth={3}>
 				<Fragment slot="heading">Chapter 4</Fragment>
 
 				<Table full={true}>
@@ -8902,7 +8902,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter5" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter5" depth={3}>
 				<Fragment slot="heading">Chapter 5</Fragment>
 
 				<Table full={true}>
@@ -8966,7 +8966,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter6" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter6" depth={3}>
 				<Fragment slot="heading">Chapter 6</Fragment>
 
 				<Table full={true}>
@@ -9006,7 +9006,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter7" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter7" depth={3}>
 				<Fragment slot="heading">Chapter 7</Fragment>
 
 				<Table full={true}>
@@ -9102,7 +9102,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter8" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter8" depth={3}>
 				<Fragment slot="heading">Chapter 8</Fragment>
 
 				<Table full={true}>
@@ -9158,7 +9158,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter9" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter9" depth={3}>
 				<Fragment slot="heading">Chapter 9</Fragment>
 
 				<Table full={true}>
@@ -9254,7 +9254,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter11" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter11" depth={3}>
 				<Fragment slot="heading">Chapter 11</Fragment>
 
 				<Table full={true}>
@@ -9302,7 +9302,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter13" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter13" depth={3}>
 				<Fragment slot="heading">Chapter 13</Fragment>
 
 				<Table full={true}>
@@ -9438,7 +9438,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter14" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter14" depth={3}>
 				<Fragment slot="heading">Chapter 14</Fragment>
 
 				<Table full={true}>
@@ -9486,7 +9486,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter15" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter15" depth={3}>
 				<Fragment slot="heading">Chapter 15</Fragment>
 
 				<Table full={true}>
@@ -9534,7 +9534,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter16" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter16" depth={3}>
 				<Fragment slot="heading">Chapter 16</Fragment>
 
 				<Table full={true}>
@@ -9598,7 +9598,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter17" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter17" depth={3}>
 				<Fragment slot="heading">Chapter 17</Fragment>
 
 				<Table full={true}>
@@ -9662,7 +9662,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter18" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter18" depth={3}>
 				<Fragment slot="heading">Chapter 18</Fragment>
 
 				<Table full={true}>
@@ -9686,7 +9686,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter19" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter19" depth={3}>
 				<Fragment slot="heading">Chapter 19</Fragment>
 
 				<Table full={true}>
@@ -9822,7 +9822,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter20" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter20" depth={3}>
 				<Fragment slot="heading">Chapter 20</Fragment>
 
 				<Table full={true}>
@@ -9878,7 +9878,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter21" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter21" depth={3}>
 				<Fragment slot="heading">Chapter 21</Fragment>
 
 				<Table full={true}>
@@ -10006,7 +10006,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter22" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter22" depth={3}>
 				<Fragment slot="heading">Chapter 22</Fragment>
 
 				<Table full={true}>
@@ -10078,7 +10078,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter23" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter23" depth={3}>
 				<Fragment slot="heading">Chapter 23</Fragment>
 
 				<Table full={true}>
@@ -10134,7 +10134,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter24" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter24" depth={3}>
 				<Fragment slot="heading">Chapter 24</Fragment>
 
 				<Table full={true}>
@@ -10230,7 +10230,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter25" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter25" depth={3}>
 				<Fragment slot="heading">Chapter 25</Fragment>
 
 				<Table full={true}>
@@ -10294,7 +10294,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter26" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter26" depth={3}>
 				<Fragment slot="heading">Chapter 26</Fragment>
 
 				<Table full={true}>
@@ -10414,7 +10414,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter27" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter27" depth={3}>
 				<Fragment slot="heading">Chapter 27</Fragment>
 
 				<Table full={true}>
@@ -10518,7 +10518,7 @@ const structuredData: StructuredData = {
 					</tbody>
 				</Table>
 			</Section>
-			<Section id="talk-shinpen-chapter28" depth={3} headingType="c">
+			<Section id="talk-shinpen-chapter28" depth={3}>
 				<Fragment slot="heading">Chapter 28</Fragment>
 
 				<Table full={true}>
@@ -10639,7 +10639,7 @@ const structuredData: StructuredData = {
 
 		<p>いくつか注目したい点を抜粋しましょう。</p>
 
-		<Section id="matome-tv" depth={2} headingType="b">
+		<Section id="matome-tv" depth={2}>
 			<Fragment slot="heading">TV シリーズ</Fragment>
 
 			<List>
@@ -10652,7 +10652,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="matome-shinpen" depth={2} headingType="b">
+		<Section id="matome-shinpen" depth={2}>
 			<Fragment slot="heading">[新編]叛逆の物語</Fragment>
 
 			<List>

--- a/astro/src/pages/madoka/yomoyama/official_news.astro
+++ b/astro/src/pages/madoka/yomoyama/official_news.astro
@@ -19,7 +19,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">TV シリーズ</Fragment>
 
 		<ListLink index={true}>
@@ -104,7 +104,7 @@ const slugger = new GithubSlugger();
 			<li><Anchor href="https://www.madoka-magica.com/tv/news/#n263559" icon={false}>『魔法少女まどか☆マギカ オンライン』みんなでテスト参加者募集開始!</Anchor> （2012年6月4日）</li>
 		</ListLink>
 	</Section>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">劇場版</Fragment>
 
 		<ListLink index={true}>

--- a/astro/src/pages/madoka/yomoyama/umeten_guide.astro
+++ b/astro/src/pages/madoka/yomoyama/umeten_guide.astro
@@ -51,13 +51,13 @@ const structuredData: StructuredData = {
 	<Section id="chapter1">
 		<Fragment slot="heading">第1章　プロローグ、展覧会メインビジュアル ほか</Fragment>
 
-		<Section id="no1" depth={2} headingType="c">
+		<Section id="no1" depth={2}>
 			<Fragment slot="heading">1　プロローグ</Fragment>
 
 			<p>3人の挨拶。阿澄佳奈、悠木碧は簡単な自己紹介付き。</p>
 		</Section>
 
-		<Section id="no2" depth={2} headingType="c">
+		<Section id="no2" depth={2}>
 			<Fragment slot="heading">2　「蒼樹うめ展」描き下ろしイラスト（展覧会メインビジュアル）</Fragment>
 
 			<p>描き下ろしイラストについてのトーク。</p>
@@ -75,7 +75,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no3" depth={2} headingType="c">
+		<Section id="no3" depth={2}>
 			<Fragment slot="heading">3　クレヨン画「お友だち」 〜子どもの頃の夢と漫画家になるまで</Fragment>
 
 			<p>蒼樹うめの一人トーク。</p>
@@ -100,7 +100,7 @@ const structuredData: StructuredData = {
 	<Section id="chapter2">
 		<Fragment slot="heading">第2章　ひだまりスケッチ</Fragment>
 
-		<Section id="no4" depth={2} headingType="c">
+		<Section id="no4" depth={2}>
 			<Fragment slot="heading">4　「ひだまりスケッチ」連載スタートのきっかけ</Fragment>
 
 			<Box>
@@ -112,7 +112,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no5" depth={2} headingType="c">
+		<Section id="no5" depth={2}>
 			<Fragment slot="heading">5　実体験に基づく「ひだまり」の世界</Fragment>
 
 			<Box>
@@ -127,7 +127,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no6" depth={2} headingType="c">
+		<Section id="no6" depth={2}>
 			<Fragment slot="heading">6　「ひだまりスケッチ」作画用資料（ひだまりカラーパレット）</Fragment>
 
 			<Box>
@@ -138,7 +138,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no7" depth={2} headingType="c">
+		<Section id="no7" depth={2}>
 			<Fragment slot="heading">7　阿澄佳奈が語る「ひだまりスケッチ」の魅力とうめ先生</Fragment>
 
 			<p>阿澄佳奈の一人トーク。</p>
@@ -156,7 +156,7 @@ const structuredData: StructuredData = {
 	<Section id="chapter3">
 		<Fragment slot="heading">第3章　原稿の部屋</Fragment>
 
-		<Section id="no8" depth={2} headingType="c">
+		<Section id="no8" depth={2}>
 			<Fragment slot="heading">8　スペシャルトラック: 「原稿の部屋」　〜アトリエでの過ごし方</Fragment>
 
 			<p>阿澄佳奈、悠木碧との視聴者が蒼樹うめのアトリエを訪問するという体での小芝居風。</p>
@@ -175,7 +175,7 @@ const structuredData: StructuredData = {
 	<Section id="chapter4">
 		<Fragment slot="heading">第4章　魔法少女まどか☆マギカ</Fragment>
 
-		<Section id="no9" depth={2} headingType="c">
+		<Section id="no9" depth={2}>
 			<Fragment slot="heading">9　TVアニメ「魔法少女まどか☆マギカ」キャラクターデザイン原案</Fragment>
 
 			<Box>
@@ -188,7 +188,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no10" depth={2} headingType="c">
+		<Section id="no10" depth={2}>
 			<Fragment slot="heading">10　TVアニメ「魔法少女まどか☆マギカ」第1話、第2話エンディングイラスト 〜悠木碧が語る「魔法少女まどか☆マギカ」の魅力とうめ先生</Fragment>
 
 			<p>悠木碧の一人トーク。</p>
@@ -202,7 +202,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no11" depth={2} headingType="c">
+		<Section id="no11" depth={2}>
 			<Fragment slot="heading">11　「劇場版　魔法少女まどか☆マギカ [新編]叛逆の物語」キャラクターデザイン（私服）</Fragment>
 
 			<Box>
@@ -213,7 +213,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no12" depth={2} headingType="c">
+		<Section id="no12" depth={2}>
 			<Fragment slot="heading">12　「劇場版　魔法少女まどか☆マギカ」劇場プレゼント色紙　〜お気に入りの一枚</Fragment>
 
 			<Box>
@@ -228,7 +228,7 @@ const structuredData: StructuredData = {
 	<Section id="chapter5">
 		<Fragment slot="heading">第5章　収録を終えて、エピローグ ほか</Fragment>
 
-		<Section id="no13" depth={2} headingType="c">
+		<Section id="no13" depth={2}>
 			<Fragment slot="heading">13　微熱空間 〜うめ先生の恋愛漫画</Fragment>
 
 			<Box>
@@ -239,7 +239,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no14" depth={2} headingType="c">
+		<Section id="no14" depth={2}>
 			<Fragment slot="heading">14　スペシャルトラック: 収録を終えて</Fragment>
 
 			<Box>
@@ -249,7 +249,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no15" depth={2} headingType="c">
+		<Section id="no15" depth={2}>
 			<Fragment slot="heading">15　TVアニメ「ニセコイ」第14話エンドカードイラスト、TVアニメ「彼女がフラグをおられたら」第11話エンドカードイラスト「吟遊院芹香」</Fragment>
 
 			<Box>
@@ -266,7 +266,7 @@ const structuredData: StructuredData = {
 			</Box>
 		</Section>
 
-		<Section id="no16" depth={2} headingType="c">
+		<Section id="no16" depth={2}>
 			<Fragment slot="heading">16　「蒼樹うめ展」描き下ろしイラスト（オリジナル） 〜エピローグ</Fragment>
 
 			<Box>

--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -35,25 +35,25 @@ const slugger = new GithubSlugger();
 	<Section id="history">
 		<Fragment slot="heading">歴史</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2001年2月</Fragment>
 
 			<p>前身のサイトを開設。<Anchor href="https://web.archive.org/web/20010202073300/http://www.cool.ne.jp/"><cite>COOL ONLINE</cite></Anchor>の無料会員枠を利用（容量20MB）。<q>地域コミュニティ</q>を謳っており、登録の際にまず都市を選択、それによってサブドメインが振り分けられた（e.g. <code>tokyo.cool.ne.jp</code>）。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2001年6月<!-- 1日 --></Fragment>
 
 			<p>掲載写真の増大により容量面で厳しくなり、<Anchor href="https://web.archive.org/web/20010421065319/http://freehp.goo.ne.jp/"><cite>goo フリーホームページ</cite></Anchor>に移転（容量50MB）。URL は <code is:raw>http://users.goo.ne.jp/${userId}</code> 形式だが、IP アドレスのドメインにリダイレクトされる（ブラウザのアドレスバーには IP アドレスの数字が表示される）というすごい仕様だった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2002年3月<!-- 26日 --></Fragment>
 
 			<p><Anchor href="http://www.nurs.or.jp/"><cite>ネットワーク利用技術研究会（NURS）</cite></Anchor>に移転。レンタルサーバーではなく研究・実験目的のサーバーであり、Telnet が制限なしに使えたので、root 権限が必要なこと以外は割となんでもできた。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2012年2月<!-- 12日 --></Fragment>
 
 			<p><cite>NURS</cite> はドメインがサブドメインで分ける方式ではなく全ユーザー共通であり、Cookie の導入がセキュリティ上の理由<NoteRef by="nurs-cookie" />で躊躇われることから<Anchor href="https://www.inetd.co.jp/"><cite>アイネットディー</cite></Anchor>に移転したうえで独自ドメインを取得。月額270円の格安サーバーにしては Cron の制限が緩いのがありがたかった。</p>
@@ -61,7 +61,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="nurs-cookie"><Anchor href="http://takagi-hiromitsu.jp/diary/20100501.html">高木浩光＠自宅の日記 - <cite>共用SSLサーバの危険性が理解されていない</cite></Anchor>で解説されているように、フレームを利用して他サイトから読み出すことが可能なため。</NoteRefContent>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年1月</Fragment>
 
 			<p>常時 TLS の波に乗り<Anchor href="https://vps.sakura.ad.jp/"><cite>さくらの VPS</cite></Anchor> に移転。<Anchor href="https://letsencrypt.org/">Let's Encrypt</Anchor>を利用して TLS 対応を行う。</p>

--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -35,25 +35,25 @@ const slugger = new GithubSlugger();
 	<Section id="history">
 		<Fragment slot="heading">歴史</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2001年2月</Fragment>
 
 			<p>前身のサイトを開設。<Anchor href="https://web.archive.org/web/20010202073300/http://www.cool.ne.jp/"><cite>COOL ONLINE</cite></Anchor>の無料会員枠を利用（容量20MB）。<q>地域コミュニティ</q>を謳っており、登録の際にまず都市を選択、それによってサブドメインが振り分けられた（e.g. <code>tokyo.cool.ne.jp</code>）。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2001年6月<!-- 1日 --></Fragment>
 
 			<p>掲載写真の増大により容量面で厳しくなり、<Anchor href="https://web.archive.org/web/20010421065319/http://freehp.goo.ne.jp/"><cite>goo フリーホームページ</cite></Anchor>に移転（容量50MB）。URL は <code is:raw>http://users.goo.ne.jp/${userId}</code> 形式だが、IP アドレスのドメインにリダイレクトされる（ブラウザのアドレスバーには IP アドレスの数字が表示される）というすごい仕様だった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2002年3月<!-- 26日 --></Fragment>
 
 			<p><Anchor href="http://www.nurs.or.jp/"><cite>ネットワーク利用技術研究会（NURS）</cite></Anchor>に移転。レンタルサーバーではなく研究・実験目的のサーバーであり、Telnet が制限なしに使えたので、root 権限が必要なこと以外は割となんでもできた。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2012年2月<!-- 12日 --></Fragment>
 
 			<p><cite>NURS</cite> はドメインがサブドメインで分ける方式ではなく全ユーザー共通であり、Cookie の導入がセキュリティ上の理由<NoteRef by="nurs-cookie" />で躊躇われることから<Anchor href="https://www.inetd.co.jp/"><cite>アイネットディー</cite></Anchor>に移転したうえで独自ドメインを取得。月額270円の格安サーバーにしては Cron の制限が緩いのがありがたかった。</p>
@@ -61,7 +61,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="nurs-cookie"><Anchor href="http://takagi-hiromitsu.jp/diary/20100501.html">高木浩光＠自宅の日記 - <cite>共用SSLサーバの危険性が理解されていない</cite></Anchor>で解説されているように、フレームを利用して他サイトから読み出すことが可能なため。</NoteRefContent>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年1月</Fragment>
 
 			<p>常時 TLS の波に乗り<Anchor href="https://vps.sakura.ad.jp/"><cite>さくらの VPS</cite></Anchor> に移転。<Anchor href="https://letsencrypt.org/">Let's Encrypt</Anchor>を利用して TLS 対応を行う。</p>

--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -170,7 +170,7 @@ const slugger = new GithubSlugger();
 	<Section id="html">
 		<Fragment slot="heading">HTML</Fragment>
 
-		<Section id="html-mime" depth={2} headingType="b">
+		<Section id="html-mime" depth={2}>
 			<Fragment slot="heading">MIME タイプ</Fragment>
 
 			<p>HTML コンテンツの MIME タイプは <code>text/html</code> としている。</p>
@@ -180,7 +180,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="xhtml-blog">当サイトのブログ記事：<Anchor href="https://blog.w0s.jp/entry/706"><cite>XHTML の終焉と XHTML 1.0 Transitional 時代の思い出</cite></Anchor>（2024年）</NoteRefContent>
 		</Section>
 
-		<Section id="html-indent" depth={2} headingType="b">
+		<Section id="html-indent" depth={2}>
 			<Fragment slot="heading">インデント</Fragment>
 
 			<p>インデントをタブにするかスペースにするかは永遠の議題であるが、当サイトではタブを採用している。</p>
@@ -190,7 +190,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="tab-raddit">Raddit の投稿：<Anchor href="https://www.reddit.com/r/javascript/comments/c8drjo/nobody_talks_about_the_real_reason_to_use_tabs/" lang="en"><cite>Nobody talks about the real reason to use Tabs over Spaces</cite></Anchor>（2019年）</NoteRefContent>
 		</Section>
 
-		<Section id="html-minify" depth={2} headingType="b">
+		<Section id="html-minify" depth={2}>
 			<Fragment slot="heading">最小化</Fragment>
 
 			<p>当サイトでは HTML の最小化を行っていない。……とわざわざ宣言しなければならないほど、昨今のフロントエンドフレームワークでは出力される HTML を自動的に最小化するのが当然の風潮がある。しかし最小化はデメリットも多く、あくまで最終手段と考えている。</p>
@@ -207,7 +207,7 @@ const slugger = new GithubSlugger();
 			<p><code>w0s.jp</code> ではフロントエンドフレームワークに <Anchor href="https://astro.build/">Astro</Anchor> を使用しているのだが、デフォルト設定では例に漏れず最小化されてしまうため <Anchor href="https://docs.astro.build/en/reference/configuration-reference/#compresshtml"><code>compressHTML</code></Anchor> を無効にしている。さらに事前レンダリングする静的ページでは <Anchor href="https://prettier.io/">Prettier</Anchor> による整形処理をビルド工程に挟んでいる。</p>
 		</Section>
 
-		<Section id="html-external" depth={2} headingType="b">
+		<Section id="html-external" depth={2}>
 			<Fragment slot="heading">外部リンク</Fragment>
 
 			<p>当サイトでは外部サイトのリンクに <code>target=_blank</code> の属性を設定していない。</p>
@@ -226,7 +226,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section id="html-redirect" depth={2} headingType="b">
+		<Section id="html-redirect" depth={2}>
 			<Fragment slot="heading">3xx リダイレクト画面</Fragment>
 
 			<p>URL が変更になった場合は 301 Moved Permanently、フォームの POST 送信後には 303 See Other などいくつかのケースでは HTTP レスポンスでリダイレクトを設定している。</p>
@@ -253,7 +253,7 @@ const slugger = new GithubSlugger();
 			<p>しかし近年の Web フレームワークはリダイレクト先のリンクが含まれていなかったり、好ましくない HTML を返していたり、あるいはレスポンスコンテンツ自体が空だったりといった有様である。そのため当サイトでは Express, Hono ともデフォルトで用意されているリダイレクト機能は使わず、前者は <Anchor href="https://expressjs.com/en/5x/api/response/#ressendbody"><code>res.send()</code></Anchor> メソッド、後者は <Anchor href="https://hono.dev/docs/api/context#html"><code>c.html()</code></Anchor> メソッドの第2〜3引数を活用する形で独自の HTML を返すようにカスタマイズしている。</p>
 		</Section>
 
-		<Section id="html-clienterror" depth={2} headingType="b">
+		<Section id="html-clienterror" depth={2}>
 			<Fragment slot="heading">4xx クライアントエラー画面</Fragment>
 
 			<p>404 Not Found のエラー画面には JavaScript で以下の機能を組み込んでいる。</p>
@@ -264,7 +264,7 @@ const slugger = new GithubSlugger();
 			</List>
 		</Section>
 
-		<Section id="html-lint" depth={2} headingType="b">
+		<Section id="html-lint" depth={2}>
 			<Fragment slot="heading">Lint</Fragment>
 
 			<p><Anchor href="https://markuplint.dev/">Markuplint</Anchor>を使用したチェックを実施している。</p>
@@ -298,7 +298,7 @@ const slugger = new GithubSlugger();
 	<Section id="style">
 		<Fragment slot="heading">スタイルシート<small>（CSS）</small></Fragment>
 
-		<Section id="style-darktheme" depth={2} headingType="b">
+		<Section id="style-darktheme" depth={2}>
 			<Fragment slot="heading">ダークテーマ</Fragment>
 
 			<p>いわゆるダークテーマを制作者スタイルシートで提供するサイトが多いが、本来は OS やブラウザが提供すべきものと考えており、当サイトにおいてテーマの切り替え機構を提供するつもりはない。</p>
@@ -358,7 +358,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="darktheme-blog-border">当サイトのブログ記事：<Anchor href="https://blog.w0s.jp/entry/765"><cite>ブラウザの強制ダークテーマ対策で <code>border-color: transparent</code> を避ける</cite></Anchor>（2026年）</NoteRefContent>
 		</Section>
 
-		<Section id="style-reader" depth={2} headingType="b">
+		<Section id="style-reader" depth={2}>
 			<Fragment slot="heading">リーダー表示</Fragment>
 
 			<p>昨今のブラウザはリーダーモードを備えたものも多いが、制作者の意図どおりに表示されるとは限らないため、それとは別個に制作者スタイルシートにてリーダー表示を実装している。</p>
@@ -366,13 +366,13 @@ const slugger = new GithubSlugger();
 			<p>ヘッダーやフッターを非表示にする簡易なスタイルシートを用意し、<Anchor href="https://html.spec.whatwg.org/multipage/links.html#the-link-is-an-alternative-stylesheet">代替スタイルシート</Anchor>で任意に適用可能な状態としている。PC 版 Firefox ではメニューバーの「表示」→「スタイルシート」から切り替え可能である。他ブラウザでも拡張機能が公開されている。</p>
 		</Section>
 
-		<Section id="style-print" depth={2} headingType="b">
+		<Section id="style-print" depth={2}>
 			<Fragment slot="heading">印刷用スタイル</Fragment>
 
 			<p>ディスプレイ表示の眩しさを低減するため、ページの背景色は白色ではなく、若干黄味がかった色を設定している。印刷時にはそのような配慮は不要なので Media Queries の <code>@media print</code> を使い完全な白（<code>#ffffff</code>）に設定している。</p>
 		</Section>
 
-		<Section id="style-class" depth={2} headingType="b">
+		<Section id="style-class" depth={2}>
 			<Fragment slot="heading">クラス名</Fragment>
 
 			<p><code>class</code> 属性値の命名規則にはさまざまな考え方があるが、当サイトではユーティリティーファーストを採用していない。</p>
@@ -390,7 +390,7 @@ const slugger = new GithubSlugger();
 			<p>もっともこれらを考慮すると、巷で言われているユーティリティーファーストの利点はだいぶ薄れてしまう。当サイトでそれを採用していないのは単純に実装コスト面で判断した結果に過ぎない。</p>
 		</Section>
 
-		<Section id="style-build" depth={2} headingType="b">
+		<Section id="style-build" depth={2}>
 			<Fragment slot="heading">ビルド</Fragment>
 
 			<p>CSS ファイルのビルドには <Anchor href="https://postcss.org/">PostCSS</Anchor>を使用している。</p>
@@ -398,7 +398,7 @@ const slugger = new GithubSlugger();
 			<p>複数のプラグインを使用しているが、それらはブラウザが対応していない機能の先行使用、あるいはパフォーマンス向上等が目的であり、標準化の見込みのないプラグインは使っていない。いざとなればビルド前のコードをそのままブラウザに読み込ませても問題ないような作り方をしている。</p>
 		</Section>
 
-		<Section id="style-minify" depth={2} headingType="b">
+		<Section id="style-minify" depth={2}>
 			<Fragment slot="heading">最小化</Fragment>
 
 			<p>当サイトでは CSS の最小化を行っていない。理由は <a href="#html-minify">HTML のそれ</a>と同じである。</p>
@@ -408,7 +408,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="css-minify-blog">当サイトのブログ記事：<Anchor href="https://blog.w0s.jp/entry/674"><cite>CSS ファイルの最小化を止めた</cite></Anchor>（2022年）</NoteRefContent>
 		</Section>
 
-		<Section id="style-comment" depth={2} headingType="b">
+		<Section id="style-comment" depth={2}>
 			<Fragment slot="heading">コメント</Fragment>
 
 			<p>最小化にも関連する話だが、HTML と同様に CSS もユーザーが直接閲覧するものであるため、ビルド工程でコメントを一律に削除することはせず、以下の2種に分類して処理している。</p>
@@ -439,7 +439,7 @@ const slugger = new GithubSlugger();
 			/>
 		</Section>
 
-		<Section id="style-lint" depth={2} headingType="b">
+		<Section id="style-lint" depth={2}>
 			<Fragment slot="heading">Lint</Fragment>
 
 			<p><Anchor href="https://stylelint.io/">Stylelint</Anchor>を使用したチェックを実施している。<Anchor href="https://github.com/stylelint/stylelint-config-standard"><code>stylelint-config-standard</code></Anchor> で定義されている一般的な慣習とは別に、当サイトでは<Anchor href="https://github.com/SaekiTominaga/config/tree/main/packages/stylelint">独自のルール</Anchor>を多数設定している。</p>
@@ -462,7 +462,7 @@ const slugger = new GithubSlugger();
 	<Section id="script">
 		<Fragment slot="heading">スクリプト<small>（JavaScript）</small></Fragment>
 
-		<Section id="script-disabled" depth={2} headingType="b">
+		<Section id="script-disabled" depth={2}>
 			<Fragment slot="heading">JavaScript 無効環境および類似ケースに対する考え方</Fragment>
 
 			<p>当サイトでは JavaScript は補助的な使用とし、スクリプトの全部ないし一部が動かない場合でもコンテンツの閲覧に支障がないようにしている。すなわち Client Side Rendering 方式のようにユーザーに JavaScript の動作を強要する作り方はしていない。</p>
@@ -513,7 +513,7 @@ doSomething(); // 環境によってはここには到達しない`}
 			/>
 		</Section>
 
-		<Section id="script-error" depth={2} headingType="b">
+		<Section id="script-error" depth={2}>
 			<Fragment slot="heading">エラー検知</Fragment>
 
 			<p>作成したスクリプト機能は普段使いのブラウザでの軽い動作確認はしているが、きちんとしたテストは行っていない。というよりサーバーサイドプログラムとは異なり、ブラウザには様々な設定項目があり、また Bot 等を含めたあらゆる環境が存在するためそれらを網羅したテストの実施は現実的に不可能である。もとより前述のとおり JavaScript が動かなくてもコンテンツの閲覧には支障がないように作っているため、テストの実施は割り切り、せめて発生してしまったエラーは把握できるよう <code>error</code> イベントを検知し通知する機能を組み込んでいる。<Anchor href="https://github.com/SaekiTominaga/js-library-browser/tree/main/packages/report-js-error">この検知プログラムは GitHub で公開</Anchor>しているが、簡略化したコード例を下記に示す。</p>
@@ -548,7 +548,7 @@ doSomething(); // 環境によってはここには到達しない`}
 	<Section id="a11y">
 		<Fragment slot="heading">アクセシビリティ</Fragment>
 
-		<Section id="a11y-important" depth={2} headingType="b">
+		<Section id="a11y-important" depth={2}>
 			<Fragment slot="heading">アクセシビリティで重要視していること</Fragment>
 
 			<p>Web アクセシビリティでもっとも重要な点は「ユーザーの閲覧環境を問わないこと」だと考えている。決して「ユーザーの利便性を高めること」が目的なのではない。紙の本や TV など情報を伝える媒体にはそれぞれに特性があるが、こと閲覧環境の豊富さにおいて Web は他の追従を許さない。Web が Web であり続けるためにもこのことは最優先で守っていかなければならない。</p>
@@ -560,7 +560,7 @@ doSomething(); // 環境によってはここには到達しない`}
 			<p>さて、Web アクセシビリティではスクリーンリーダーをはじめとした支援技術の話題が事欠かない。しかし当サイトでは支援技術を特段に意識することはなく、読み上げの最適化も行っていない。本ページではここの章を含み見出しの横にはセルフリンクを設けているが、そのマークアップは単に <code>&lt;a href="#foo"&gt;§&lt;/a&gt;</code> としている。記号文字を読まないスクリーンリーダーの存在は承知しているが、だからといって <code>aria-label</code> 属性の追加といった対応は Web アクセシビリティとしてはナンセンスである。</p>
 		</Section>
 
-		<Section id="a11y-visuallyhidden" depth={2} headingType="b">
+		<Section id="a11y-visuallyhidden" depth={2}>
 			<Fragment slot="heading">Visually hidden テクニック</Fragment>
 
 			<p>当サイトではいわゆる Visually hidden のテクニックは使っていない。</p>

--- a/astro/src/pages/technology.astro
+++ b/astro/src/pages/technology.astro
@@ -35,25 +35,25 @@ const slugger = new GithubSlugger();
 	<Section id="history">
 		<Fragment slot="heading">歴史</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="d">
+		<Section slugger={slugger} depth={2} headingType="c">
 			<Fragment slot="heading">2001年2月</Fragment>
 
 			<p>前身のサイトを開設。<Anchor href="https://web.archive.org/web/20010202073300/http://www.cool.ne.jp/"><cite>COOL ONLINE</cite></Anchor>の無料会員枠を利用（容量20MB）。<q>地域コミュニティ</q>を謳っており、登録の際にまず都市を選択、それによってサブドメインが振り分けられた（e.g. <code>tokyo.cool.ne.jp</code>）。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="d">
+		<Section slugger={slugger} depth={2} headingType="c">
 			<Fragment slot="heading">2001年6月<!-- 1日 --></Fragment>
 
 			<p>掲載写真の増大により容量面で厳しくなり、<Anchor href="https://web.archive.org/web/20010421065319/http://freehp.goo.ne.jp/"><cite>goo フリーホームページ</cite></Anchor>に移転（容量50MB）。URL は <code is:raw>http://users.goo.ne.jp/${userId}</code> 形式だが、IP アドレスのドメインにリダイレクトされる（ブラウザのアドレスバーには IP アドレスの数字が表示される）というすごい仕様だった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="d">
+		<Section slugger={slugger} depth={2} headingType="c">
 			<Fragment slot="heading">2002年3月<!-- 26日 --></Fragment>
 
 			<p><Anchor href="http://www.nurs.or.jp/"><cite>ネットワーク利用技術研究会（NURS）</cite></Anchor>に移転。レンタルサーバーではなく研究・実験目的のサーバーであり、Telnet が制限なしに使えたので、root 権限が必要なこと以外は割となんでもできた。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="d">
+		<Section slugger={slugger} depth={2} headingType="c">
 			<Fragment slot="heading">2012年2月<!-- 12日 --></Fragment>
 
 			<p><cite>NURS</cite> はドメインがサブドメインで分ける方式ではなく全ユーザー共通であり、Cookie の導入がセキュリティ上の理由<NoteRef by="nurs-cookie" />で躊躇われることから<Anchor href="https://www.inetd.co.jp/"><cite>アイネットディー</cite></Anchor>に移転したうえで独自ドメインを取得。月額270円の格安サーバーにしては Cron の制限が緩いのがありがたかった。</p>
@@ -61,7 +61,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="nurs-cookie"><Anchor href="http://takagi-hiromitsu.jp/diary/20100501.html">高木浩光＠自宅の日記 - <cite>共用SSLサーバの危険性が理解されていない</cite></Anchor>で解説されているように、フレームを利用して他サイトから読み出すことが可能なため。</NoteRefContent>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="d">
+		<Section slugger={slugger} depth={2} headingType="c">
 			<Fragment slot="heading">2017年1月</Fragment>
 
 			<p>常時 TLS の波に乗り<Anchor href="https://vps.sakura.ad.jp/"><cite>さくらの VPS</cite></Anchor> に移転。<Anchor href="https://letsencrypt.org/">Let's Encrypt</Anchor>を利用して TLS 対応を行う。</p>

--- a/astro/src/pages/tokyu/an/iketama_compare.astro
+++ b/astro/src/pages/tokyu/an/iketama_compare.astro
@@ -26,9 +26,9 @@ const slugger = new GithubSlugger();
 
 		<p>池上線、多摩川線では、始発駅と旗の台、雪が谷大塚発車時にワンマン運転の案内放送が行われますが、このうち旗の台発車時においては、1000系のみ<q>お降りになりましたら…</q>の文言が用いられています。以下に下り列車の例を示します。</p>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
 
 					<Box>
@@ -39,7 +39,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">1000系</Fragment>
 
 					<Box>
@@ -57,9 +57,9 @@ const slugger = new GithubSlugger();
 
 		<p>池上線雪が谷大塚止まりの列車は、下り列車のみ一部駅の停車中に注意放送が流れます。7600系、7700系は旗の台と石川台、1000系は旗の台のみですが、車内放送に続いて車外放送も流れるのが特徴です。以下に旗の台停車中の例を示します。</p>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
 
 					<Box>
@@ -68,7 +68,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">1000系</Fragment>
 
 					<Box>
@@ -86,9 +86,9 @@ const slugger = new GithubSlugger();
 
 		<p>蒲田駅で折り返し池上線 – 多摩川線を通し運転する列車は、始発駅発車時などに蒲田折り返し後の行先を案内しますが、7600系、7700系は後に続くはずのワンマン案内が省略されます。以下に五反田発、蒲田折り返し、多摩川行き列車における旗の台発車時の例を示します。</p>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
 
 					<Box>
@@ -99,7 +99,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">1000系</Fragment>
 
 					<Box>

--- a/astro/src/pages/tokyu/an/iketama_compare.astro
+++ b/astro/src/pages/tokyu/an/iketama_compare.astro
@@ -28,7 +28,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
 
 					<Box>
@@ -39,7 +39,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1000系</Fragment>
 
 					<Box>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
 
 					<Box>
@@ -68,7 +68,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1000系</Fragment>
 
 					<Box>
@@ -88,7 +88,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
 
 					<Box>
@@ -99,7 +99,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1000系</Fragment>
 
 					<Box>

--- a/astro/src/pages/tokyu/an/index.astro
+++ b/astro/src/pages/tokyu/an/index.astro
@@ -23,7 +23,7 @@ const slugger = new GithubSlugger();
 	<Section id="tokyu">
 		<Fragment slot="heading">東急電鉄</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">東横線</Fragment>
 
 			<IndexTable>
@@ -71,7 +71,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">目黒線</Fragment>
 
 			<IndexTable>
@@ -121,7 +121,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線</Fragment>
 
 			<IndexTable>
@@ -163,7 +163,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">大井町線</Fragment>
 
 			<IndexTable>
@@ -205,7 +205,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">池上線</Fragment>
 
 			<IndexTable>
@@ -251,7 +251,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">東急多摩川線</Fragment>
 
 			<IndexTable>
@@ -297,7 +297,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">こどもの国線</Fragment>
 
 			<IndexTable>
@@ -324,7 +324,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">世田谷線</Fragment>
 
 			<IndexTable>
@@ -369,7 +369,7 @@ const slugger = new GithubSlugger();
 	<Section id="transfer">
 		<Fragment slot="heading">譲渡車両</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">十和田観光電鉄<small>（2012年廃線）</small></Fragment>
 
 			<IndexTable>
@@ -395,7 +395,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">弘南鉄道（弘南線）</Fragment>
 
 			<IndexTable>
@@ -439,7 +439,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">弘南鉄道（大鰐線）</Fragment>
 
 			<IndexTable>
@@ -485,7 +485,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">福島交通</Fragment>
 
 			<IndexTable>
@@ -553,7 +553,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">秩父鉄道</Fragment>
 
 			<IndexTable>
@@ -582,7 +582,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">富山地方鉄道</Fragment>
 
 			<IndexTable>
@@ -630,7 +630,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">北陸鉄道（石川線）</Fragment>
 
 			<IndexTable>
@@ -666,7 +666,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">上田電鉄</Fragment>
 
 			<IndexTable>
@@ -710,7 +710,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">長野電鉄</Fragment>
 
 			<IndexTable>
@@ -739,7 +739,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">伊豆急行</Fragment>
 
 			<IndexTable>
@@ -773,7 +773,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">大井川鐵道（大井川本線）</Fragment>
 
 			<IndexTable>
@@ -809,7 +809,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">養老鉄道</Fragment>
 
 			<IndexTable>
@@ -845,7 +845,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">伊賀鉄道</Fragment>
 
 			<IndexTable>
@@ -871,7 +871,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">水間鉄道</Fragment>
 
 			<IndexTable>
@@ -932,7 +932,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">熊本電気鉄道（菊池線）<small>（2016年東急譲渡車引退）</small></Fragment>
 
 			<IndexTable>

--- a/astro/src/pages/tokyu/an/index.astro
+++ b/astro/src/pages/tokyu/an/index.astro
@@ -23,7 +23,7 @@ const slugger = new GithubSlugger();
 	<Section id="tokyu">
 		<Fragment slot="heading">東急電鉄</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">東横線</Fragment>
 
 			<IndexTable>
@@ -71,7 +71,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">目黒線</Fragment>
 
 			<IndexTable>
@@ -121,7 +121,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線</Fragment>
 
 			<IndexTable>
@@ -163,7 +163,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">大井町線</Fragment>
 
 			<IndexTable>
@@ -205,7 +205,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">池上線</Fragment>
 
 			<IndexTable>
@@ -251,7 +251,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">東急多摩川線</Fragment>
 
 			<IndexTable>
@@ -297,7 +297,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">こどもの国線</Fragment>
 
 			<IndexTable>
@@ -324,7 +324,7 @@ const slugger = new GithubSlugger();
 			</IndexTable>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">世田谷線</Fragment>
 
 			<IndexTable>
@@ -369,7 +369,7 @@ const slugger = new GithubSlugger();
 	<Section id="transfer">
 		<Fragment slot="heading">譲渡車両</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">十和田観光電鉄<small>（2012年廃線）</small></Fragment>
 
 			<IndexTable>
@@ -395,7 +395,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">弘南鉄道（弘南線）</Fragment>
 
 			<IndexTable>
@@ -439,7 +439,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">弘南鉄道（大鰐線）</Fragment>
 
 			<IndexTable>
@@ -485,7 +485,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">福島交通</Fragment>
 
 			<IndexTable>
@@ -553,7 +553,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">秩父鉄道</Fragment>
 
 			<IndexTable>
@@ -582,7 +582,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">富山地方鉄道</Fragment>
 
 			<IndexTable>
@@ -630,7 +630,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">北陸鉄道（石川線）</Fragment>
 
 			<IndexTable>
@@ -666,7 +666,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">上田電鉄</Fragment>
 
 			<IndexTable>
@@ -710,7 +710,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">長野電鉄</Fragment>
 
 			<IndexTable>
@@ -739,7 +739,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">伊豆急行</Fragment>
 
 			<IndexTable>
@@ -773,7 +773,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">大井川鐵道（大井川本線）</Fragment>
 
 			<IndexTable>
@@ -809,7 +809,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">養老鉄道</Fragment>
 
 			<IndexTable>
@@ -845,7 +845,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">伊賀鉄道</Fragment>
 
 			<IndexTable>
@@ -871,7 +871,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">水間鉄道</Fragment>
 
 			<IndexTable>
@@ -932,7 +932,7 @@ const slugger = new GithubSlugger();
 				</tbody>
 			</IndexTable>
 		</Section>
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">熊本電気鉄道（菊池線）<small>（2016年東急譲渡車引退）</small></Fragment>
 
 			<IndexTable>

--- a/astro/src/pages/tokyu/an/menu.astro
+++ b/astro/src/pages/tokyu/an/menu.astro
@@ -29,7 +29,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -38,7 +38,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>
@@ -54,7 +54,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -63,7 +63,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>
@@ -79,7 +79,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -88,7 +88,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>
@@ -104,7 +104,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -113,7 +113,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>
@@ -129,7 +129,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -138,7 +138,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>

--- a/astro/src/pages/tokyu/an/menu.astro
+++ b/astro/src/pages/tokyu/an/menu.astro
@@ -27,9 +27,9 @@ const slugger = new GithubSlugger();
 	<Section id="portable">
 		<Fragment slot="heading">携帯電話<small>（通常時）</small></Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -38,7 +38,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>
@@ -52,9 +52,9 @@ const slugger = new GithubSlugger();
 	<Section id="trans">
 		<Fragment slot="heading">全国交通安全運動<small>（例年4月上旬、9月下旬）</small></Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -63,7 +63,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>
@@ -77,9 +77,9 @@ const slugger = new GithubSlugger();
 	<Section id="summer">
 		<Fragment slot="heading">夏季の輸送対策と安全運動<small>（例年7月下旬）</small></Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -88,7 +88,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>
@@ -102,9 +102,9 @@ const slugger = new GithubSlugger();
 	<Section id="fire">
 		<Fragment slot="heading">全国火災予防運動<small>（例年11月中旬、3月上旬）</small></Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -113,7 +113,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>
@@ -127,9 +127,9 @@ const slugger = new GithubSlugger();
 	<Section id="year">
 		<Fragment slot="heading">年末年始輸送安全総点検<small>（例年12月下旬〜1月上旬）</small></Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Box>
@@ -138,7 +138,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">目黒線</Fragment>
 
 					<Box>

--- a/astro/src/pages/tokyu/an/sound.astro
+++ b/astro/src/pages/tokyu/an/sound.astro
@@ -24,10 +24,10 @@ const slugger = new GithubSlugger();
 	<Section id="tokyu">
 		<Fragment slot="heading">東急電鉄</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">東横線</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">通勤特急列車の英語放送</Fragment>
 
 				<p>ラッシュ時に運転される通勤特急列車では、基本的に英語放送が省略されますが、始発駅停車中のみ流れる場合があります。</p>
@@ -42,7 +42,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">日比谷線直通、種別案内が<q>各駅停車</q>のみ</Fragment>
 
 				<p>上り日比谷線直通列車における武蔵小杉駅停車中の案内では、東急車のみ種別案内に<q>日比谷線直通</q>が含まれていませんでした。2008年の横浜市交グリーンライン開業に伴う変更で修正されています。</p>
@@ -57,10 +57,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">目黒線</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">下り奥沢止まりの放送</Fragment>
 
 				<p>下り奥沢行きのうち、上りホームの3番線に到着する列車では、下車しない場合もいったん改札を出る必要がありました。これは2006年の急行運転開始前のバージョンです。</p>
@@ -76,10 +76,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">準急列車の放送</Fragment>
 
 				<p>平日朝間に上りのみ設定されている準急列車の放送のうち、通過駅のある区間は急行列車に似た内容となっていますが、二子玉川到着時のみ各駅停車になる旨の案内が行われます。</p>
@@ -94,10 +94,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">大井町線</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">お立ちのお客様は、吊り革・手摺りにお掴まりください。</Fragment>
 
 				<p>カーブの続く上野毛〜二子玉川間では、立客向けの注意放送が行われていました。同様の案内は東横線の一部区間でも行われていましたが、現在ではこどもの国線の始発駅発車時に残るのみとなっています。</p>
@@ -112,7 +112,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">路線名を言わない</Fragment>
 
 				<p>2009年の溝の口延伸以前、鷺沼始発の大井町線直通列車は、始発駅発車時の案内で路線名を省略し、<q>東急線</q>と放送されていました。</p>
@@ -127,7 +127,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">不自然な間のある放送</Fragment>
 
 				<p>大井町線旗の台駅はもともと2面2線の対向式ホームで、上り列車は北千束発車時の自動放送で<q>お出口は左側に変わります。</q>と案内していました。駅改良工事に伴い2006年に開扉方向が変わった際、当該部分が削除されましたが、その際に前後の切り詰めを行わなかったため、放送途中に不自然な間が生じていました。後に自動放送休止期間を経て、2009年の溝の口延伸の際に全面的な更新が成されています。</p>
@@ -143,10 +143,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">池上線</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">1000系ワンマン案内、<q>お降りになりましたら…</q></Fragment>
 
 				<p>池上、多摩川線では、主要駅発車時に<q>発車ベルが鳴り終わりましたら…</q>というワンマン運転の案内が流れますが、1000系のうち旗の台発車時のみは異なる文言となっています。</p>
@@ -162,10 +162,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">世田谷線</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">携帯電話マナー放送、<q>オレンジ色の吊り革付近は、…</q></Fragment>
 
 				<p>下り西太子堂発車時に流れる携帯電話マナー放送は、上り列車の<q>吊り革がオレンジ色の優先席付近では…</q>に対し、異なる文言となっています。</p>
@@ -184,10 +184,10 @@ const slugger = new GithubSlugger();
 	<Section id="transfer">
 		<Fragment slot="heading">譲渡車両</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">弘南鉄道（弘南線）</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">テープ時代の放送</Fragment>
 
 				<p>2008年の放送装置IC化以前の放送で、現在とは印象が異なるものです。</p>
@@ -202,10 +202,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">福島交通</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">飯坂温泉駅降車ホーム使用休止</Fragment>
 
 				<p>冬季は飯坂温泉駅の降車専用ホームが使用休止されるため、乗車ホームが降車兼用となります。到着時の案内文言はしばしば変更されており、ここでは2007年の放送装置IC化直前のバージョンを紹介します。</p>
@@ -220,10 +220,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">伊豆急行</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">快速列車の放送</Fragment>
 
 				<p>伊豆急行線では多客期などに臨時快速が運転されますが、近年は東急から譲渡された8000系が使われています。一部で停車駅案内を行うほか、通過駅がある場合に限り<q>次の停車駅は…</q>と案内されます。</p>
@@ -238,10 +238,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">北陸鉄道（石川線）</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">英語案内付きの放送</Fragment>
 
 				<p>北陸鉄道石川線では、主要駅の次駅放送に英語案内が含まれます。</p>
@@ -257,10 +257,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">熊本電気鉄道（菊池線）</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">男性声による放送</Fragment>
 
 				<p>熊本電気鉄道では、珍しく男性声による放送が行われています。また一部区間で宣伝放送が行われていましたが、2008年に中止されています。</p>

--- a/astro/src/pages/tokyu/an/sound.astro
+++ b/astro/src/pages/tokyu/an/sound.astro
@@ -24,10 +24,10 @@ const slugger = new GithubSlugger();
 	<Section id="tokyu">
 		<Fragment slot="heading">東急電鉄</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">東横線</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">通勤特急列車の英語放送</Fragment>
 
 				<p>ラッシュ時に運転される通勤特急列車では、基本的に英語放送が省略されますが、始発駅停車中のみ流れる場合があります。</p>
@@ -42,7 +42,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">日比谷線直通、種別案内が<q>各駅停車</q>のみ</Fragment>
 
 				<p>上り日比谷線直通列車における武蔵小杉駅停車中の案内では、東急車のみ種別案内に<q>日比谷線直通</q>が含まれていませんでした。2008年の横浜市交グリーンライン開業に伴う変更で修正されています。</p>
@@ -57,10 +57,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">目黒線</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">下り奥沢止まりの放送</Fragment>
 
 				<p>下り奥沢行きのうち、上りホームの3番線に到着する列車では、下車しない場合もいったん改札を出る必要がありました。これは2006年の急行運転開始前のバージョンです。</p>
@@ -76,10 +76,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">準急列車の放送</Fragment>
 
 				<p>平日朝間に上りのみ設定されている準急列車の放送のうち、通過駅のある区間は急行列車に似た内容となっていますが、二子玉川到着時のみ各駅停車になる旨の案内が行われます。</p>
@@ -94,10 +94,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">大井町線</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">お立ちのお客様は、吊り革・手摺りにお掴まりください。</Fragment>
 
 				<p>カーブの続く上野毛〜二子玉川間では、立客向けの注意放送が行われていました。同様の案内は東横線の一部区間でも行われていましたが、現在ではこどもの国線の始発駅発車時に残るのみとなっています。</p>
@@ -112,7 +112,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">路線名を言わない</Fragment>
 
 				<p>2009年の溝の口延伸以前、鷺沼始発の大井町線直通列車は、始発駅発車時の案内で路線名を省略し、<q>東急線</q>と放送されていました。</p>
@@ -127,7 +127,7 @@ const slugger = new GithubSlugger();
 				</Box>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">不自然な間のある放送</Fragment>
 
 				<p>大井町線旗の台駅はもともと2面2線の対向式ホームで、上り列車は北千束発車時の自動放送で<q>お出口は左側に変わります。</q>と案内していました。駅改良工事に伴い2006年に開扉方向が変わった際、当該部分が削除されましたが、その際に前後の切り詰めを行わなかったため、放送途中に不自然な間が生じていました。後に自動放送休止期間を経て、2009年の溝の口延伸の際に全面的な更新が成されています。</p>
@@ -143,10 +143,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">池上線</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">1000系ワンマン案内、<q>お降りになりましたら…</q></Fragment>
 
 				<p>池上、多摩川線では、主要駅発車時に<q>発車ベルが鳴り終わりましたら…</q>というワンマン運転の案内が流れますが、1000系のうち旗の台発車時のみは異なる文言となっています。</p>
@@ -162,10 +162,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">世田谷線</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">携帯電話マナー放送、<q>オレンジ色の吊り革付近は、…</q></Fragment>
 
 				<p>下り西太子堂発車時に流れる携帯電話マナー放送は、上り列車の<q>吊り革がオレンジ色の優先席付近では…</q>に対し、異なる文言となっています。</p>
@@ -184,10 +184,10 @@ const slugger = new GithubSlugger();
 	<Section id="transfer">
 		<Fragment slot="heading">譲渡車両</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">弘南鉄道（弘南線）</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">テープ時代の放送</Fragment>
 
 				<p>2008年の放送装置IC化以前の放送で、現在とは印象が異なるものです。</p>
@@ -202,10 +202,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">福島交通</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">飯坂温泉駅降車ホーム使用休止</Fragment>
 
 				<p>冬季は飯坂温泉駅の降車専用ホームが使用休止されるため、乗車ホームが降車兼用となります。到着時の案内文言はしばしば変更されており、ここでは2007年の放送装置IC化直前のバージョンを紹介します。</p>
@@ -220,10 +220,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">伊豆急行</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">快速列車の放送</Fragment>
 
 				<p>伊豆急行線では多客期などに臨時快速が運転されますが、近年は東急から譲渡された8000系が使われています。一部で停車駅案内を行うほか、通過駅がある場合に限り<q>次の停車駅は…</q>と案内されます。</p>
@@ -238,10 +238,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">北陸鉄道（石川線）</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">英語案内付きの放送</Fragment>
 
 				<p>北陸鉄道石川線では、主要駅の次駅放送に英語案内が含まれます。</p>
@@ -257,10 +257,10 @@ const slugger = new GithubSlugger();
 			</Section>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">熊本電気鉄道（菊池線）</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="c">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">男性声による放送</Fragment>
 
 				<p>熊本電気鉄道では、珍しく男性声による放送が行われています。また一部区間で宣伝放送が行われていましたが、2008年に中止されています。</p>

--- a/astro/src/pages/tokyu/book/tetsupic749/mm21.astro
+++ b/astro/src/pages/tokyu/book/tetsupic749/mm21.astro
@@ -129,10 +129,10 @@ const structuredData: StructuredData = {
 	<Section id="errata">
 		<Fragment slot="heading">正誤データ</Fragment>
 
-		<Section id="errata-toyoko-car" depth={2} headingType="b">
+		<Section id="errata-toyoko-car" depth={2}>
 			<Fragment slot="heading">1. 東横線関連の車両動向など</Fragment>
 
-			<Section id="errata-toyoko-car-8590change" depth={3} headingType="c">
+			<Section id="errata-toyoko-car-8590change" depth={3}>
 				<Fragment slot="heading">8694F, 8695Fの転籍</Fragment>
 
 				<Box>
@@ -147,10 +147,10 @@ const structuredData: StructuredData = {
 			</Section>
 		</Section>
 
-		<Section id="errata-sign" depth={2} headingType="b">
+		<Section id="errata-sign" depth={2}>
 			<Fragment slot="heading">4. 表示器の更新</Fragment>
 
-			<Section id="errata-sign-8000spcm" depth={3} headingType="c">
+			<Section id="errata-sign-8000spcm" depth={3}>
 				<Fragment slot="heading">8021F, 8023Fの字幕</Fragment>
 
 				<Box>

--- a/astro/src/pages/tokyu/book/tetsupic749/ttm.astro
+++ b/astro/src/pages/tokyu/book/tetsupic749/ttm.astro
@@ -42,7 +42,7 @@ const structuredData: StructuredData = {
 
 		<p>レプリカも含めた展示車両を紹介する。</p>
 
-		<Section id="deha3456" depth={2} headingType="b">
+		<Section id="deha3456" depth={2}>
 			<Fragment slot="heading">(1) デハ3450形3456号（カット車両）</Fragment>
 
 			<p>正面口（南口）を入ってまず目につくのがこのデハ3450形である。実車の頭部約1/3をカットして展示されている。運転台での操作により前方の車輪が動作し、また放送装置などの機器も扱えるようになっている。</p>
@@ -52,7 +52,7 @@ const structuredData: StructuredData = {
 			<p>ちなみに、3456号は1963(昭和38)年に、3450形の中で最初に車体・室内更新工事が行われた車両である。</p>
 		</Section>
 
-		<Section id="kuha8090" depth={2} headingType="b">
+		<Section id="kuha8090" depth={2}>
 			<Fragment slot="heading">(2) 8090系8090号（シミュレータ）</Fragment>
 
 			<p>運転シミュレーション体験ができ、当館の一番の目玉でもある。車体は8090系13次車（Tc2車）を元に制作され、車号は8090となっている。その後、実車でも8090号が登場したが、そちらは17次車（Tc1車）であり、別物である。</p>
@@ -64,7 +64,7 @@ const structuredData: StructuredData = {
 			<p>運転体験がメインな為、通常は電源を切られているが、字幕表示器や放送装置なども実際に動作する。なお、SRアンテナや冷房キセの再現は、高津時代のスペースの関係から省略されている。</p>
 		</Section>
 
-		<Section id="moha517" depth={2} headingType="b">
+		<Section id="moha517" depth={2}>
 			<Fragment slot="heading">(3) モハ510形517号（シミュレータ）</Fragment>
 
 			<p>先に記した3456号をカットした際、反対側切断面のうち3.7m分を510形時代に復元したものである。517号は3456号の旧番で、こちらはツーハンドルタイプの運転体験が行える。</p>
@@ -72,7 +72,7 @@ const structuredData: StructuredData = {
 			<p>当初はシミュレータ装置はなく、「最新型」8090系との室内構造の比較を目的に作られたようであるが、高津時代の館内リニューアルの際に8090系のスクリーンを更新するにあたり、従来使われていたもののお下がりを取り付けられた。また、その際に運転室部分の正面窓を二段窓から一段固定窓に変更されている。</p>
 		</Section>
 
-		<Section id="deha204" depth={2} headingType="b">
+		<Section id="deha204" depth={2}>
 			<Fragment slot="heading">(4) デハ200形204号</Fragment>
 
 			<p>玉川線で活躍していた204号車を展示保存している。</p>
@@ -82,7 +82,7 @@ const structuredData: StructuredData = {
 			<p>なお、同車は1969(昭和44)年の廃車後、多摩川園で保存されていたが、閉園に伴い高津駅コンコースへ。その後、モハ510号が同地に置かれることとなり、一旦倉庫地へ避難した後、1991(平成3)年に高津3号館へ移動された。更に博物館の移転により、2002(平成14)年11月に宮崎台に輸送されるという、幾度もの移動劇を繰り返している。</p>
 		</Section>
 
-		<Section id="moha510" depth={2} headingType="b">
+		<Section id="moha510" depth={2}>
 			<Fragment slot="heading">(5) モハ510形510号（復元車両）</Fragment>
 
 			<p>1989(平成元)年に引退したデハ3450形の1号車である3450号を登場時の姿に復元し、保存展示しているものである。高津時代は年に数回の公開時しか車内に立ち入れなかったが、現在では運転室も含め、常時公開されている。</p>
@@ -90,7 +90,7 @@ const structuredData: StructuredData = {
 			<p>屋外展示な為、客室内には空調装置が整備されたが、座席下に設置されており、外観上目立たないようになっている。周囲が暗くなると、室内常用白熱灯などが点灯し、ノスタルジックな気分に浸ることができる。なお、吊革は危険防止のため、宮崎台オープン直後に全て取り外されている。</p>
 		</Section>
 
-		<Section id="bus&airport" depth={2} headingType="b">
+		<Section id="bus&airport" depth={2}>
 			<Fragment slot="heading">(6) バス、航空機</Fragment>
 
 			<p>鉄道車両以外の実物展示品については、概要のみを簡素に述べる。</p>

--- a/astro/src/pages/tokyu/book/tetsupic789/mizuma1000.astro
+++ b/astro/src/pages/tokyu/book/tetsupic789/mizuma1000.astro
@@ -59,73 +59,73 @@ const slugger = new GithubSlugger();
 	<Section id="body">
 		<Fragment slot="heading">3. 車体</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">電気連結器</Fragment>
 
 			<p>東急時代、長らく中間に封じ込められていた7101、7102の正面には、西側、東側に1本ずつ電気連結器と栓納めが残されていたが、両車とも撤去された。なお、元東急7000系における海側ジャンパ栓の残存例としては、弘南鉄道大鰐線の7000系奇数車が挙げられるが、山側コネクタが残っていたのは水間鉄道の2両のみであった（<a href="#errata-body-ecoupler">※訂正あり</a>）。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">台枠部</Fragment>
 
 			<p>正面、連結方妻面の台枠部には金属板が貼られたが、7101、7102の正面西側にあった55芯ジャンパ栓納め撤去跡を隠すような形状となっている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">正面ステップ</Fragment>
 
 			<p>正面下部には、片足を掛けられる小型のステップが付いていたが、改造にあたり撤去された。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">正面窓</Fragment>
 
 			<p>Hゴム支持であった正面窓は、金属支持に変更されており、室外側、室内側ともに印象が変わっている。なお、窓Hゴムは他社譲渡車も含め大半が黒色であるが、改造前の7101は貫通扉窓のみ灰色であった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">ワイパーまわり</Fragment>
 
 			<p>ワイパーは間欠機能付きの電気式タイプに交換された。取付部は従来と同じ位置ながら、空気式に比べて大型となり、色も黒となった。また、正面窓下の風取入口跡に貼られた金属板のうち、運転台側の方はワイパー取付部まで伸びる長いものとなっている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">正面表示器</Fragment>
 
 			<p>正面の表示器窓は、正面窓と同じく金属支持になった。字幕は通常「水間⇔貝塚」固定であったが、LED表示に改造され、行先駅名のみを表示（水間行きなら「水間」と表示）するようになった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">レスポンスブロック受</Fragment>
 
 			<p>7101、7102の連結方妻面東側には、地下鉄日比谷線乗り入れの証しとも言えるレスポンスブロック受が残されていたが、両車とも撤去されてしまった。東急7700系改造車や他社譲渡車では、撤去跡に締められたボルトにその名残が見られる程度であるが、1002は金属片で塞がれており、目立つ存在である。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">転落防止装置</Fragment>
 
 			<p>各車の連結方妻面には、転落防止装置が設置された。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">車外Dコック</Fragment>
 
 			<p>連結方妻面の両脇には、Dコック管が床下から立ち上がっているが、転落防止装置に干渉しないようにするため、従来と比べて背が低いタイプに交換された。古い設置部にはボルトが締められているが、1001の東側は金属片によって塞がれている。また、弁の位置を示す印として三角形のシールが妻面・側面に跨がる形で貼られていたが、1000形車両では妻面端部への貼付となり、側面からは見えにくくなった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">昇降ステップ</Fragment>
 
 			<p>正面、連結方妻面の右側には昇降ステップが付いているが、ステップ上面の滑り止め形状にはバリエーションがあり、1002の妻面は他と異なる模様をしている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">妻面銘板</Fragment>
 
 			<p>連結方妻面右側には楕円形の製造銘板が留められているが、台枠部に金属板を貼った関係からか、もともと「東京急行電鉄」の楕円銘板が留められていた場所へ移動された。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">ロゴマーク</Fragment>
 
 			<p>側面の旧東急社紋掲出部には、水間鉄道のロゴマークが貼られていたが、1001、1002はコスモスをかたどったマークに変更された。</p>
@@ -135,13 +135,13 @@ const slugger = new GithubSlugger();
 	<Section id="roof">
 		<Fragment slot="heading">4. 屋根上機器</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">冷房装置</Fragment>
 
 			<p>1001、1002は、従来のベンチレータを撤去して東芝製のユニットクーラRPU-2204C（9,000kcal/h）が3台搭載された。装置形式やキセ形状は従来の冷改車と同じであるが、キセの色は7000系車両が青がかっているのに対し白色となった。また、製造が2006年と新しいためか、銘板の様式が他車と異なる。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">ヒューズ箱</Fragment>
 
 			<p>7000系非冷房車のヒューズ箱は、パンタグラフの車央方に設置されているが、1001は冷房装置搭載に伴い、従来の冷改車と同じく車端方に移設された。</p>
@@ -151,13 +151,13 @@ const slugger = new GithubSlugger();
 	<Section id="room">
 		<Fragment slot="heading">5. 客室内</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">側入口滑り止め</Fragment>
 
 			<p>床面は塗り替えられており、側入口にあった滑り止めは撤去された。なお、元東急7000系としては、北陸鉄道譲渡車も滑り止めを撤去されている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">運客仕切、妻面</Fragment>
 
 			<p>運客仕切の車掌台側にある非常用の赤玉コックは引き続き残されている。なお、同様のコックは、同時期に譲渡された北陸鉄道向け車両にも存在するが、そちらには透明のカバーが付けられている。</p>
@@ -169,31 +169,31 @@ const slugger = new GithubSlugger();
 			<p>禁煙標記も取り替えられ、禁煙マーク付きのシールが運客仕切にのみ貼られている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">車椅子スペース</Fragment>
 
 			<p>運客仕切と側客戸の間に存在する空間を活用して車椅子スペースが用意され、側壁には手すりが設けられた。このように、座席を撤去することなく容易に工事を行う例は、豊橋鉄道渥美線譲渡車でも見られる。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">妻窓</Fragment>
 
 			<p>東急時代の更新工事時に、妻窓・側窓の下段が固定式とされたことは前述のとおりであるが、レスポンスブロック受がある部分は、引き続き下段も開くようになっていた。しかし、レスポンスブロック受が撤去され転落防止装置が設置されたため、ガイドレールにストッパを嵌め、開閉はできなくなった。ただし、窓戸錠は残っている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">側引戸</Fragment>
 
 			<p>側引戸鴨居のドアエンジン点検蓋底面には、灯具が設置され、扉扱い時には赤く点滅する。また、同時にチャイムが鳴る。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">側灯点検蓋</Fragment>
 
 			<p>室外には車体側灯として戸閉灯が存在するが、室内には点検蓋が設置されている。室内化粧板の張り替えに伴い蓋が一新され、従来にない形状となった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">座席</Fragment>
 
 			<p>モケットは橙系のものに交換されており、室内の暖色系化に貢献している。袖仕切や蹴込板なども含めた構造自体に変化は見られない。</p>
@@ -201,13 +201,13 @@ const slugger = new GithubSlugger();
 			<p>貝塚向き先頭車の連結方車端部は優先座席となっており、モケット色が淡い青系で区別されている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">吊手</Fragment>
 
 			<p>レール方向吊手のスリーブは、広告が彫り込まれていない無地のものとなったが、デビュー直後には他車と同様に沿線企業の広告シールが貼られている。側入口付近の枕木方向には吊手棒が増設されていたが、吊手は設置されていない。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">天井</Fragment>
 
 			<p>冷房化にあたり、天井部は冷風口の設置や旋回扇・中吊広告受などの移動が行われた。配置は、入線後に自社で冷改された7001、7101にそれぞれ準じたものとなっており、譲渡時に冷改された車両と比べると、連結方車端部の中吊広告受が一つ少ない。</p>
@@ -240,10 +240,10 @@ const slugger = new GithubSlugger();
 	<Section id="errata">
 		<Fragment slot="heading">正誤データ</Fragment>
 
-		<Section id="errata-body" depth={2} headingType="b">
+		<Section id="errata-body" depth={2}>
 			<Fragment slot="heading">3. 車体</Fragment>
 
-			<Section id="errata-body-ecoupler" depth={3} headingType="c">
+			<Section id="errata-body-ecoupler" depth={3}>
 				<Fragment slot="heading">電気連結器</Fragment>
 
 				<Box>

--- a/astro/src/pages/tokyu/book/tetsupic789/mizuma1000.astro
+++ b/astro/src/pages/tokyu/book/tetsupic789/mizuma1000.astro
@@ -59,73 +59,73 @@ const slugger = new GithubSlugger();
 	<Section id="body">
 		<Fragment slot="heading">3. 車体</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">電気連結器</Fragment>
 
 			<p>東急時代、長らく中間に封じ込められていた7101、7102の正面には、西側、東側に1本ずつ電気連結器と栓納めが残されていたが、両車とも撤去された。なお、元東急7000系における海側ジャンパ栓の残存例としては、弘南鉄道大鰐線の7000系奇数車が挙げられるが、山側コネクタが残っていたのは水間鉄道の2両のみであった（<a href="#errata-body-ecoupler">※訂正あり</a>）。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">台枠部</Fragment>
 
 			<p>正面、連結方妻面の台枠部には金属板が貼られたが、7101、7102の正面西側にあった55芯ジャンパ栓納め撤去跡を隠すような形状となっている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">正面ステップ</Fragment>
 
 			<p>正面下部には、片足を掛けられる小型のステップが付いていたが、改造にあたり撤去された。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">正面窓</Fragment>
 
 			<p>Hゴム支持であった正面窓は、金属支持に変更されており、室外側、室内側ともに印象が変わっている。なお、窓Hゴムは他社譲渡車も含め大半が黒色であるが、改造前の7101は貫通扉窓のみ灰色であった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">ワイパーまわり</Fragment>
 
 			<p>ワイパーは間欠機能付きの電気式タイプに交換された。取付部は従来と同じ位置ながら、空気式に比べて大型となり、色も黒となった。また、正面窓下の風取入口跡に貼られた金属板のうち、運転台側の方はワイパー取付部まで伸びる長いものとなっている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">正面表示器</Fragment>
 
 			<p>正面の表示器窓は、正面窓と同じく金属支持になった。字幕は通常「水間⇔貝塚」固定であったが、LED表示に改造され、行先駅名のみを表示（水間行きなら「水間」と表示）するようになった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">レスポンスブロック受</Fragment>
 
 			<p>7101、7102の連結方妻面東側には、地下鉄日比谷線乗り入れの証しとも言えるレスポンスブロック受が残されていたが、両車とも撤去されてしまった。東急7700系改造車や他社譲渡車では、撤去跡に締められたボルトにその名残が見られる程度であるが、1002は金属片で塞がれており、目立つ存在である。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">転落防止装置</Fragment>
 
 			<p>各車の連結方妻面には、転落防止装置が設置された。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">車外Dコック</Fragment>
 
 			<p>連結方妻面の両脇には、Dコック管が床下から立ち上がっているが、転落防止装置に干渉しないようにするため、従来と比べて背が低いタイプに交換された。古い設置部にはボルトが締められているが、1001の東側は金属片によって塞がれている。また、弁の位置を示す印として三角形のシールが妻面・側面に跨がる形で貼られていたが、1000形車両では妻面端部への貼付となり、側面からは見えにくくなった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">昇降ステップ</Fragment>
 
 			<p>正面、連結方妻面の右側には昇降ステップが付いているが、ステップ上面の滑り止め形状にはバリエーションがあり、1002の妻面は他と異なる模様をしている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">妻面銘板</Fragment>
 
 			<p>連結方妻面右側には楕円形の製造銘板が留められているが、台枠部に金属板を貼った関係からか、もともと「東京急行電鉄」の楕円銘板が留められていた場所へ移動された。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">ロゴマーク</Fragment>
 
 			<p>側面の旧東急社紋掲出部には、水間鉄道のロゴマークが貼られていたが、1001、1002はコスモスをかたどったマークに変更された。</p>
@@ -135,13 +135,13 @@ const slugger = new GithubSlugger();
 	<Section id="roof">
 		<Fragment slot="heading">4. 屋根上機器</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">冷房装置</Fragment>
 
 			<p>1001、1002は、従来のベンチレータを撤去して東芝製のユニットクーラRPU-2204C（9,000kcal/h）が3台搭載された。装置形式やキセ形状は従来の冷改車と同じであるが、キセの色は7000系車両が青がかっているのに対し白色となった。また、製造が2006年と新しいためか、銘板の様式が他車と異なる。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">ヒューズ箱</Fragment>
 
 			<p>7000系非冷房車のヒューズ箱は、パンタグラフの車央方に設置されているが、1001は冷房装置搭載に伴い、従来の冷改車と同じく車端方に移設された。</p>
@@ -151,13 +151,13 @@ const slugger = new GithubSlugger();
 	<Section id="room">
 		<Fragment slot="heading">5. 客室内</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">側入口滑り止め</Fragment>
 
 			<p>床面は塗り替えられており、側入口にあった滑り止めは撤去された。なお、元東急7000系としては、北陸鉄道譲渡車も滑り止めを撤去されている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">運客仕切、妻面</Fragment>
 
 			<p>運客仕切の車掌台側にある非常用の赤玉コックは引き続き残されている。なお、同様のコックは、同時期に譲渡された北陸鉄道向け車両にも存在するが、そちらには透明のカバーが付けられている。</p>
@@ -169,31 +169,31 @@ const slugger = new GithubSlugger();
 			<p>禁煙標記も取り替えられ、禁煙マーク付きのシールが運客仕切にのみ貼られている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">車椅子スペース</Fragment>
 
 			<p>運客仕切と側客戸の間に存在する空間を活用して車椅子スペースが用意され、側壁には手すりが設けられた。このように、座席を撤去することなく容易に工事を行う例は、豊橋鉄道渥美線譲渡車でも見られる。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">妻窓</Fragment>
 
 			<p>東急時代の更新工事時に、妻窓・側窓の下段が固定式とされたことは前述のとおりであるが、レスポンスブロック受がある部分は、引き続き下段も開くようになっていた。しかし、レスポンスブロック受が撤去され転落防止装置が設置されたため、ガイドレールにストッパを嵌め、開閉はできなくなった。ただし、窓戸錠は残っている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">側引戸</Fragment>
 
 			<p>側引戸鴨居のドアエンジン点検蓋底面には、灯具が設置され、扉扱い時には赤く点滅する。また、同時にチャイムが鳴る。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">側灯点検蓋</Fragment>
 
 			<p>室外には車体側灯として戸閉灯が存在するが、室内には点検蓋が設置されている。室内化粧板の張り替えに伴い蓋が一新され、従来にない形状となった。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">座席</Fragment>
 
 			<p>モケットは橙系のものに交換されており、室内の暖色系化に貢献している。袖仕切や蹴込板なども含めた構造自体に変化は見られない。</p>
@@ -201,13 +201,13 @@ const slugger = new GithubSlugger();
 			<p>貝塚向き先頭車の連結方車端部は優先座席となっており、モケット色が淡い青系で区別されている。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">吊手</Fragment>
 
 			<p>レール方向吊手のスリーブは、広告が彫り込まれていない無地のものとなったが、デビュー直後には他車と同様に沿線企業の広告シールが貼られている。側入口付近の枕木方向には吊手棒が増設されていたが、吊手は設置されていない。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">天井</Fragment>
 
 			<p>冷房化にあたり、天井部は冷風口の設置や旋回扇・中吊広告受などの移動が行われた。配置は、入線後に自社で冷改された7001、7101にそれぞれ準じたものとなっており、譲渡時に冷改された車両と比べると、連結方車端部の中吊広告受が一つ少ない。</p>

--- a/astro/src/pages/tokyu/book/tetsupic851/tokyu_transfer.astro
+++ b/astro/src/pages/tokyu/book/tetsupic851/tokyu_transfer.astro
@@ -270,10 +270,10 @@ const structuredData: StructuredData = {
 	<Section id="errata">
 		<Fragment slot="heading">正誤データ</Fragment>
 
-		<Section id="errata-ueda" depth={2} headingType="b">
+		<Section id="errata-ueda" depth={2}>
 			<Fragment slot="heading">上田電鉄</Fragment>
 
-			<Section id="errata-ueda-moquette" depth={3} headingType="c">
+			<Section id="errata-ueda-moquette" depth={3}>
 				<Fragment slot="heading">7200系「まるまどりーむ号」の座席モケット</Fragment>
 
 				<Box>

--- a/astro/src/pages/tokyu/data/acu_8500.astro
+++ b/astro/src/pages/tokyu/data/acu_8500.astro
@@ -38,7 +38,7 @@ const slugger = new GithubSlugger();
 	<Section id="8637F">
 		<Fragment slot="heading">8637F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点</Fragment>
 
 			<Embedded>
@@ -46,7 +46,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2019年時点</Fragment>
 
 			<!-- 2018-12-03, 2019-01-10, 2019-07-19 -->
@@ -56,7 +56,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2022年時点</Fragment>
 
 			<!-- 2022-07-29 -->
@@ -66,7 +66,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2026年時点</Fragment>
 
 			<!-- 2026-05-03 -->
@@ -88,7 +88,7 @@ const slugger = new GithubSlugger();
 	<Section id="8638F">
 		<Fragment slot="heading">8638F<small>（2019年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点</Fragment>
 
 			<Embedded>
@@ -96,7 +96,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2019年時点</Fragment>
 
 			<!-- 2018-12-03, 2019-01-10 -->
@@ -114,7 +114,7 @@ const slugger = new GithubSlugger();
 	<Section id="8639F">
 		<Fragment slot="heading">8639F<small>（2018年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点</Fragment>
 
 			<Embedded>
@@ -128,7 +128,7 @@ const slugger = new GithubSlugger();
 	<Section id="8640F">
 		<Fragment slot="heading">8640F<small>（2019年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点、2019年時点</Fragment>
 
 			<!-- 2019-01-10 -->
@@ -144,7 +144,7 @@ const slugger = new GithubSlugger();
 	<Section id="8641F">
 		<Fragment slot="heading">8641F<small>（2019年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点、2019年時点</Fragment>
 
 			<!-- 2018-12-05, 2019-01-10 -->
@@ -160,7 +160,7 @@ const slugger = new GithubSlugger();
 	<Section id="8642F">
 		<Fragment slot="heading">8642F<small>（2019年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点</Fragment>
 
 			<Embedded>
@@ -168,7 +168,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2018年時点</Fragment>
 
 			<!-- 2018-12-03 -->
@@ -178,7 +178,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2019年時点</Fragment>
 
 			<!-- 2019-07-18 -->

--- a/astro/src/pages/tokyu/data/acu_8500.astro
+++ b/astro/src/pages/tokyu/data/acu_8500.astro
@@ -38,7 +38,7 @@ const slugger = new GithubSlugger();
 	<Section id="8637F">
 		<Fragment slot="heading">8637F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点</Fragment>
 
 			<Embedded>
@@ -46,7 +46,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2019年時点</Fragment>
 
 			<!-- 2018-12-03, 2019-01-10, 2019-07-19 -->
@@ -56,7 +56,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2022年時点</Fragment>
 
 			<!-- 2022-07-29 -->
@@ -66,7 +66,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2026年時点</Fragment>
 
 			<!-- 2026-05-03 -->
@@ -88,7 +88,7 @@ const slugger = new GithubSlugger();
 	<Section id="8638F">
 		<Fragment slot="heading">8638F<small>（2019年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点</Fragment>
 
 			<Embedded>
@@ -96,7 +96,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2019年時点</Fragment>
 
 			<!-- 2018-12-03, 2019-01-10 -->
@@ -114,7 +114,7 @@ const slugger = new GithubSlugger();
 	<Section id="8639F">
 		<Fragment slot="heading">8639F<small>（2018年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点</Fragment>
 
 			<Embedded>
@@ -128,7 +128,7 @@ const slugger = new GithubSlugger();
 	<Section id="8640F">
 		<Fragment slot="heading">8640F<small>（2019年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点、2019年時点</Fragment>
 
 			<!-- 2019-01-10 -->
@@ -144,7 +144,7 @@ const slugger = new GithubSlugger();
 	<Section id="8641F">
 		<Fragment slot="heading">8641F<small>（2019年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点、2019年時点</Fragment>
 
 			<!-- 2018-12-05, 2019-01-10 -->
@@ -160,7 +160,7 @@ const slugger = new GithubSlugger();
 	<Section id="8642F">
 		<Fragment slot="heading">8642F<small>（2019年運用離脱）</small></Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年時点</Fragment>
 
 			<Embedded>
@@ -168,7 +168,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2018年時点</Fragment>
 
 			<!-- 2018-12-03 -->
@@ -178,7 +178,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2019年時点</Fragment>
 
 			<!-- 2019-07-18 -->

--- a/astro/src/pages/tokyu/data/acu_9000.astro
+++ b/astro/src/pages/tokyu/data/acu_9000.astro
@@ -40,7 +40,7 @@ const slugger = new GithubSlugger();
 	<Section id="9001F">
 		<Fragment slot="heading">9001F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2018年</Fragment>
 
 			<Embedded>
@@ -48,7 +48,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2018年〜</Fragment>
 
 			<Embedded>
@@ -66,7 +66,7 @@ const slugger = new GithubSlugger();
 	<Section id="9002F">
 		<Fragment slot="heading">9002F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2009年</Fragment>
 
 			<Embedded>
@@ -74,7 +74,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2009年〜2013年</Fragment>
 
 			<Embedded>
@@ -82,7 +82,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -90,7 +90,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -110,7 +110,7 @@ const slugger = new GithubSlugger();
 	<Section id="9003F">
 		<Fragment slot="heading">9003F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年〜2013年</Fragment>
 
 			<Embedded>
@@ -118,7 +118,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -126,7 +126,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -144,7 +144,7 @@ const slugger = new GithubSlugger();
 	<Section id="9004F">
 		<Fragment slot="heading">9004F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年〜2013年</Fragment>
 
 			<Embedded>
@@ -152,7 +152,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -160,7 +160,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -178,7 +178,7 @@ const slugger = new GithubSlugger();
 	<Section id="9005F">
 		<Fragment slot="heading">9005F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -186,7 +186,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -202,7 +202,7 @@ const slugger = new GithubSlugger();
 	<Section id="9006F">
 		<Fragment slot="heading">9006F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年〜2017年</Fragment>
 
 			<Embedded>
@@ -210,7 +210,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -226,7 +226,7 @@ const slugger = new GithubSlugger();
 	<Section id="9007F">
 		<Fragment slot="heading">9007F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2009年〜2010年</Fragment>
 
 			<Embedded>
@@ -234,7 +234,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2010年〜2013年</Fragment>
 
 			<Embedded>
@@ -242,7 +242,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -250,7 +250,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -270,7 +270,7 @@ const slugger = new GithubSlugger();
 	<Section id="9008F">
 		<Fragment slot="heading">9008F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2011年〜2013年</Fragment>
 
 			<Embedded>
@@ -278,7 +278,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年</Fragment>
 
 			<Embedded>
@@ -286,7 +286,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -294,7 +294,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -312,7 +312,7 @@ const slugger = new GithubSlugger();
 	<Section id="9009F">
 		<Fragment slot="heading">9009F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2009年〜2013年</Fragment>
 
 			<Embedded>
@@ -320,7 +320,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -328,7 +328,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜2018年頃</Fragment>
 
 			<Embedded>
@@ -336,7 +336,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2018年頃〜</Fragment>
 
 			<Embedded>
@@ -356,7 +356,7 @@ const slugger = new GithubSlugger();
 	<Section id="9010F">
 		<Fragment slot="heading">9010F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年</Fragment>
 
 			<Embedded>
@@ -364,7 +364,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -372,7 +372,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -390,7 +390,7 @@ const slugger = new GithubSlugger();
 	<Section id="9011F">
 		<Fragment slot="heading">9011F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2011年〜2013年</Fragment>
 
 			<Embedded>
@@ -398,7 +398,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -406,7 +406,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -424,7 +424,7 @@ const slugger = new GithubSlugger();
 	<Section id="9012F">
 		<Fragment slot="heading">9012F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -432,7 +432,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -450,7 +450,7 @@ const slugger = new GithubSlugger();
 	<Section id="9013F">
 		<Fragment slot="heading">9013F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2012年〜2013年</Fragment>
 
 			<Embedded>
@@ -458,7 +458,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -466,7 +466,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -484,7 +484,7 @@ const slugger = new GithubSlugger();
 	<Section id="9014F">
 		<Fragment slot="heading">9014F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2018年</Fragment>
 
 			<Embedded>
@@ -492,7 +492,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2018年〜</Fragment>
 
 			<Embedded>
@@ -508,7 +508,7 @@ const slugger = new GithubSlugger();
 	<Section id="9015F">
 		<Fragment slot="heading">9015F</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2012年〜2018年</Fragment>
 
 			<Embedded>
@@ -516,7 +516,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2018年〜</Fragment>
 
 			<Embedded>

--- a/astro/src/pages/tokyu/data/acu_9000.astro
+++ b/astro/src/pages/tokyu/data/acu_9000.astro
@@ -40,7 +40,7 @@ const slugger = new GithubSlugger();
 	<Section id="9001F">
 		<Fragment slot="heading">9001F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2018年</Fragment>
 
 			<Embedded>
@@ -48,7 +48,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2018年〜</Fragment>
 
 			<Embedded>
@@ -66,7 +66,7 @@ const slugger = new GithubSlugger();
 	<Section id="9002F">
 		<Fragment slot="heading">9002F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2009年</Fragment>
 
 			<Embedded>
@@ -74,7 +74,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2009年〜2013年</Fragment>
 
 			<Embedded>
@@ -82,7 +82,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -90,7 +90,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -110,7 +110,7 @@ const slugger = new GithubSlugger();
 	<Section id="9003F">
 		<Fragment slot="heading">9003F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年〜2013年</Fragment>
 
 			<Embedded>
@@ -118,7 +118,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -126,7 +126,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -144,7 +144,7 @@ const slugger = new GithubSlugger();
 	<Section id="9004F">
 		<Fragment slot="heading">9004F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年〜2013年</Fragment>
 
 			<Embedded>
@@ -152,7 +152,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -160,7 +160,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -178,7 +178,7 @@ const slugger = new GithubSlugger();
 	<Section id="9005F">
 		<Fragment slot="heading">9005F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -186,7 +186,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -202,7 +202,7 @@ const slugger = new GithubSlugger();
 	<Section id="9006F">
 		<Fragment slot="heading">9006F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年〜2017年</Fragment>
 
 			<Embedded>
@@ -210,7 +210,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -226,7 +226,7 @@ const slugger = new GithubSlugger();
 	<Section id="9007F">
 		<Fragment slot="heading">9007F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2009年〜2010年</Fragment>
 
 			<Embedded>
@@ -234,7 +234,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2010年〜2013年</Fragment>
 
 			<Embedded>
@@ -242,7 +242,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -250,7 +250,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -270,7 +270,7 @@ const slugger = new GithubSlugger();
 	<Section id="9008F">
 		<Fragment slot="heading">9008F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2011年〜2013年</Fragment>
 
 			<Embedded>
@@ -278,7 +278,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年</Fragment>
 
 			<Embedded>
@@ -286,7 +286,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -294,7 +294,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -312,7 +312,7 @@ const slugger = new GithubSlugger();
 	<Section id="9009F">
 		<Fragment slot="heading">9009F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2009年〜2013年</Fragment>
 
 			<Embedded>
@@ -320,7 +320,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -328,7 +328,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜2018年頃</Fragment>
 
 			<Embedded>
@@ -336,7 +336,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2018年頃〜</Fragment>
 
 			<Embedded>
@@ -356,7 +356,7 @@ const slugger = new GithubSlugger();
 	<Section id="9010F">
 		<Fragment slot="heading">9010F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年</Fragment>
 
 			<Embedded>
@@ -364,7 +364,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -372,7 +372,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -390,7 +390,7 @@ const slugger = new GithubSlugger();
 	<Section id="9011F">
 		<Fragment slot="heading">9011F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2011年〜2013年</Fragment>
 
 			<Embedded>
@@ -398,7 +398,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -406,7 +406,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -424,7 +424,7 @@ const slugger = new GithubSlugger();
 	<Section id="9012F">
 		<Fragment slot="heading">9012F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -432,7 +432,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -450,7 +450,7 @@ const slugger = new GithubSlugger();
 	<Section id="9013F">
 		<Fragment slot="heading">9013F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2012年〜2013年</Fragment>
 
 			<Embedded>
@@ -458,7 +458,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2017年</Fragment>
 
 			<Embedded>
@@ -466,7 +466,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2017年〜</Fragment>
 
 			<Embedded>
@@ -484,7 +484,7 @@ const slugger = new GithubSlugger();
 	<Section id="9014F">
 		<Fragment slot="heading">9014F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2013年〜2018年</Fragment>
 
 			<Embedded>
@@ -492,7 +492,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2018年〜</Fragment>
 
 			<Embedded>
@@ -508,7 +508,7 @@ const slugger = new GithubSlugger();
 	<Section id="9015F">
 		<Fragment slot="heading">9015F</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2012年〜2018年</Fragment>
 
 			<Embedded>
@@ -516,7 +516,7 @@ const slugger = new GithubSlugger();
 			</Embedded>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2018年〜</Fragment>
 
 			<Embedded>

--- a/astro/src/pages/tokyu/data/form_car.astro
+++ b/astro/src/pages/tokyu/data/form_car.astro
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 
 		<Flex>
 			<FlexItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">デヤ7200形</Fragment>
 
 					<MachineForm>
@@ -64,7 +64,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</FlexItem>
 			<FlexItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">デヤ7290形</Fragment>
 
 					<MachineForm>
@@ -87,7 +87,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</FlexItem>
 			<FlexItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">サヤ7590形</Fragment>
 
 					<MachineForm>
@@ -115,7 +115,7 @@ const slugger = new GithubSlugger();
 	<Section id="series7600">
 		<Fragment slot="heading">7600系</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線</Fragment>
 
 			<MachineForm>
@@ -151,7 +151,7 @@ const slugger = new GithubSlugger();
 	<Section id="series7700">
 		<Fragment slot="heading">7700系</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線</Fragment>
 
 			<MachineForm>
@@ -183,7 +183,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線（7915F）</Fragment>
 
 			<MachineForm>
@@ -218,7 +218,7 @@ const slugger = new GithubSlugger();
 	<Section id="series8000">
 		<Fragment slot="heading">8000系グループ</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線8500系（CP3台編成）</Fragment>
 
 			<MachineForm>
@@ -289,7 +289,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線8500系（CP4台編成・8637F）</Fragment>
 
 			<MachineForm>
@@ -356,7 +356,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線8500系（VVVF車組込・8642F）</Fragment>
 
 			<MachineForm>
@@ -423,7 +423,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線8090系</Fragment>
 
 			<MachineForm>
@@ -490,7 +490,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">大井町線8090系（先頭車が12〜13次車）</Fragment>
 
 			<MachineForm>
@@ -536,7 +536,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">大井町線8090系（先頭車が16〜17次車）</Fragment>
 
 			<MachineForm>
@@ -582,7 +582,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">大井町線8090系（先頭車が8590系）</Fragment>
 
 			<MachineForm>
@@ -624,7 +624,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">大井町線8500系</Fragment>
 
 			<MachineForm>
@@ -670,7 +670,7 @@ const slugger = new GithubSlugger();
 	<Section id="series9000">
 		<Fragment slot="heading">9000系</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">東横線</Fragment>
 
 			<MachineForm>
@@ -727,7 +727,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">大井町線</Fragment>
 
 			<MachineForm>
@@ -773,7 +773,7 @@ const slugger = new GithubSlugger();
 	<Section id="series1000">
 		<Fragment slot="heading">1000系</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">東横線1000系</Fragment>
 
 			<MachineForm>
@@ -830,7 +830,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線1000N′系</Fragment>
 
 			<MachineForm>
@@ -862,7 +862,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線1000N系</Fragment>
 
 			<MachineForm>
@@ -898,7 +898,7 @@ const slugger = new GithubSlugger();
 	<Section id="series2000">
 		<Fragment slot="heading">2000系</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線</Fragment>
 
 			<MachineForm>
@@ -969,7 +969,7 @@ const slugger = new GithubSlugger();
 	<Section id="series3000">
 		<Fragment slot="heading">新3000系</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">目黒線</Fragment>
 
 			<MachineForm>
@@ -1020,7 +1020,7 @@ const slugger = new GithubSlugger();
 	<Section id="series300">
 		<Fragment slot="heading">300系</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">世田谷線</Fragment>
 
 			<MachineForm>
@@ -1051,7 +1051,7 @@ const slugger = new GithubSlugger();
 	<Section id="seriesY000">
 		<Fragment slot="heading">Y000系</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">こどもの国線</Fragment>
 
 			<MachineForm>

--- a/astro/src/pages/tokyu/data/form_car.astro
+++ b/astro/src/pages/tokyu/data/form_car.astro
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 
 		<Flex>
 			<FlexItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">デヤ7200形</Fragment>
 
 					<MachineForm>
@@ -64,7 +64,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</FlexItem>
 			<FlexItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">デヤ7290形</Fragment>
 
 					<MachineForm>
@@ -87,7 +87,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</FlexItem>
 			<FlexItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">サヤ7590形</Fragment>
 
 					<MachineForm>
@@ -115,7 +115,7 @@ const slugger = new GithubSlugger();
 	<Section id="series7600">
 		<Fragment slot="heading">7600系</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線</Fragment>
 
 			<MachineForm>
@@ -151,7 +151,7 @@ const slugger = new GithubSlugger();
 	<Section id="series7700">
 		<Fragment slot="heading">7700系</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線</Fragment>
 
 			<MachineForm>
@@ -183,7 +183,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線（7915F）</Fragment>
 
 			<MachineForm>
@@ -218,7 +218,7 @@ const slugger = new GithubSlugger();
 	<Section id="series8000">
 		<Fragment slot="heading">8000系グループ</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線8500系（CP3台編成）</Fragment>
 
 			<MachineForm>
@@ -289,7 +289,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線8500系（CP4台編成・8637F）</Fragment>
 
 			<MachineForm>
@@ -356,7 +356,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線8500系（VVVF車組込・8642F）</Fragment>
 
 			<MachineForm>
@@ -423,7 +423,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線8090系</Fragment>
 
 			<MachineForm>
@@ -490,7 +490,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">大井町線8090系（先頭車が12〜13次車）</Fragment>
 
 			<MachineForm>
@@ -536,7 +536,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">大井町線8090系（先頭車が16〜17次車）</Fragment>
 
 			<MachineForm>
@@ -582,7 +582,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">大井町線8090系（先頭車が8590系）</Fragment>
 
 			<MachineForm>
@@ -624,7 +624,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">大井町線8500系</Fragment>
 
 			<MachineForm>
@@ -670,7 +670,7 @@ const slugger = new GithubSlugger();
 	<Section id="series9000">
 		<Fragment slot="heading">9000系</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">東横線</Fragment>
 
 			<MachineForm>
@@ -727,7 +727,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">大井町線</Fragment>
 
 			<MachineForm>
@@ -773,7 +773,7 @@ const slugger = new GithubSlugger();
 	<Section id="series1000">
 		<Fragment slot="heading">1000系</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">東横線1000系</Fragment>
 
 			<MachineForm>
@@ -830,7 +830,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線1000N′系</Fragment>
 
 			<MachineForm>
@@ -862,7 +862,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">池上、多摩川線1000N系</Fragment>
 
 			<MachineForm>
@@ -898,7 +898,7 @@ const slugger = new GithubSlugger();
 	<Section id="series2000">
 		<Fragment slot="heading">2000系</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">田園都市線</Fragment>
 
 			<MachineForm>
@@ -969,7 +969,7 @@ const slugger = new GithubSlugger();
 	<Section id="series3000">
 		<Fragment slot="heading">新3000系</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">目黒線</Fragment>
 
 			<MachineForm>
@@ -1020,7 +1020,7 @@ const slugger = new GithubSlugger();
 	<Section id="series300">
 		<Fragment slot="heading">300系</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">世田谷線</Fragment>
 
 			<MachineForm>
@@ -1051,7 +1051,7 @@ const slugger = new GithubSlugger();
 	<Section id="seriesY000">
 		<Fragment slot="heading">Y000系</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">こどもの国線</Fragment>
 
 			<MachineForm>

--- a/astro/src/pages/tokyu/data/form_line.astro
+++ b/astro/src/pages/tokyu/data/form_line.astro
@@ -39,7 +39,7 @@ const slugger = new GithubSlugger();
 	<Section id="toyoko">
 		<Fragment slot="heading">東横線</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">9000系</Fragment>
 
 			<MachineForm>
@@ -96,7 +96,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1000系</Fragment>
 
 			<MachineForm>
@@ -157,7 +157,7 @@ const slugger = new GithubSlugger();
 	<Section id="meguro">
 		<Fragment slot="heading">目黒線</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">3000系</Fragment>
 
 			<MachineForm>
@@ -208,7 +208,7 @@ const slugger = new GithubSlugger();
 	<Section id="dento">
 		<Fragment slot="heading">田園都市線</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">8500系（CP3台編成）</Fragment>
 
 			<MachineForm>
@@ -279,7 +279,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">8500系（CP4台編成・8637F）</Fragment>
 
 			<MachineForm>
@@ -346,7 +346,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">8500系（VVVF車組込・8642F）</Fragment>
 
 			<MachineForm>
@@ -413,7 +413,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">8090系（先頭車が8590系）</Fragment>
 
 			<MachineForm>
@@ -480,7 +480,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">2000系</Fragment>
 
 			<MachineForm>
@@ -551,7 +551,7 @@ const slugger = new GithubSlugger();
 	<Section id="oimachi">
 		<Fragment slot="heading">大井町線</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">8090系（先頭車が12〜13次車）</Fragment>
 
 			<MachineForm>
@@ -597,7 +597,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">8090系（先頭車が16〜17次車）</Fragment>
 
 			<MachineForm>
@@ -643,7 +643,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">8090系（先頭車が8590系）</Fragment>
 
 			<MachineForm>
@@ -685,7 +685,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">8500系</Fragment>
 
 			<MachineForm>
@@ -727,7 +727,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">9000系</Fragment>
 
 			<MachineForm>
@@ -771,7 +771,7 @@ const slugger = new GithubSlugger();
 
 		<Flex>
 			<FlexItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">デヤ7200形</Fragment>
 
 					<MachineForm>
@@ -794,7 +794,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</FlexItem>
 			<FlexItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">デヤ7290形</Fragment>
 
 					<MachineForm>
@@ -817,7 +817,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</FlexItem>
 			<FlexItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">サヤ7590形</Fragment>
 
 					<MachineForm>
@@ -845,7 +845,7 @@ const slugger = new GithubSlugger();
 	<Section id="iketama">
 		<Fragment slot="heading">池上、多摩川線</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">7600系</Fragment>
 
 			<MachineForm>
@@ -877,7 +877,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">7700系</Fragment>
 
 			<MachineForm>
@@ -909,7 +909,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">7700系（7915F）</Fragment>
 
 			<MachineForm>
@@ -940,7 +940,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1000N′系</Fragment>
 
 			<MachineForm>
@@ -972,7 +972,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">1000N系</Fragment>
 
 			<MachineForm>
@@ -1008,7 +1008,7 @@ const slugger = new GithubSlugger();
 	<Section id="kodomo">
 		<Fragment slot="heading">こどもの国線</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">横浜高速鉄道Y000系</Fragment>
 
 			<MachineForm>
@@ -1038,7 +1038,7 @@ const slugger = new GithubSlugger();
 	<Section id="setagaya">
 		<Fragment slot="heading">世田谷線</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">300系</Fragment>
 
 			<MachineForm>

--- a/astro/src/pages/tokyu/data/form_line.astro
+++ b/astro/src/pages/tokyu/data/form_line.astro
@@ -39,7 +39,7 @@ const slugger = new GithubSlugger();
 	<Section id="toyoko">
 		<Fragment slot="heading">東横線</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">9000系</Fragment>
 
 			<MachineForm>
@@ -96,7 +96,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1000系</Fragment>
 
 			<MachineForm>
@@ -157,7 +157,7 @@ const slugger = new GithubSlugger();
 	<Section id="meguro">
 		<Fragment slot="heading">目黒線</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">3000系</Fragment>
 
 			<MachineForm>
@@ -208,7 +208,7 @@ const slugger = new GithubSlugger();
 	<Section id="dento">
 		<Fragment slot="heading">田園都市線</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">8500系（CP3台編成）</Fragment>
 
 			<MachineForm>
@@ -279,7 +279,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">8500系（CP4台編成・8637F）</Fragment>
 
 			<MachineForm>
@@ -346,7 +346,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">8500系（VVVF車組込・8642F）</Fragment>
 
 			<MachineForm>
@@ -413,7 +413,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">8090系（先頭車が8590系）</Fragment>
 
 			<MachineForm>
@@ -480,7 +480,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">2000系</Fragment>
 
 			<MachineForm>
@@ -551,7 +551,7 @@ const slugger = new GithubSlugger();
 	<Section id="oimachi">
 		<Fragment slot="heading">大井町線</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">8090系（先頭車が12〜13次車）</Fragment>
 
 			<MachineForm>
@@ -597,7 +597,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">8090系（先頭車が16〜17次車）</Fragment>
 
 			<MachineForm>
@@ -643,7 +643,7 @@ const slugger = new GithubSlugger();
 			</ListNote>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">8090系（先頭車が8590系）</Fragment>
 
 			<MachineForm>
@@ -685,7 +685,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">8500系</Fragment>
 
 			<MachineForm>
@@ -727,7 +727,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">9000系</Fragment>
 
 			<MachineForm>
@@ -771,7 +771,7 @@ const slugger = new GithubSlugger();
 
 		<Flex>
 			<FlexItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">デヤ7200形</Fragment>
 
 					<MachineForm>
@@ -794,7 +794,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</FlexItem>
 			<FlexItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">デヤ7290形</Fragment>
 
 					<MachineForm>
@@ -817,7 +817,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</FlexItem>
 			<FlexItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">サヤ7590形</Fragment>
 
 					<MachineForm>
@@ -845,7 +845,7 @@ const slugger = new GithubSlugger();
 	<Section id="iketama">
 		<Fragment slot="heading">池上、多摩川線</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">7600系</Fragment>
 
 			<MachineForm>
@@ -877,7 +877,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">7700系</Fragment>
 
 			<MachineForm>
@@ -909,7 +909,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">7700系（7915F）</Fragment>
 
 			<MachineForm>
@@ -940,7 +940,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1000N′系</Fragment>
 
 			<MachineForm>
@@ -972,7 +972,7 @@ const slugger = new GithubSlugger();
 			</MachineForm>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">1000N系</Fragment>
 
 			<MachineForm>
@@ -1008,7 +1008,7 @@ const slugger = new GithubSlugger();
 	<Section id="kodomo">
 		<Fragment slot="heading">こどもの国線</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">横浜高速鉄道Y000系</Fragment>
 
 			<MachineForm>
@@ -1038,7 +1038,7 @@ const slugger = new GithubSlugger();
 	<Section id="setagaya">
 		<Fragment slot="heading">世田谷線</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="c">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">300系</Fragment>
 
 			<MachineForm>

--- a/astro/src/pages/tokyu/data/form_local.astro
+++ b/astro/src/pages/tokyu/data/form_local.astro
@@ -29,7 +29,7 @@ const structuredData: StructuredData = {
 	<Section id="konan">
 		<Fragment slot="heading">弘南鉄道</Fragment>
 
-		<Section id="konan-konan" depth={2} headingType="c">
+		<Section id="konan-konan" depth={2}>
 			<Fragment slot="heading">弘南線</Fragment>
 
 			<Flex>
@@ -113,7 +113,7 @@ const structuredData: StructuredData = {
 			</ListNote>
 		</Section>
 
-		<Section id="konan-owani" depth={2} headingType="c">
+		<Section id="konan-owani" depth={2}>
 			<Fragment slot="heading">大鰐線</Fragment>
 
 			<Flex>

--- a/astro/src/pages/tokyu/data/history/index.astro
+++ b/astro/src/pages/tokyu/data/history/index.astro
@@ -84,7 +84,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData} toc={false}>
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">検索条件入力</Fragment>
 
 		<form>
@@ -193,7 +193,7 @@ const slugger = new GithubSlugger();
 
 	{
 		cars !== undefined && (
-			<Section slugger={slugger} autofocus={true} class="js-scroll-into-view">
+			<Section id={slugger} autofocus={true} class="js-scroll-into-view">
 				<Fragment slot="heading">検索結果</Fragment>
 
 				{hitLength >= 1 && (

--- a/astro/src/pages/tokyu/data/history/ref.astro
+++ b/astro/src/pages/tokyu/data/history/ref.astro
@@ -21,7 +21,7 @@ const structuredData: StructuredData = {
 	<Section id="source">
 		<Fragment slot="heading">入籍日、改番日の出典</Fragment>
 
-		<Section id="source-tetsupic442" depth={2} headingType="b">
+		<Section id="source-tetsupic442" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル1985年1月臨時増刊号（No.442）<small>（東京急行電鉄特集）</small></Fragment>
 
 			<List>
@@ -33,7 +33,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="source-tetsupic496" depth={2} headingType="b">
+		<Section id="source-tetsupic496" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル1988年5月臨時増刊号（No.496）<small>（新車年鑑1988年版）</small></Fragment>
 
 			<List>
@@ -41,7 +41,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="source-tetsupic534" depth={2} headingType="b">
+		<Section id="source-tetsupic534" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル1990年10月臨時増刊号（No.534）<small>（新車年鑑1990年版）</small></Fragment>
 
 			<List>
@@ -49,7 +49,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="source-tetsupic550" depth={2} headingType="b">
+		<Section id="source-tetsupic550" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル1991年10月臨時増刊号（No.550）<small>（新車年鑑1991年版）</small></Fragment>
 
 			<List>
@@ -57,7 +57,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="source-tetsupic600" depth={2} headingType="b">
+		<Section id="source-tetsupic600" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル1994年12月臨時増刊号（No.600）<small>（東京急行電鉄特集）</small></Fragment>
 
 			<List>
@@ -74,7 +74,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="source-tetsupic692" depth={2} headingType="b">
+		<Section id="source-tetsupic692" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル2000年10月臨時増刊号（No.692）<small>（新車年鑑2000年版）</small></Fragment>
 
 			<List>
@@ -82,7 +82,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="source-tetsupic708" depth={2} headingType="b">
+		<Section id="source-tetsupic708" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル2001年10月臨時増刊号（No.708）<small>（新車年鑑2001年版）</small></Fragment>
 
 			<List>
@@ -90,7 +90,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="source-tetsupic749" depth={2} headingType="b">
+		<Section id="source-tetsupic749" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル2004年7月臨時増刊号（No.749）<small>（東京急行電鉄特集）</small></Fragment>
 
 			<List>
@@ -103,7 +103,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="source-form1995" depth={2} headingType="b">
+		<Section id="source-form1995" depth={2}>
 			<Fragment slot="heading">私鉄車両編成表 '95年版</Fragment>
 
 			<List>
@@ -123,7 +123,7 @@ const structuredData: StructuredData = {
 			<li>鉄道ピクトリアル1986年5月臨時増刊号（No.464）「<cite>民鉄車両 竣功月日表</cite>」</li>
 		</List>
 
-		<Section id="referer-form" depth={2} headingType="b">
+		<Section id="referer-form" depth={2}>
 			<Fragment slot="heading">私鉄車両編成表（ジェー・アール・アール）</Fragment>
 
 			<List>
@@ -159,7 +159,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="referer-rj" depth={2} headingType="b">
+		<Section id="referer-rj" depth={2}>
 			<Fragment slot="heading">鉄道ジャーナル（私鉄車両のうごき）</Fragment>
 
 			<List>
@@ -211,7 +211,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="referer-tetsupic" depth={2} headingType="b">
+		<Section id="referer-tetsupic" depth={2}>
 			<Fragment slot="heading">鉄道ピクトリアル（新車年鑑、鉄道車両年鑑）</Fragment>
 
 			<List>
@@ -240,7 +240,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="referer-dj" depth={2} headingType="b">
+		<Section id="referer-dj" depth={2}>
 			<Fragment slot="heading">鉄道ダイヤ情報（私鉄DATA FILE 私鉄車両のうごき）</Fragment>
 
 			<List>
@@ -312,7 +312,7 @@ const structuredData: StructuredData = {
 			</List>
 		</Section>
 
-		<Section id="referer-etc" depth={2} headingType="b">
+		<Section id="referer-etc" depth={2}>
 			<Fragment slot="heading">その他</Fragment>
 
 			<List>

--- a/astro/src/pages/tokyu/data/history_mekama&toyoko_passenger.astro
+++ b/astro/src/pages/tokyu/data/history_mekama&toyoko_passenger.astro
@@ -1723,7 +1723,7 @@ const slugger = new GithubSlugger();
 		</Table>
 	</Section>
 
-	<Section slugger={slugger} id="kuha3650">
+	<Section id="kuha3650">
 		<Fragment slot="heading">クハ3650形</Fragment>
 
 		<p><DateWareki value="1942-01" />には後にクハ3650形として竣功する制御客車6両の認可申請が(新)東京横浜電鉄より提出されましたが、認可は東京急行電鉄の成立後となっため、<a href="/tokyu/data/history_tokyu#kuha3650">東京急行電鉄のページ</a>に記載します。</p>

--- a/astro/src/pages/tokyu/data/history_mekama&toyoko_passenger.astro
+++ b/astro/src/pages/tokyu/data/history_mekama&toyoko_passenger.astro
@@ -161,7 +161,7 @@ const slugger = new GithubSlugger();
 		<NoteRefContent id="jinchu1942-03-30"><DocOfficial company="神中鉄道" no="神鉄午第15号" date="1942-03-30" title="電動客車譲受使用認可申請書" url="https://www.digital.archives.go.jp/item/529924" /></NoteRefContent>
 	</Section>
 
-	<Section slugger={slugger} box={true}>
+	<Section id={slugger} box={true}>
 		<Fragment slot="heading">形式不明<small>（製造中止）</small></Fragment>
 
 		<p>目黒蒲田電鉄が10両の新製を計画しつつも実現しなかった車両で、購入認可申請の後、認可前に申請が取り下げられています。取り下げの理由は<q>更ニ改良設計ノ上申請致度候</q>とあるものの、タイミングからすれば後述の<a href="#deha20">鉄道省車両の譲受（デハ20形）</a>が行われることになったため新製を取り止めた可能性が考えられます。</p>

--- a/astro/src/pages/tokyu/data/spec_freight.astro
+++ b/astro/src/pages/tokyu/data/spec_freight.astro
@@ -290,7 +290,7 @@ const structuredData: StructuredData = {
 
 		<NoteRefContent id="tomu81-weight">製造時の認可申請書では 7.57t とされているが、後の車両竣功図表や<Anchor href="https://www.digital.archives.go.jp/item/508799"><DateWareki value="1929" />の貨車標記変更報告</Anchor>では 7.73t となっている。</NoteRefContent>
 
-		<Section depth={2} headingType="b" id="to5">
+		<Section depth={2} id="to5">
 			<Fragment slot="heading">ト5形譲受前の前歴と諸元</Fragment>
 
 			<p>ト5形は目黒蒲田電鉄では2両とも同じ諸元とされていますが、まったく異なる出自を持っていました。官設鉄道や日本鉄道時代の諸元を見ると、上州鉄道からの譲受車であることには疑いの余地があるほどの違いがあることが分かります。</p>

--- a/astro/src/pages/tokyu/machine/aci.astro
+++ b/astro/src/pages/tokyu/machine/aci.astro
@@ -27,9 +27,9 @@ const structuredData: StructuredData = {
 	<Section id="original">
 		<Fragment slot="heading">オリジナルタイプ（製造時）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="inv049" depth={2} headingType="c">
+				<Section id="inv049" depth={2}>
 					<Fragment slot="heading">INV-049</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -44,7 +44,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="inv088" depth={2} headingType="c">
+				<Section id="inv088" depth={2}>
 					<Fragment slot="heading">INV-088</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -64,9 +64,9 @@ const structuredData: StructuredData = {
 	<Section id="renewal2014">
 		<Fragment slot="heading">2014年更新後</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc220" depth={2} headingType="c">
+				<Section id="tc220" depth={2}>
 					<Fragment slot="heading">TCE-220</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/aps.astro
+++ b/astro/src/pages/tokyu/machine/aps.astro
@@ -455,7 +455,7 @@ const structuredData: StructuredData = {
 	<Section id="mg-few">
 		<Fragment slot="heading">小容量 MG</Fragment>
 
-		<Section id="clg107" depth={2} headingType="b">
+		<Section id="clg107" depth={2}>
 			<Fragment slot="heading">CLG107<small>（東京芝浦電気、2.5kVA）</small></Fragment>
 
 			<Flex>
@@ -486,7 +486,7 @@ const structuredData: StructuredData = {
 			<p>稼働個体は長津田車両工場のデワ3043 を最後に消滅し、2023年現在は保存車で数基が残っています。</p>
 		</Section>
 
-		<Section id="clg308" depth={2} headingType="b">
+		<Section id="clg308" depth={2}>
 			<Fragment slot="heading">CLG308<small>（東京芝浦電気、1.5kVA）</small></Fragment>
 
 			<Flex>
@@ -504,7 +504,7 @@ const structuredData: StructuredData = {
 			<p>現在は電車とバスの博物館にデハ204 が保存されていますが、MG が現存しているかどうかは不明です。機器の写真が掲載された資料としては<DocMagazine name="東芝レビュー" date="1956年4月号" no={75} article="昭和30年における東芝技術の成果" pages={[427]} url="https://dl.ndl.go.jp/pid/3253766/1/39" />があります。</p>
 		</Section>
 
-		<Section id="clg316" depth={2} headingType="b">
+		<Section id="clg316" depth={2}>
 			<Fragment slot="heading">CLG316<small>（東京芝浦電気、5kVA）</small></Fragment>
 
 			<Flex>
@@ -520,7 +520,7 @@ const structuredData: StructuredData = {
 			<NoteRefContent id="pic269"><DocMagazine name="鉄道ピクトリアル" date="1972年9月号" no={269} article="私鉄車両めぐり〔93〕東京急行電鉄の車両" authors={['荻原二郎', '久原秀雄', '宮田道一']} pages={[72]} /></NoteRefContent>
 		</Section>
 
-		<Section id="tdk381" depth={2} headingType="b">
+		<Section id="tdk381" depth={2}>
 			<Fragment slot="heading">TDK381<small>（東洋電機製造、6kVA）</small></Fragment>
 
 			<Flex>
@@ -542,7 +542,7 @@ const structuredData: StructuredData = {
 			<p>各地に譲渡された車両のうち弘南鉄道弘南線では7000系が現役で活躍しているほか、稼働機会は皆無なものの弘南鉄道大鰐線の6000系と水間鉄道7000系でも見ることができます。</p>
 		</Section>
 
-		<Section id="clg320" depth={2} headingType="b">
+		<Section id="clg320" depth={2}>
 			<Fragment slot="heading">CLG320<small>（東京芝浦電気、7kVA）</small></Fragment>
 
 			<Flex>
@@ -566,7 +566,7 @@ const structuredData: StructuredData = {
 			<p>なお、東洋電機車の MG が 400Hz 出力の高周波タイプになったのに対し、こちらは従来どおり 120Hz 出力でした。</p>
 		</Section>
 
-		<Section id="hg533" depth={2} headingType="b">
+		<Section id="hg533" depth={2}>
 			<Fragment slot="heading">HG533<small>（日立製作所、7.5kVA）</small></Fragment>
 
 			<Flex>
@@ -584,7 +584,7 @@ const structuredData: StructuredData = {
 			<p>北陸鉄道譲渡車は譲渡時に <a href="#tdk366">TDK366 型</a>に換装されたため、2023年現在は弘南鉄道大鰐線のみに残っています。</p>
 		</Section>
 
-		<Section id="clg339" depth={2} headingType="b">
+		<Section id="clg339" depth={2}>
 			<Fragment slot="heading">CLG339<small>（東京芝浦電気、7.5kVA）</small></Fragment>
 
 			<Flex>
@@ -619,7 +619,7 @@ const structuredData: StructuredData = {
 			<p>譲渡車では、上田交通と豊橋鉄道向けの車両は大きな改造もなく、このうち豊橋鉄道では2023年現在も活躍中ですが、十和田観光電鉄譲渡車は両運化のため <a href="#cda021">SIV 搭載</a>により撤去されました。</p>
 		</Section>
 
-		<Section id="clg319" depth={2} headingType="b">
+		<Section id="clg319" depth={2}>
 			<Fragment slot="heading">CLG319<small>（東京芝浦電気、5.5kVA）</small></Fragment>
 
 			<Flex>
@@ -649,7 +649,7 @@ const structuredData: StructuredData = {
 			<p>1991年に電気検測車に改造されたデヤ7290 には前述のとおり2基の MG が装備されましたが、2位寄りにはこの CLG319 型が搭載され、2012年の引退まで使用されました。</p>
 		</Section>
 
-		<Section id="clg333" depth={2} headingType="b">
+		<Section id="clg333" depth={2}>
 			<Fragment slot="heading">CLG333<small>（東京芝浦電気、9kVA）</small></Fragment>
 
 			<Flex>
@@ -673,7 +673,7 @@ const structuredData: StructuredData = {
 			<NoteRefContent id="pic601"><DocMagazine name="鉄道ピクトリアル" date="1995年1月号" no={601} article="箱根登山鉄道車両沿革史〔前編〕" authors={['鈴木大地']} pages={[81]} /></NoteRefContent>
 		</Section>
 
-		<Section id="tdk359" depth={2} headingType="b">
+		<Section id="tdk359" depth={2}>
 			<Fragment slot="heading">TDK359<small>（東洋電機製造、9kVA）</small></Fragment>
 
 			<Flex>
@@ -695,7 +695,7 @@ const structuredData: StructuredData = {
 			<p>2023年現在は最後まで残っていたモハ5101A が北熊本車庫で動態保存されています。</p>
 		</Section>
 
-		<Section id="tdk366" depth={2} headingType="b">
+		<Section id="tdk366" depth={2}>
 			<Fragment slot="heading">TDK366<small>（東洋電機製造、5.5kVA）</small></Fragment>
 
 			<Flex>
@@ -719,7 +719,7 @@ const structuredData: StructuredData = {
 	<Section id="siv-few">
 		<Fragment slot="heading">小容量 SIV</Fragment>
 
-		<Section id="bs33" depth={2} headingType="b">
+		<Section id="bs33" depth={2}>
 			<Fragment slot="heading">BS33<small>（東京芝浦電気、10kVA）</small></Fragment>
 
 			<Flex>
@@ -745,7 +745,7 @@ const structuredData: StructuredData = {
 			<NoteRefContent id="youtube-00vGUHVu_K4"><Anchor href="https://www.youtube.com/watch?v=00vGUHVu_K4">2018/05/17 【ジャカルタ】 東急8000系 8003F カリデレス駅</Anchor>の先頭から2両目。</NoteRefContent>
 		</Section>
 
-		<Section id="inv009" depth={2} headingType="b">
+		<Section id="inv009" depth={2}>
 			<Fragment slot="heading">INV009<small>（東芝、2kVA）</small></Fragment>
 
 			<Flex>
@@ -769,7 +769,7 @@ const structuredData: StructuredData = {
 	<Section id="fan-power">
 		<Fragment slot="heading">扇風機電源装置</Fragment>
 
-		<Section id="s11" depth={2} headingType="b">
+		<Section id="s11" depth={2}>
 			<Fragment slot="heading">S11<small>（小糸工業、1kVA）</small></Fragment>
 
 			<Flex>
@@ -793,7 +793,7 @@ const structuredData: StructuredData = {
 	<Section id="mg-much">
 		<Fragment slot="heading">大容量 MG</Fragment>
 
-		<Section id="clg350" depth={2} headingType="b">
+		<Section id="clg350" depth={2}>
 			<Fragment slot="heading">CLG350<small>（東京芝浦電気、140kVA）</small></Fragment>
 
 			<Flex>
@@ -813,7 +813,7 @@ const structuredData: StructuredData = {
 			<p>8000系グループの廃車進行に伴い2011年をもって東急電鉄からは消滅しましたが、伊豆急行や長野電鉄、秩父鉄道などの譲渡先では今も多くが活躍しています。</p>
 		</Section>
 
-		<Section id="hg554" depth={2} headingType="b">
+		<Section id="hg554" depth={2}>
 			<Fragment slot="heading">HG554<small>（日立製作所、90kVA）</small></Fragment>
 
 			<Flex>
@@ -831,7 +831,7 @@ const structuredData: StructuredData = {
 			<p>3両とも豊橋鉄道に譲渡されましたが、2009年に <a href="#bs483">SIV への置き換え</a>が行われて消滅しました。</p>
 		</Section>
 
-		<Section id="tdk3725" depth={2} headingType="b">
+		<Section id="tdk3725" depth={2}>
 			<Fragment slot="heading">TDK3725<small>（東洋電機製造、75kVA）</small></Fragment>
 
 			<Flex>
@@ -855,7 +855,7 @@ const structuredData: StructuredData = {
 	<Section id="siv-much">
 		<Fragment slot="heading">大容量 SIV</Fragment>
 
-		<Section id="bs443" depth={2} headingType="b">
+		<Section id="bs443" depth={2}>
 			<Fragment slot="heading">BS443<small>（東京芝浦電気、170kVA）</small></Fragment>
 
 			<Flex>
@@ -877,7 +877,7 @@ const structuredData: StructuredData = {
 			<p>1990年から1996年にかけて GTO サイリスタを使用した <a href="#inv029">INV029 型</a>および IGBT の <a href="#inv095">INV095 型</a>への置き換えが行われ、消滅しました。8000系グループの2〜6次車に搭載されていた <a href="#clg350">CLG350 型 MG</a> は2011年の引退まで使われ、2023年現在も譲渡先で多数稼働しているのとは対照的です。</p>
 		</Section>
 
-		<Section id="bs477" depth={2} headingType="b">
+		<Section id="bs477" depth={2}>
 			<Fragment slot="heading">BS477<small>（東京芝浦電気、50kVA）</small></Fragment>
 
 			<Flex>
@@ -912,7 +912,7 @@ const structuredData: StructuredData = {
 			<p>一方、水間鉄道に譲渡された7000系のうち、1991年に現地で冷房改造されたデハ7101（現在のデハ1004）には同じ BS477 型でも改良型の B タイプが新製搭載されました。こちらは後述する <a href="#bs482">BS482 型</a>などと同じく箱前面の冷却フィンで冷却するタイプであり、半導体スタック部分の前面蓋が網目状になっているなど A タイプとは大きく異なる構造となっています。こちらは2022年現在も現役です。</p>
 		</Section>
 
-		<Section id="bs482" depth={2} headingType="b">
+		<Section id="bs482" depth={2}>
 			<Fragment slot="heading">BS482<small>（東京芝浦電気、170kVA）</small></Fragment>
 
 			<Flex>
@@ -934,7 +934,7 @@ const structuredData: StructuredData = {
 			<p>8000系グループの廃車に伴い東急電鉄からは2022年に消滅しましたが、秩父鉄道などの譲渡先で見ることができます。</p>
 		</Section>
 
-		<Section id="inv003" depth={2} headingType="b">
+		<Section id="inv003" depth={2}>
 			<Fragment slot="heading">INV003<small>（東芝、120kVA）</small></Fragment>
 
 			<Flex>
@@ -954,7 +954,7 @@ const structuredData: StructuredData = {
 			<NoteRefContent id="inv003-change">2005年時点の現車調査において、9000系1次車の SIV 搭載車（デハ9201, 9301, 9401）はいずれも1987年8月製造の INV020 型を搭載していました。2次車の最初の車両である 9002F の SIV は1987年8〜9月製造（入籍は同年11月）なので、それと同時期に交換されたものと考えられます。</NoteRefContent>
 		</Section>
 
-		<Section id="inv006" depth={2} headingType="b">
+		<Section id="inv006" depth={2}>
 			<Fragment slot="heading">INV006<small>（東芝、90kVA）</small></Fragment>
 
 			<Flex>
@@ -981,7 +981,7 @@ const structuredData: StructuredData = {
 			<p>豊橋鉄道譲渡車のうち唯一 <a href="#bs477">50kVA SIV</a> を搭載していたク2806（東急クハ7505）はこの 90kVA タイプへ換装されましたが、転用品ではなく2003年に新製されたものであり、他の個体と比べて半導体スタック部分の前面蓋の網目面積が狭い特徴があります。</p>
 		</Section>
 
-		<Section id="inv008" depth={2} headingType="b">
+		<Section id="inv008" depth={2}>
 			<Fragment slot="heading">INV008<small>（東芝、170kVA）</small></Fragment>
 
 			<Flex>
@@ -999,7 +999,7 @@ const structuredData: StructuredData = {
 			<p>8500系の引退に伴い2023年に消滅しました。</p>
 		</Section>
 
-		<Section id="inv020" depth={2} headingType="b">
+		<Section id="inv020" depth={2}>
 			<Fragment slot="heading">INV020<small>（東芝、120kVA）</small></Fragment>
 
 			<Flex>
@@ -1017,7 +1017,7 @@ const structuredData: StructuredData = {
 			<p>同年の9000系2次車以降もこのタイプが採用、9000系1次車も同時期に換装され、さらに1988年の1000系にも広まりました。</p>
 		</Section>
 
-		<Section id="rg467" depth={2} headingType="b">
+		<Section id="rg467" depth={2}>
 			<Fragment slot="heading">RG467 (SVH120-467)<small>（東洋電機製造、120kVA）</small></Fragment>
 
 			<Flex>
@@ -1041,7 +1041,7 @@ const structuredData: StructuredData = {
 			<p>クハ7910 は廃車後解体、クハ7914 は養老鉄道に譲渡されたものの SIV は<a href="#rg5096">換装された</a>ため現存しません。</p>
 		</Section>
 
-		<Section id="inv029" depth={2} headingType="b">
+		<Section id="inv029" depth={2}>
 			<Fragment slot="heading">INV029<small>（東芝、170kVA）</small></Fragment>
 
 			<Flex>
@@ -1072,7 +1072,7 @@ const structuredData: StructuredData = {
 			<p>富山地方鉄道に譲渡された8590系は改造が施され、半導体スタック部分の前面網目に覆いが付けられています。</p>
 		</Section>
 
-		<Section id="inv095" depth={2} headingType="b">
+		<Section id="inv095" depth={2}>
 			<Fragment slot="heading">INV095<small>（東芝、170kVA）</small></Fragment>
 
 			<Flex>
@@ -1092,7 +1092,7 @@ const structuredData: StructuredData = {
 			<NoteRefContent id="denkisha552"><DocMagazine name="電気車の科学" date="1994年4月号" no={552} article="鉄道車両用静止形低圧電源装置（SIV）開発の歴史と発展" authors={['宮田道一', '柳田啓一郎']} pages={[17]} /></NoteRefContent>
 		</Section>
 
-		<Section id="inv127" depth={2} headingType="b">
+		<Section id="inv127" depth={2}>
 			<Fragment slot="heading">INV127<small>（東芝、210kVA）</small></Fragment>
 
 			<Flex>
@@ -1110,7 +1110,7 @@ const structuredData: StructuredData = {
 			<p><a href="#inv095">INV095 型</a>と同じく素子は IGBT を使用、冷却はヒートパイプ式自冷ですが、三相交流の出力電圧は 440V となっています。</p>
 		</Section>
 
-		<Section id="inv104" depth={2} headingType="b">
+		<Section id="inv104" depth={2}>
 			<Fragment slot="heading">INV104<small>（東芝、100kVA）</small></Fragment>
 
 			<Flex>
@@ -1128,7 +1128,7 @@ const structuredData: StructuredData = {
 			<p>2013年の大井町線8090系引退により東急電鉄からは消滅しましたが、デハ8282 は秩父鉄道に譲渡され、SIV もそのまま使われています。また、デハ8296 の搭載分は <a href="#bs33">10kVA SIV</a> を搭載していたデハ8280 の秩父鉄道譲渡に際し流用されました。その結果、秩父鉄道7800系（全4編成）は <a href="#inv153">INV 153 型</a>とともに SIV が 100kVA に統一されています。</p>
 		</Section>
 
-		<Section id="inv146" depth={2} headingType="b">
+		<Section id="inv146" depth={2}>
 			<Fragment slot="heading">INV146<small>（東芝、250kVA）</small></Fragment>
 
 			<Flex>
@@ -1146,7 +1146,7 @@ const structuredData: StructuredData = {
 			<p>なお、この車両は2007年の伊豆急行への譲渡にあたり、電源装置が MG に戻されています。</p>
 		</Section>
 
-		<Section id="inv153" depth={2} headingType="b">
+		<Section id="inv153" depth={2}>
 			<Fragment slot="heading">INV153<small>（東芝、100kVA）</small></Fragment>
 
 			<Flex>
@@ -1166,7 +1166,7 @@ const structuredData: StructuredData = {
 			<p>東急電鉄での活躍はわずか8年ほどでしたが、両車とも秩父鉄道に譲渡されて活躍中です。</p>
 		</Section>
 
-		<Section id="inv205" depth={2} headingType="b">
+		<Section id="inv205" depth={2}>
 			<Fragment slot="heading">INV205<small>（東芝、260kVA）</small></Fragment>
 
 			<Flex>
@@ -1193,7 +1193,7 @@ const structuredData: StructuredData = {
 			<p>2019年には9020系に改番され、他の編成ともども大井町線に転籍しています。</p>
 		</Section>
 
-		<Section id="cda021" depth={2} headingType="b">
+		<Section id="cda021" depth={2}>
 			<Fragment slot="heading">CDA021<small>（富士電機、30kVA）</small></Fragment>
 
 			<Flex>
@@ -1215,7 +1215,7 @@ const structuredData: StructuredData = {
 			<NoteRefContent id="pic644"><DocMagazine name="鉄道ピクトリアル" date="1997年10月臨時増刊号・新車年鑑" no={644} article="民鉄車両諸元表" pages={[175]} /></NoteRefContent>
 		</Section>
 
-		<Section id="bs483" depth={2} headingType="b">
+		<Section id="bs483" depth={2}>
 			<Fragment slot="heading">BS483<small>（東京芝浦電気、90kVA）</small></Fragment>
 
 			<Flex>
@@ -1233,7 +1233,7 @@ const structuredData: StructuredData = {
 			<p>いずれも新製ではなく転用品で、2007年に始まった更新工事で SIV を換装した小田急電鉄8000形（4両編成）の発生品である可能性が考えられます。</p>
 		</Section>
 
-		<Section id="rg5096" depth={2} headingType="b">
+		<Section id="rg5096" depth={2}>
 			<Fragment slot="heading">RG5096<small>（東洋電機製造）</small></Fragment>
 
 			<Flex>
@@ -1282,7 +1282,7 @@ const structuredData: StructuredData = {
 		<Section id="vvvf">
 			<Fragment slot="heading">VVVF 主制御器 / SIV 一体型</Fragment>
 
-			<Section id="rg660" depth={2} headingType="b">
+			<Section id="rg660" depth={2}>
 				<Fragment slot="heading">RG660<small>（東洋電機製造、140kVA）</small></Fragment>
 
 				<Flex>
@@ -1304,7 +1304,7 @@ const structuredData: StructuredData = {
 				<p>2010年に廃車され、消滅しました。</p>
 			</Section>
 
-			<Section id="svf041" depth={2} headingType="b">
+			<Section id="svf041" depth={2}>
 				<Fragment slot="heading">SVF041<small>（東芝、80kVA）</small></Fragment>
 
 				<Flex>
@@ -1322,7 +1322,7 @@ const structuredData: StructuredData = {
 				<p>2012年に登場した動力車デヤ7500、電気検測車デヤ7550 にも同じシステムが採用されています。</p>
 			</Section>
 
-			<Section id="svf091" depth={2} headingType="b">
+			<Section id="svf091" depth={2}>
 				<Fragment slot="heading">SVF091<small>（東芝、150kVA）</small></Fragment>
 
 				<Flex>
@@ -1349,7 +1349,7 @@ const structuredData: StructuredData = {
 	<Section id="series300">
 		<Fragment slot="heading">空調制御装置</Fragment>
 
-		<Section id="da61t" depth={2} headingType="b">
+		<Section id="da61t" depth={2}>
 			<Fragment slot="heading">DA61T<small>（三菱電機、20kVA）</small></Fragment>
 
 			<Flex>

--- a/astro/src/pages/tokyu/machine/atc.astro
+++ b/astro/src/pages/tokyu/machine/atc.astro
@@ -35,9 +35,9 @@ const structuredData: StructuredData = {
 	<Section id="dento">
 		<Fragment slot="heading">田園都市線、こどもの国線</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="dento-2" depth={2} headingType="c">
+				<Section id="dento-2" depth={2}>
 					<Fragment slot="heading">8590系、2000系<small>（三菱電機）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -52,7 +52,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="kodomo-2" depth={2} headingType="c">
+				<Section id="kodomo-2" depth={2}>
 					<Fragment slot="heading">Y000系<small>（日立製作所）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -70,9 +70,9 @@ const structuredData: StructuredData = {
 	<Section id="toyoko">
 		<Fragment slot="heading">東横線</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="toyoko-1" depth={2} headingType="c">
+				<Section id="toyoko-1" depth={2}>
 					<Fragment slot="heading">8000系（一部）<small>（日立製作所）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -87,7 +87,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="toyoko-2" depth={2} headingType="c">
+				<Section id="toyoko-2" depth={2}>
 					<Fragment slot="heading">8000系、9000系、1000系<small>（日立製作所）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -105,9 +105,9 @@ const structuredData: StructuredData = {
 	<Section id="meguro">
 		<Fragment slot="heading">目黒線</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="meguro-1" depth={2} headingType="c">
+				<Section id="meguro-1" depth={2}>
 					<Fragment slot="heading">新3000系<small>（三菱電機）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -125,9 +125,9 @@ const structuredData: StructuredData = {
 	<Section id="oimachi-ats">
 		<Fragment slot="heading">大井町線（ATS時代）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="dento-1" depth={2} headingType="c">
+				<Section id="dento-1" depth={2}>
 					<Fragment slot="heading">8000系、8090系、9000系<small>（日立製作所）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -147,9 +147,9 @@ const structuredData: StructuredData = {
 	<Section id="oimachi-atc">
 		<Fragment slot="heading">大井町線（ATC-P化）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="oimachi-1" depth={2} headingType="c">
+				<Section id="oimachi-1" depth={2}>
 					<Fragment slot="heading">8090系（一部）、9000系（一部）<small>（日立製作所）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/bce.astro
+++ b/astro/src/pages/tokyu/machine/bce.astro
@@ -36,9 +36,9 @@ const structuredData: StructuredData = {
 	<Section id="hsc">
 		<Fragment slot="heading">電磁直通ブレーキ</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="hd23" depth={2} headingType="c">
+				<Section id="hd23" depth={2}>
 					<Fragment slot="heading">7200系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -58,9 +58,9 @@ const structuredData: StructuredData = {
 	<Section id="electric">
 		<Fragment slot="heading">電気指令式ブレーキ</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="e6" depth={2} headingType="c">
+				<Section id="e6" depth={2}>
 					<Fragment slot="heading">8000系グループ、サヤ7590</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -75,7 +75,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="e30" depth={2} headingType="c">
+				<Section id="e30" depth={2}>
 					<Fragment slot="heading">9000系、1000系、2000系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -92,7 +92,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="e53" depth={2} headingType="c">
+				<Section id="e53" depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -107,7 +107,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="e78" depth={2} headingType="c">
+				<Section id="e78" depth={2}>
 					<Fragment slot="heading">新3000系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -122,7 +122,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="e80" depth={2} headingType="c">
+				<Section id="e80" depth={2}>
 					<Fragment slot="heading">300系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/bt.astro
+++ b/astro/src/pages/tokyu/machine/bt.astro
@@ -39,9 +39,9 @@ const slugger = new GithubSlugger();
 	<Section id="series7200">
 		<Fragment slot="heading">7200系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">7200系<small>（100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -57,9 +57,9 @@ const slugger = new GithubSlugger();
 	<Section id="series8000">
 		<Fragment slot="heading">8000系グループ、7600系、7700系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">8000系<small>（100V・20Ah、100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -70,7 +70,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">8500系、8090系、7600系、7700系<small>（100V・40Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -81,7 +81,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">7700系<small>（100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -92,7 +92,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">8500系、8090系<small>（24V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -103,7 +103,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系<small>（24V・20Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -119,9 +119,9 @@ const slugger = new GithubSlugger();
 	<Section id="series9000">
 		<Fragment slot="heading">9000系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">9000系<small>（100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -132,7 +132,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">9000系<small>（100V・30Ah / 24V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -148,9 +148,9 @@ const slugger = new GithubSlugger();
 	<Section id="series1000">
 		<Fragment slot="heading">1000系、2000系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">1000系、2000系<small>（100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -161,7 +161,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">1000系、2000系<small>（100V・30Ah / 24V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -177,9 +177,9 @@ const slugger = new GithubSlugger();
 	<Section id="series3000">
 		<Fragment slot="heading">新3000系、Y000系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">新3000系、Y000系<small>（100V・60Ah / 24V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -195,9 +195,9 @@ const slugger = new GithubSlugger();
 	<Section id="series300">
 		<Fragment slot="heading">300系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">300系<small>（100V・20Ah / 24V・80Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/bt.astro
+++ b/astro/src/pages/tokyu/machine/bt.astro
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7200系<small>（100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -59,7 +59,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">8000系<small>（100V・20Ah、100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -70,7 +70,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">8500系、8090系、7600系、7700系<small>（100V・40Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -81,7 +81,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7700系<small>（100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -92,7 +92,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">8500系、8090系<small>（24V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -103,7 +103,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系<small>（24V・20Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -121,7 +121,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">9000系<small>（100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -132,7 +132,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">9000系<small>（100V・30Ah / 24V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -150,7 +150,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1000系、2000系<small>（100V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -161,7 +161,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1000系、2000系<small>（100V・30Ah / 24V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -179,7 +179,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">新3000系、Y000系<small>（100V・60Ah / 24V・30Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -197,7 +197,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">300系<small>（100V・20Ah / 24V・80Ah）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/cont_fcc.astro
+++ b/astro/src/pages/tokyu/machine/cont_fcc.astro
@@ -181,7 +181,7 @@ const structuredData: StructuredData = {
 
 		<p>東急線からは<DateWareki value="2008" />までに消滅しましたが、国内では伊豆急行の譲渡車で多数が活躍しています。</p>
 
-		<Section id="8000-m1" depth={2} headingType="c" box={true}>
+		<Section id="8000-m1" depth={2} box={true}>
 			<Fragment slot="heading">8000系グループの単独 M<span class="u-tokyu-unit">1</span> 系車</Fragment>
 
 			<p>8000系はもともと新玉川線完成時に⑥両編成にて使用される想定で製造され、電動車は M<span class="u-tokyu-unit">1</span>–M<span class="u-tokyu-unit">2</span> で2両ユニットを組む構成ですが、1〜4次車の登場当初は東横線にて 3M2T の⑤両編成で運用されていました。この場合、電動車が奇数両になりますから、うち1両は MCOS 操作により M<span class="u-tokyu-unit">1</span> 車（デハ8100形）のみの単独制御となります。主電動機の接続は4台で、並列段には進まず直列制御のみとなり、電力回生ブレーキの有効速度はユニット車の直並列渡りに相当する約 45km/h までとなります（通常のユニット車は約 22km/h）。また運転特性を合わせるため、2ノッチ時もユニット車は強制的に3ノッチ投入で並列段に入るよう設定されました。</p>

--- a/astro/src/pages/tokyu/machine/cont_gto.astro
+++ b/astro/src/pages/tokyu/machine/cont_gto.astro
@@ -370,10 +370,10 @@ const slugger = new GithubSlugger();
 
 		<p>RG614-A-M 型と同じく、7600系の引退に伴い<DateWareki value="2015" />に消滅しました。</p>
 
-		<Section slugger={slugger} depth={2} box={true}>
+		<Section id={slugger} depth={2} box={true}>
 			<Fragment slot="heading">7600系編成替えと制御装置の変遷</Fragment>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1986" />5月時点<small>（デビュー）</small></Fragment>
 
 				<dl>
@@ -396,7 +396,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1986" />9月〜<DateWareki value="1987" />3月<small>（目蒲線転用・暫定編成）</small></Fragment>
 
 				<dl>
@@ -417,7 +417,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1987" />4月時点<small>（7601F 大井町線復帰）</small></Fragment>
 
 				<dl>
@@ -440,7 +440,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1988" />4月時点<small>（7601F〜7602F 目蒲線転籍）</small></Fragment>
 
 				<dl>
@@ -461,7 +461,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1988" />秋時点<small>（7601F〜7602F 1C4M 化）</small></Fragment>
 
 				<dl>
@@ -487,7 +487,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1989" />4月時点<small>（全車池上線転籍）</small></Fragment>
 
 				<dl>
@@ -508,7 +508,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1990" />5月時点<small>（7603F 編成替え &amp; 1C4M 化）</small></Fragment>
 
 				<dl>
@@ -529,7 +529,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1995" />4月時点<small>（室内更新）</small></Fragment>
 
 				<dl>
@@ -550,7 +550,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3}>
+			<Section id={slugger} depth={3}>
 				<Fragment slot="heading">参考文献</Fragment>
 
 				<List>

--- a/astro/src/pages/tokyu/machine/cont_gto.astro
+++ b/astro/src/pages/tokyu/machine/cont_gto.astro
@@ -370,10 +370,10 @@ const slugger = new GithubSlugger();
 
 		<p>RG614-A-M 型と同じく、7600系の引退に伴い<DateWareki value="2015" />に消滅しました。</p>
 
-		<Section slugger={slugger} depth={2} headingType="c" box={true}>
+		<Section slugger={slugger} depth={2} box={true}>
 			<Fragment slot="heading">7600系編成替えと制御装置の変遷</Fragment>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1986" />5月時点<small>（デビュー）</small></Fragment>
 
 				<dl>
@@ -396,7 +396,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1986" />9月〜<DateWareki value="1987" />3月<small>（目蒲線転用・暫定編成）</small></Fragment>
 
 				<dl>
@@ -417,7 +417,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1987" />4月時点<small>（7601F 大井町線復帰）</small></Fragment>
 
 				<dl>
@@ -440,7 +440,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1988" />4月時点<small>（7601F〜7602F 目蒲線転籍）</small></Fragment>
 
 				<dl>
@@ -461,7 +461,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1988" />秋時点<small>（7601F〜7602F 1C4M 化）</small></Fragment>
 
 				<dl>
@@ -487,7 +487,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1989" />4月時点<small>（全車池上線転籍）</small></Fragment>
 
 				<dl>
@@ -508,7 +508,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1990" />5月時点<small>（7603F 編成替え &amp; 1C4M 化）</small></Fragment>
 
 				<dl>
@@ -529,7 +529,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading"><DateWareki value="1995" />4月時点<small>（室内更新）</small></Fragment>
 
 				<dl>
@@ -550,7 +550,7 @@ const slugger = new GithubSlugger();
 				</dl>
 			</Section>
 
-			<Section slugger={slugger} depth={3} headingType="d">
+			<Section slugger={slugger} depth={3}>
 				<Fragment slot="heading">参考文献</Fragment>
 
 				<List>

--- a/astro/src/pages/tokyu/machine/cont_high.astro
+++ b/astro/src/pages/tokyu/machine/cont_high.astro
@@ -351,7 +351,7 @@ const structuredData: StructuredData = {
 
 		<p>現在は弘南鉄道大鰐線にC編成が1編成のみが残っていますが、本線で動くことはまずありません。</p>
 
-		<Section id="tdk-fr" depth={2} headingType="c" box={true}>
+		<Section id="tdk-fr" depth={2} box={true}>
 			<Fragment slot="heading">磁気増幅器制御の整流子型界磁調整器による弱め界磁制御</Fragment>
 
 			<p>抵抗制御車の力行において、速度上昇に伴い主電動機の回転が速くなるにつれ逆起電力が増加してゆきますが、低速域では抵抗を徐々に減らしてゆくことで主電動機に流れる電流を調整し、一定の加速度を維持します。すべての抵抗が短絡した後は、本来であれば回転力の伸びが大幅に低下し加速度が落ちてゆくところ、界磁に流れる電流を弱めて逆起電力を減らすことでその低下度を抑えることができ、これを<dfn>弱め界磁制御</dfn>と呼びます。</p>
@@ -408,7 +408,7 @@ const structuredData: StructuredData = {
 
 		<p>旧6000系B編成は晩年 VVVF インバーター制御の試験車として改造され、この制御装置は<DateWareki value="1984" />に消滅しました。</p>
 
-		<Section id="mcm" depth={2} headingType="c" box={true}>
+		<Section id="mcm" depth={2} box={true}>
 			<Fragment slot="heading">東芝 MCM パッケージ型主制御器</Fragment>
 
 			<p>旧6000系B編成の主制御器は東芝の資料によると <dfn>MCM 型</dfn>として区分されていますが<NoteRef type="ref" by="toshiba127" />、本来の MCM 型の特徴とはかなり違いがあります。</p>

--- a/astro/src/pages/tokyu/machine/cont_old.astro
+++ b/astro/src/pages/tokyu/machine/cont_old.astro
@@ -462,7 +462,7 @@ const structuredData: StructuredData = {
 			</FlexItem>
 		</Flex>
 
-		<Section id="moha150-transition" depth={2} headingType="c" box={true}>
+		<Section id="moha150-transition" depth={2} box={true}>
 			<Fragment slot="heading">モハ150形（デハ3300形）の制御装置の変遷</Fragment>
 
 			<p>前述のとおり鉄道省払い下げ車の半鋼体化改造は3回に分けて行われ、サハ1形<small>（東急サハ3350形）</small>4両とモハ150形<small>（東急デハ3300形）</small>11両になりました。</p>
@@ -568,7 +568,7 @@ const structuredData: StructuredData = {
 
 		<NoteRefContent id="echizen1101"><a href="/tokyu/yomoyama/echizen_mc1101">えちぜん鉄道MC1101形の主制御器（MMC-H-10K 型）</a></NoteRefContent>
 
-		<Section id="mmc-first" depth={2} headingType="c" box={true}>
+		<Section id="mmc-first" depth={2} box={true}>
 			<Fragment slot="heading">日本初の多段式制御装置の採用電車は?</Fragment>
 
 			<p>東京横浜電鉄モハ1000形は日本で初めて多段式制御装置を採用した電車であると紹介されることがありますが、日本初であることには疑念を抱いています。</p>

--- a/astro/src/pages/tokyu/machine/cp.astro
+++ b/astro/src/pages/tokyu/machine/cp.astro
@@ -353,7 +353,7 @@ const slugger = new GithubSlugger();
 	<Section id="hs20">
 		<Fragment slot="heading">HS20</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機<small>（HS20-1）</small></Fragment>
 
 			<Flex>
@@ -386,7 +386,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="sim">SIM とは開発元である佐竹製作所（現在の<Anchor href="https://satake-japan.co.jp/">株式会社サタケ</Anchor>）から名称を取った SATAKE Induction Motor の略です。1989年に開発され、1992年に東急電車にて初めて実車搭載がなされました。装置の詳細は<DocMagazine name="電気車の科学" date="1993年10月号" no={546} article="SIMモータ式空気圧縮機の実用化について" authors={['宮田道一', '尾崎正明']} pages={[36, 39]} />や<DocMagazine name="自動化技術" date="1993年11月号" article="車載用双固定子形誘導電動機式空気圧縮機の実用化" authors={['丸山博正']} pages={[56, 59]} url="https://dl.ndl.go.jp/pid/2322419/1/46" />に、また開発時のエピソードは<Anchor href="https://satake-japan.co.jp/news/new-release/news120418-2.html">新幹線E5系に採用された時のニュースリリース</Anchor>に掲載されています。</NoteRefContent>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機<small>（HS20G）</small></Fragment>
 
 			<Flex>
@@ -408,7 +408,7 @@ const slugger = new GithubSlugger();
 	<Section id="hs10">
 		<Fragment slot="heading">HS10</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機</Fragment>
 
 			<Flex>
@@ -437,7 +437,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="hs20-iga">2012年にク105 の銘板を調査したところ、製造番号は 89035 でした。通常、製造番号の上2桁は製造年を表すため、これは1989年製造であるものと思われます。一方、1000N′系の登場は1991年です。</NoteRefContent>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機</Fragment>
 
 			<Flex>
@@ -457,7 +457,7 @@ const slugger = new GithubSlugger();
 	<Section id="hs5">
 		<Fragment slot="heading">HS5</Fragment>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機<small>（HS5）</small></Fragment>
 
 			<Flex>
@@ -475,7 +475,7 @@ const slugger = new GithubSlugger();
 			<p>昔ながらのギヤ式 DH 型を搭載していた世田谷線のデハ70形は1980年代後半に CP 更新が行われ、この HS5 型へ交換されました。廃車後は300系に転用され、三軒茶屋向きのB車に2機が搭載されています。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2}>
+		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機<small>（HS5-1）</small></Fragment>
 
 			<Flex>

--- a/astro/src/pages/tokyu/machine/cp.astro
+++ b/astro/src/pages/tokyu/machine/cp.astro
@@ -353,7 +353,7 @@ const slugger = new GithubSlugger();
 	<Section id="hs20">
 		<Fragment slot="heading">HS20</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機<small>（HS20-1）</small></Fragment>
 
 			<Flex>
@@ -386,7 +386,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="sim">SIM とは開発元である佐竹製作所（現在の<Anchor href="https://satake-japan.co.jp/">株式会社サタケ</Anchor>）から名称を取った SATAKE Induction Motor の略です。1989年に開発され、1992年に東急電車にて初めて実車搭載がなされました。装置の詳細は<DocMagazine name="電気車の科学" date="1993年10月号" no={546} article="SIMモータ式空気圧縮機の実用化について" authors={['宮田道一', '尾崎正明']} pages={[36, 39]} />や<DocMagazine name="自動化技術" date="1993年11月号" article="車載用双固定子形誘導電動機式空気圧縮機の実用化" authors={['丸山博正']} pages={[56, 59]} url="https://dl.ndl.go.jp/pid/2322419/1/46" />に、また開発時のエピソードは<Anchor href="https://satake-japan.co.jp/news/new-release/news120418-2.html">新幹線E5系に採用された時のニュースリリース</Anchor>に掲載されています。</NoteRefContent>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機<small>（HS20G）</small></Fragment>
 
 			<Flex>
@@ -408,7 +408,7 @@ const slugger = new GithubSlugger();
 	<Section id="hs10">
 		<Fragment slot="heading">HS10</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機</Fragment>
 
 			<Flex>
@@ -437,7 +437,7 @@ const slugger = new GithubSlugger();
 			<NoteRefContent id="hs20-iga">2012年にク105 の銘板を調査したところ、製造番号は 89035 でした。通常、製造番号の上2桁は製造年を表すため、これは1989年製造であるものと思われます。一方、1000N′系の登場は1991年です。</NoteRefContent>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機</Fragment>
 
 			<Flex>
@@ -457,7 +457,7 @@ const slugger = new GithubSlugger();
 	<Section id="hs5">
 		<Fragment slot="heading">HS5</Fragment>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機<small>（HS5）</small></Fragment>
 
 			<Flex>
@@ -475,7 +475,7 @@ const slugger = new GithubSlugger();
 			<p>昔ながらのギヤ式 DH 型を搭載していた世田谷線のデハ70形は1980年代後半に CP 更新が行われ、この HS5 型へ交換されました。廃車後は300系に転用され、三軒茶屋向きのB車に2機が搭載されています。</p>
 		</Section>
 
-		<Section slugger={slugger} depth={2} headingType="b">
+		<Section slugger={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機<small>（HS5-1）</small></Fragment>
 
 			<Flex>

--- a/astro/src/pages/tokyu/machine/pt_7000.astro
+++ b/astro/src/pages/tokyu/machine/pt_7000.astro
@@ -41,9 +41,9 @@ const structuredData: StructuredData = {
 	<Section id="pantograph">
 		<Fragment slot="heading">菱形パンタグラフ</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="pt43" depth={2} headingType="c">
+				<Section id="pt43" depth={2}>
 					<Fragment slot="heading">PT43</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -64,7 +64,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="pt44" depth={2} headingType="c">
+				<Section id="pt44" depth={2}>
 					<Fragment slot="heading">PT44</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -87,7 +87,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="pt44s-c" depth={2} headingType="c">
+				<Section id="pt44s-c" depth={2}>
 					<Fragment slot="heading">PT44S（C型）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -111,7 +111,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="pt44s" depth={2} headingType="c">
+				<Section id="pt44s" depth={2}>
 					<Fragment slot="heading">PT44S（D型、E型）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -131,7 +131,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="pt4309" depth={2} headingType="c">
+				<Section id="pt4309" depth={2}>
 					<Fragment slot="heading">PT4309（架線検測車・測定用）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -154,9 +154,9 @@ const structuredData: StructuredData = {
 	<Section id="single-arm">
 		<Fragment slot="heading">シングルアーム形パンタグラフ</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="pt7108" depth={2} headingType="c">
+				<Section id="pt7108" depth={2}>
 					<Fragment slot="heading">PT7108</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/rec.astro
+++ b/astro/src/pages/tokyu/machine/rec.astro
@@ -47,9 +47,9 @@ const structuredData: StructuredData = {
 	<Section id="series7200">
 		<Fragment slot="heading">7200系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rs120" depth={2} headingType="c">
+				<Section id="rs120" depth={2}>
 					<Fragment slot="heading">RS120</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -67,9 +67,9 @@ const structuredData: StructuredData = {
 	<Section id="series8000">
 		<Fragment slot="heading">8000系グループ</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rs175" depth={2} headingType="c">
+				<Section id="rs175" depth={2}>
 					<Fragment slot="heading">RS175</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -82,7 +82,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="rs180" depth={2} headingType="c">
+				<Section id="rs180" depth={2}>
 					<Fragment slot="heading">RS180</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -100,9 +100,9 @@ const structuredData: StructuredData = {
 	<Section id="series9000">
 		<Fragment slot="heading">9000系、1000系、2000系、クハ7915</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rfe001a" depth={2} headingType="c">
+				<Section id="rfe001a" depth={2}>
 					<Fragment slot="heading">RFE001-A、RFE001-B</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -115,7 +115,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="rfe001d" depth={2} headingType="c">
+				<Section id="rfe001d" depth={2}>
 					<Fragment slot="heading">RFE001-C、RFE001-D</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -130,7 +130,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="rfe001e" depth={2} headingType="c">
+				<Section id="rfe001e" depth={2}>
 					<Fragment slot="heading">RFE001-E、RFE001-F</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -145,7 +145,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="rfe001g" depth={2} headingType="c">
+				<Section id="rfe001g" depth={2}>
 					<Fragment slot="heading">RFE001-G</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -163,9 +163,9 @@ const structuredData: StructuredData = {
 	<Section id="series7600">
 		<Fragment slot="heading">7600系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rfe005" depth={2} headingType="c">
+				<Section id="rfe005" depth={2}>
 					<Fragment slot="heading">RFE005</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -183,9 +183,9 @@ const structuredData: StructuredData = {
 	<Section id="series8500-18">
 		<Fragment slot="heading">8500系（18次車以降の編成車）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rfe007" depth={2} headingType="c">
+				<Section id="rfe007" depth={2}>
 					<Fragment slot="heading">RFE007</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -203,9 +203,9 @@ const structuredData: StructuredData = {
 	<Section id="series7700">
 		<Fragment slot="heading">7700系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rfe013" depth={2} headingType="c">
+				<Section id="rfe013" depth={2}>
 					<Fragment slot="heading">RFE013</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -218,7 +218,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="s4341" depth={2} headingType="c">
+				<Section id="s4341" depth={2}>
 					<Fragment slot="heading">S4341</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -236,9 +236,9 @@ const structuredData: StructuredData = {
 	<Section id="series3000">
 		<Fragment slot="heading">新3000系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="cg316" depth={2} headingType="c">
+				<Section id="cg316" depth={2}>
 					<Fragment slot="heading">CG316</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -256,9 +256,9 @@ const structuredData: StructuredData = {
 	<Section id="seriesY000">
 		<Fragment slot="heading">Y000系</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rfe059" depth={2} headingType="c">
+				<Section id="rfe059" depth={2}>
 					<Fragment slot="heading">RFE059</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -276,9 +276,9 @@ const structuredData: StructuredData = {
 	<Section id="series8090-100k">
 		<Fragment slot="heading">大井町線8090系二電源化工事車</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rfe068" depth={2} headingType="c">
+				<Section id="rfe068" depth={2}>
 					<Fragment slot="heading">RFE068</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -296,9 +296,9 @@ const structuredData: StructuredData = {
 	<Section id="v24">
 		<Fragment slot="heading">24V整流装置</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="rs157" depth={2} headingType="c">
+				<Section id="rs157" depth={2}>
 					<Fragment slot="heading">RS157</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/roof_1000n.astro
+++ b/astro/src/pages/tokyu/machine/roof_1000n.astro
@@ -38,9 +38,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-1000">
 		<Fragment slot="heading">クハ1000形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-1000N" depth={2} headingType="c">
+				<Section id="tc-1000N" depth={2}>
 					<Fragment slot="heading">1000N系、1000N′系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -60,9 +60,9 @@ const structuredData: StructuredData = {
 	<Section id="m-1200">
 		<Fragment slot="heading">デハ1200形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m-1200N" depth={2} headingType="c">
+				<Section id="m-1200N" depth={2}>
 					<Fragment slot="heading">1000N系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -77,7 +77,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m-1200N2" depth={2} headingType="c">
+				<Section id="m-1200N2" depth={2}>
 					<Fragment slot="heading">1000N′系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -95,9 +95,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-1300">
 		<Fragment slot="heading">デハ1300形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-1300N" depth={2} headingType="c">
+				<Section id="mc-1300N" depth={2}>
 					<Fragment slot="heading">1000N系、1000N′系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/roof_7200.astro
+++ b/astro/src/pages/tokyu/machine/roof_7200.astro
@@ -38,9 +38,9 @@ const structuredData: StructuredData = {
 	<Section id="cmc-7200">
 		<Fragment slot="heading">デヤ7200形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="cmc-7200-1" depth={2} headingType="c">
+				<Section id="cmc-7200-1" depth={2}>
 					<Fragment slot="heading">デヤ7200</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -60,9 +60,9 @@ const structuredData: StructuredData = {
 	<Section id="cmc-7290">
 		<Fragment slot="heading">デヤ7290形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="cmc-7290-1" depth={2} headingType="c">
+				<Section id="cmc-7290-1" depth={2}>
 					<Fragment slot="heading">デヤ7290<small>（集電装置換装前）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -79,7 +79,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="cmc-7290-2" depth={2} headingType="c">
+				<Section id="cmc-7290-2" depth={2}>
 					<Fragment slot="heading">デヤ7290<small>（集電装置シングルアーム化）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -101,9 +101,9 @@ const structuredData: StructuredData = {
 	<Section id="t-7590">
 		<Fragment slot="heading">サヤ7590形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="t-7590-1" depth={2} headingType="c">
+				<Section id="t-7590-1" depth={2}>
 					<Fragment slot="heading">サヤ7590</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/roof_7600.astro
+++ b/astro/src/pages/tokyu/machine/roof_7600.astro
@@ -39,9 +39,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-7600">
 		<Fragment slot="heading">クハ7600形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-7601" depth={2} headingType="c">
+				<Section id="tc-7601" depth={2}>
 					<Fragment slot="heading">クハ7601〜7603</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -61,9 +61,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-7650">
 		<Fragment slot="heading">デハ7650形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-7653" depth={2} headingType="c">
+				<Section id="mc-7653" depth={2}>
 					<Fragment slot="heading">デハ7653</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -80,7 +80,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7661" depth={2} headingType="c">
+				<Section id="mc-7661" depth={2}>
 					<Fragment slot="heading">デハ7661〜7662</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -100,9 +100,9 @@ const structuredData: StructuredData = {
 	<Section id="m-7670">
 		<Fragment slot="heading">デハ7670形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m-7673" depth={2} headingType="c">
+				<Section id="m-7673" depth={2}>
 					<Fragment slot="heading">デハ7673</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -117,7 +117,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m-7681" depth={2} headingType="c">
+				<Section id="m-7681" depth={2}>
 					<Fragment slot="heading">デハ7681〜7682</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/roof_7700.astro
+++ b/astro/src/pages/tokyu/machine/roof_7700.astro
@@ -42,9 +42,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700">
 		<Fragment slot="heading">デハ7700形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-7701" depth={2} headingType="c">
+				<Section id="mc-7701" depth={2}>
 					<Fragment slot="heading">デハ7701〜7702</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -61,7 +61,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7703" depth={2} headingType="c">
+				<Section id="mc-7703" depth={2}>
 					<Fragment slot="heading">デハ7703〜7708, 7712〜7714</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -74,7 +74,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7710" depth={2} headingType="c">
+				<Section id="mc-7710" depth={2}>
 					<Fragment slot="heading">デハ7710</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -92,9 +92,9 @@ const structuredData: StructuredData = {
 	<Section id="m-7800">
 		<Fragment slot="heading">デハ7800形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-7801" depth={2} headingType="c">
+				<Section id="mc-7801" depth={2}>
 					<Fragment slot="heading">デハ7801, 7803</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -109,7 +109,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7802" depth={2} headingType="c">
+				<Section id="mc-7802" depth={2}>
 					<Fragment slot="heading">デハ7802, 7805〜7808, 7812〜7714</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -122,7 +122,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7810" depth={2} headingType="c">
+				<Section id="mc-7810" depth={2}>
 					<Fragment slot="heading">デハ7810</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -140,9 +140,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900">
 		<Fragment slot="heading">クハ7900形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-7901" depth={2} headingType="c">
+				<Section id="tc-7901" depth={2}>
 					<Fragment slot="heading">クハ7901〜7902</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -157,7 +157,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7903" depth={2} headingType="c">
+				<Section id="tc-7903" depth={2}>
 					<Fragment slot="heading">クハ7903〜7914</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/roof_7700n.astro
+++ b/astro/src/pages/tokyu/machine/roof_7700n.astro
@@ -37,9 +37,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700">
 		<Fragment slot="heading">デハ7700形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-7715" depth={2} headingType="c">
+				<Section id="mc-7715" depth={2}>
 					<Fragment slot="heading">デハ7715</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -61,9 +61,9 @@ const structuredData: StructuredData = {
 	<Section id="m-7800">
 		<Fragment slot="heading">デハ7800形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m-7815" depth={2} headingType="c">
+				<Section id="m-7815" depth={2}>
 					<Fragment slot="heading">デハ7815</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -83,9 +83,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900">
 		<Fragment slot="heading">クハ7900形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-7915" depth={2} headingType="c">
+				<Section id="tc-7915" depth={2}>
 					<Fragment slot="heading">クハ7915</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/tra.astro
+++ b/astro/src/pages/tokyu/machine/tra.astro
@@ -33,9 +33,9 @@ const slugger = new GithubSlugger();
 	<Section id="door-non-treat">
 		<Fragment slot="heading">扉非扱い制御用</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">大井町線</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -48,7 +48,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -71,9 +71,9 @@ const slugger = new GithubSlugger();
 	<Section id="atc">
 		<Fragment slot="heading">列車情報などの伝送用</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">東横線（1000系まで）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -86,7 +86,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">目黒線、こどもの国線（Y000系）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -101,7 +101,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">大井町線</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/tra.astro
+++ b/astro/src/pages/tokyu/machine/tra.astro
@@ -35,7 +35,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">大井町線</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -48,7 +48,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -73,7 +73,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">東横線（1000系まで）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -86,7 +86,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">目黒線、こどもの国線（Y000系）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -101,7 +101,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">大井町線</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_1000n.astro
+++ b/astro/src/pages/tokyu/machine/ub_1000n.astro
@@ -46,9 +46,9 @@ const structuredData: StructuredData = {
 	<Section id="m1-1200">
 		<Fragment slot="heading">デハ1200形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m1-1200-s" depth={2} headingType="c">
+				<Section id="m1-1200-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -61,7 +61,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m1-1200-m" depth={2} headingType="c">
+				<Section id="m1-1200-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -79,9 +79,9 @@ const structuredData: StructuredData = {
 	<Section id="m1c-1310">
 		<Fragment slot="heading">デハ1310形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m1c-1310-s" depth={2} headingType="c">
+				<Section id="m1c-1310-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -94,7 +94,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m1c-1310-m" depth={2} headingType="c">
+				<Section id="m1c-1310-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -112,9 +112,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-1000">
 		<Fragment slot="heading">クハ1000形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-1000-sea" depth={2} headingType="c">
+				<Section id="tc-1000-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -127,7 +127,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-1000-mount" depth={2} headingType="c">
+				<Section id="tc-1000-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -145,9 +145,9 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="couple1200" depth={2} headingType="c">
+				<Section id="couple1200" depth={2}>
 					<Fragment slot="heading">デハ1200形 ｰ クハ1000形間</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -164,7 +164,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="couple1310" depth={2} headingType="c">
+				<Section id="couple1310" depth={2}>
 					<Fragment slot="heading">デハ1310形 ｰ デハ1200形間</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_1000n2.astro
+++ b/astro/src/pages/tokyu/machine/ub_1000n2.astro
@@ -45,9 +45,9 @@ const structuredData: StructuredData = {
 	<Section id="m-1200">
 		<Fragment slot="heading">デハ1200形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m-1200-sea" depth={2} headingType="c">
+				<Section id="m-1200-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -60,7 +60,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m-1200-mount" depth={2} headingType="c">
+				<Section id="m-1200-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -78,9 +78,9 @@ const structuredData: StructuredData = {
 	<Section id="m1c-1310">
 		<Fragment slot="heading">デハ1310形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m1c-1310-s" depth={2} headingType="c">
+				<Section id="m1c-1310-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -93,7 +93,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m1c-1310-m" depth={2} headingType="c">
+				<Section id="m1c-1310-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -111,9 +111,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-1000">
 		<Fragment slot="heading">クハ1000形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-1000-sea" depth={2} headingType="c">
+				<Section id="tc-1000-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -126,7 +126,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-1000-mount" depth={2} headingType="c">
+				<Section id="tc-1000-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -144,9 +144,9 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="couple1200" depth={2} headingType="c">
+				<Section id="couple1200" depth={2}>
 					<Fragment slot="heading">デハ1200形 ｰ クハ1000形間</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -163,7 +163,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="couple1310" depth={2} headingType="c">
+				<Section id="couple1310" depth={2}>
 					<Fragment slot="heading">デハ1310形 ｰ デハ1200形間</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_1500.astro
+++ b/astro/src/pages/tokyu/machine/ub_1500.astro
@@ -45,9 +45,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-1500">
 		<Fragment slot="heading">デハ1500形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-1500-sea" depth={2} headingType="c">
+				<Section id="mc-1500-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -60,7 +60,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-1500-mount" depth={2} headingType="c">
+				<Section id="mc-1500-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -78,9 +78,9 @@ const structuredData: StructuredData = {
 	<Section id="m-1600">
 		<Fragment slot="heading">デハ1600形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m-1600-sea" depth={2} headingType="c">
+				<Section id="m-1600-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -93,7 +93,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m-1600-mount" depth={2} headingType="c">
+				<Section id="m-1600-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -111,9 +111,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-1700">
 		<Fragment slot="heading">デハ1700形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-1700-sea" depth={2} headingType="c">
+				<Section id="mc-1700-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -126,7 +126,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-1700-mount" depth={2} headingType="c">
+				<Section id="mc-1700-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -144,9 +144,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-1500">
 		<Fragment slot="heading">クハ1500形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-1500-sea" depth={2} headingType="c">
+				<Section id="tc-1500-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -159,7 +159,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-1500-mount" depth={2} headingType="c">
+				<Section id="tc-1500-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -177,9 +177,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-1700">
 		<Fragment slot="heading">クハ1700形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-1700-sea" depth={2} headingType="c">
+				<Section id="tc-1700-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -192,7 +192,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-1700-mount" depth={2} headingType="c">
+				<Section id="tc-1700-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_7600.astro
+++ b/astro/src/pages/tokyu/machine/ub_7600.astro
@@ -49,9 +49,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-7650">
 		<Fragment slot="heading">デハ7650形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-7650-sea" depth={2} headingType="c">
+				<Section id="mc-7650-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -64,7 +64,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7650-mount" depth={2} headingType="c">
+				<Section id="mc-7650-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -82,9 +82,9 @@ const structuredData: StructuredData = {
 	<Section id="m-7670">
 		<Fragment slot="heading">デハ7670形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m-7670-sea" depth={2} headingType="c">
+				<Section id="m-7670-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -97,7 +97,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m-7670-mount" depth={2} headingType="c">
+				<Section id="m-7670-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -115,9 +115,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-7600">
 		<Fragment slot="heading">クハ7600形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-7600-sea" depth={2} headingType="c">
+				<Section id="tc-7600-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -130,7 +130,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7600-mount" depth={2} headingType="c">
+				<Section id="tc-7600-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -148,9 +148,9 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="couple7601" depth={2} headingType="c">
+				<Section id="couple7601" depth={2}>
 					<Fragment slot="heading">クハ7600形 ｰ デハ7670形間<small>（7601F, 7602F）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -167,7 +167,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="couple7603" depth={2} headingType="c">
+				<Section id="couple7603" depth={2}>
 					<Fragment slot="heading">クハ7600形 ｰ デハ7670形間<small>（7603F）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -184,7 +184,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="couple7661" depth={2} headingType="c">
+				<Section id="couple7661" depth={2}>
 					<Fragment slot="heading">デハ7650形 ｰ デハ7670形間<small>（7601F, 7602F）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -200,7 +200,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="couple7653" depth={2} headingType="c">
+				<Section id="couple7653" depth={2}>
 					<Fragment slot="heading">デハ7650形 ｰ デハ7670形間<small>（7603F）</small></Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_7700.astro
+++ b/astro/src/pages/tokyu/machine/ub_7700.astro
@@ -47,9 +47,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700">
 		<Fragment slot="heading">デハ7700形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-7700-sea" depth={2} headingType="c">
+				<Section id="mc-7700-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -64,7 +64,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7700-mount" depth={2} headingType="c">
+				<Section id="mc-7700-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -84,9 +84,9 @@ const structuredData: StructuredData = {
 	<Section id="m-7800">
 		<Fragment slot="heading">デハ7800形（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m-7800-sea" depth={2} headingType="c">
+				<Section id="m-7800-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -101,7 +101,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m-7800-mount" depth={2} headingType="c">
+				<Section id="m-7800-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -121,9 +121,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900">
 		<Fragment slot="heading">クハ7900形（台車間、東芝SIV搭載車）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-7900-sea" depth={2} headingType="c">
+				<Section id="tc-7900-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -140,7 +140,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7900-mount" depth={2} headingType="c">
+				<Section id="tc-7900-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -158,9 +158,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900-tdk">
 		<Fragment slot="heading">クハ7900形（台車間、東洋SIV搭載車）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-7900-tdk-s" depth={2} headingType="c">
+				<Section id="tc-7900-tdk-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -175,7 +175,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7900-tdk-m" depth={2} headingType="c">
+				<Section id="tc-7900-tdk-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -193,9 +193,9 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="couple7700" depth={2} headingType="c">
+				<Section id="couple7700" depth={2}>
 					<Fragment slot="heading">デハ7700形 ｰ デハ7800形間</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -212,7 +212,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="couple7800" depth={2} headingType="c">
+				<Section id="couple7800" depth={2}>
 					<Fragment slot="heading">デハ7800形 ｰ クハ7900形間</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_7700n.astro
+++ b/astro/src/pages/tokyu/machine/ub_7700n.astro
@@ -45,9 +45,9 @@ const structuredData: StructuredData = {
 	<Section id="mc-7715">
 		<Fragment slot="heading">デハ7715（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="mc-7715-sea" depth={2} headingType="c">
+				<Section id="mc-7715-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -60,7 +60,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7715-mount" depth={2} headingType="c">
+				<Section id="mc-7715-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -78,9 +78,9 @@ const structuredData: StructuredData = {
 	<Section id="m-7815">
 		<Fragment slot="heading">デハ7815（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m-7815-sea" depth={2} headingType="c">
+				<Section id="m-7815-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -93,7 +93,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m-7815-mount" depth={2} headingType="c">
+				<Section id="m-7815-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -111,9 +111,9 @@ const structuredData: StructuredData = {
 	<Section id="tc-7915">
 		<Fragment slot="heading">クハ7915（台車間）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="tc-7915-sea" depth={2} headingType="c">
+				<Section id="tc-7915-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -126,7 +126,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7915-mount" depth={2} headingType="c">
+				<Section id="tc-7915-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -144,9 +144,9 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="couple7715" depth={2} headingType="c">
+				<Section id="couple7715" depth={2}>
 					<Fragment slot="heading">デハ7700形 ｰ デハ7800形間</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -163,7 +163,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="couple7815" depth={2} headingType="c">
+				<Section id="couple7815" depth={2}>
 					<Fragment slot="heading">デハ7700形 ｰ デハ7800形間</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_7900_m.astro
+++ b/astro/src/pages/tokyu/machine/ub_7900_m.astro
@@ -46,9 +46,9 @@ const structuredData: StructuredData = {
 	<Section id="air">
 		<Fragment slot="heading">元空気指令車（1〜3次車）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="c7901" depth={2} headingType="c">
+				<Section id="c7901" depth={2}>
 					<Fragment slot="heading">クハ7901</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -61,7 +61,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7902" depth={2} headingType="c">
+				<Section id="c7902" depth={2}>
 					<Fragment slot="heading">クハ7902</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -74,7 +74,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7903" depth={2} headingType="c">
+				<Section id="c7903" depth={2}>
 					<Fragment slot="heading">クハ7903</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -87,7 +87,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7905" depth={2} headingType="c">
+				<Section id="c7905" depth={2}>
 					<Fragment slot="heading">クハ7905</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -100,7 +100,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7906" depth={2} headingType="c">
+				<Section id="c7906" depth={2}>
 					<Fragment slot="heading">クハ7906</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -113,7 +113,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7907" depth={2} headingType="c">
+				<Section id="c7907" depth={2}>
 					<Fragment slot="heading">クハ7907</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -126,7 +126,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7908" depth={2} headingType="c">
+				<Section id="c7908" depth={2}>
 					<Fragment slot="heading">クハ7908</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -139,7 +139,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7910" depth={2} headingType="c">
+				<Section id="c7910" depth={2}>
 					<Fragment slot="heading">クハ7910</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -157,9 +157,9 @@ const structuredData: StructuredData = {
 	<Section id="electric">
 		<Fragment slot="heading">改造当初からの電気指令車（4〜5次車）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="c7912" depth={2} headingType="c">
+				<Section id="c7912" depth={2}>
 					<Fragment slot="heading">クハ7912</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -172,7 +172,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7913" depth={2} headingType="c">
+				<Section id="c7913" depth={2}>
 					<Fragment slot="heading">クハ7913</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -185,7 +185,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="c7914" depth={2} headingType="c">
+				<Section id="c7914" depth={2}>
 					<Fragment slot="heading">クハ7914</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -203,9 +203,9 @@ const structuredData: StructuredData = {
 	<Section id="t-7950">
 		<Fragment slot="heading">サハ7950形からの改造車（5次車）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="c7915" depth={2} headingType="c">
+				<Section id="c7915" depth={2}>
 					<Fragment slot="heading">クハ7915</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_8290.astro
+++ b/astro/src/pages/tokyu/machine/ub_8290.astro
@@ -41,9 +41,9 @@ const structuredData: StructuredData = {
 	<Section id="m2-8290-bs33">
 		<Fragment slot="heading">10kVA SIV 搭載車</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m2-8290-bs33-s" depth={2} headingType="c">
+				<Section id="m2-8290-bs33-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -56,7 +56,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m2-8290-bs33-m" depth={2} headingType="c">
+				<Section id="m2-8290-bs33-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -69,7 +69,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m2-8290-bs33-j" depth={2} headingType="c">
+				<Section id="m2-8290-bs33-j" depth={2}>
 					<Fragment slot="heading">山側連結部</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -87,9 +87,9 @@ const structuredData: StructuredData = {
 	<Section id="m2-8290-inv104">
 		<Fragment slot="heading">100kVA SIV（INV-104 型）搭載車</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m2-8290-inv104-s" depth={2} headingType="c">
+				<Section id="m2-8290-inv104-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -102,7 +102,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m2-8290-inv104-m" depth={2} headingType="c">
+				<Section id="m2-8290-inv104-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -115,7 +115,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m2-8290-inv104-j" depth={2} headingType="c">
+				<Section id="m2-8290-inv104-j" depth={2}>
 					<Fragment slot="heading">山側連結部</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -133,9 +133,9 @@ const structuredData: StructuredData = {
 	<Section id="m2-8290-inv153">
 		<Fragment slot="heading">100kVA SIV（INV-153 型）搭載車</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m2-8290-inv153-s" depth={2} headingType="c">
+				<Section id="m2-8290-inv153-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -150,7 +150,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m2-8290-inv153-j" depth={2} headingType="c">
+				<Section id="m2-8290-inv153-j" depth={2}>
 					<Fragment slot="heading">山側連結部</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -166,9 +166,9 @@ const structuredData: StructuredData = {
 	<Section id="m2-8200">
 		<Fragment slot="heading">（参考）10kVA SIV 搭載車・デハ8200形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m2-820-s" depth={2} headingType="c">
+				<Section id="m2-820-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/ub_8800.astro
+++ b/astro/src/pages/tokyu/machine/ub_8800.astro
@@ -40,9 +40,9 @@ const structuredData: StructuredData = {
 	<Section id="m2-8800">
 		<Fragment slot="heading">通常のデハ8800形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m2-8800-7" depth={2} headingType="c">
+				<Section id="m2-8800-7" depth={2}>
 					<Fragment slot="heading">7〜11次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -57,7 +57,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="m2-8800-14" depth={2} headingType="c">
+				<Section id="m2-8800-14" depth={2}>
 					<Fragment slot="heading">14〜17次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -77,9 +77,9 @@ const structuredData: StructuredData = {
 	<Section id="cpremove">
 		<Fragment slot="heading">CP撤去車（6号車に連結されたデハ8800形）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="cpremove-10" depth={2} headingType="c">
+				<Section id="cpremove-10" depth={2}>
 					<Fragment slot="heading">10〜11次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -94,7 +94,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="cpremove-13" depth={2} headingType="c">
+				<Section id="cpremove-13" depth={2}>
 					<Fragment slot="heading">14〜17次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -107,7 +107,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="bttransfer" depth={2} headingType="c">
+				<Section id="bttransfer" depth={2}>
 					<Fragment slot="heading">蓄電池移設車（18-1次車）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -122,7 +122,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="frame" depth={2} headingType="c">
+				<Section id="frame" depth={2}>
 					<Fragment slot="heading">HB-2000型の吊り枠搭載車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -140,9 +140,9 @@ const structuredData: StructuredData = {
 	<Section id="hs20">
 		<Fragment slot="heading">HS-20型コンプレッサ搭載車</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="hs20-18" depth={2} headingType="c">
+				<Section id="hs20-18" depth={2}>
 					<Fragment slot="heading">18〜21次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -162,9 +162,9 @@ const structuredData: StructuredData = {
 	<Section id="m2-8290">
 		<Fragment slot="heading">（参考）デハ8290形</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="m2-8290-16" depth={2} headingType="c">
+				<Section id="m2-8290-16" depth={2}>
 					<Fragment slot="heading">16〜17次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/usl.astro
+++ b/astro/src/pages/tokyu/machine/usl.astro
@@ -34,9 +34,9 @@ const slugger = new GithubSlugger();
 	<Section id="olr">
 		<Fragment slot="heading">7200系、7600系の過負荷灯</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">オリジナルタイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -49,7 +49,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">新型タイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -67,9 +67,9 @@ const slugger = new GithubSlugger();
 	<Section id="series8000">
 		<Fragment slot="heading">8000系グループ、7600系、7700系等の床下灯</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">3灯タイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -89,9 +89,9 @@ const slugger = new GithubSlugger();
 	<Section id="series9000">
 		<Fragment slot="heading">9000系、2000系等の床下灯</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">4灯タイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -104,7 +104,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">3灯タイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/machine/usl.astro
+++ b/astro/src/pages/tokyu/machine/usl.astro
@@ -36,7 +36,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">オリジナルタイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -49,7 +49,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">新型タイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -69,7 +69,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">3灯タイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -91,7 +91,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">4灯タイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -104,7 +104,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">3灯タイプ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/set/index.astro
+++ b/astro/src/pages/tokyu/set/index.astro
@@ -18,7 +18,7 @@ const structuredData: StructuredData = {
 	<Section id="tokyu">
 		<Fragment slot="heading">東急電鉄</Fragment>
 
-		<Section id="series7600" depth={2} headingType="b">
+		<Section id="series7600" depth={2}>
 			<Fragment slot="heading">7600系、7700系</Fragment>
 
 			<IndexTable>
@@ -43,7 +43,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series8000" depth={2} headingType="b">
+		<Section id="series8000" depth={2}>
 			<Fragment slot="heading">8000系</Fragment>
 
 			<IndexTable>
@@ -77,7 +77,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series8090" depth={2} headingType="b">
+		<Section id="series8090" depth={2}>
 			<Fragment slot="heading">8090系</Fragment>
 
 			<IndexTable>
@@ -134,7 +134,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series8500" depth={2} headingType="b">
+		<Section id="series8500" depth={2}>
 			<Fragment slot="heading">8500系</Fragment>
 
 			<IndexTable>
@@ -212,7 +212,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series8590" depth={2} headingType="b">
+		<Section id="series8590" depth={2}>
 			<Fragment slot="heading">8590系</Fragment>
 
 			<IndexTable>
@@ -273,7 +273,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series9000" depth={2} headingType="b">
+		<Section id="series9000" depth={2}>
 			<Fragment slot="heading">9000系</Fragment>
 
 			<IndexTable>
@@ -345,7 +345,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series1000" depth={2} headingType="b">
+		<Section id="series1000" depth={2}>
 			<Fragment slot="heading">1000系</Fragment>
 
 			<IndexTable>
@@ -403,7 +403,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series2000" depth={2} headingType="b">
+		<Section id="series2000" depth={2}>
 			<Fragment slot="heading">2000系</Fragment>
 
 			<IndexTable>
@@ -426,7 +426,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series3000" depth={2} headingType="b">
+		<Section id="series3000" depth={2}>
 			<Fragment slot="heading">新3000系</Fragment>
 
 			<IndexTable>
@@ -447,7 +447,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="series300" depth={2} headingType="b">
+		<Section id="series300" depth={2}>
 			<Fragment slot="heading">300系</Fragment>
 
 			<IndexTable>
@@ -476,7 +476,7 @@ const structuredData: StructuredData = {
 	<Section id="transfer">
 		<Fragment slot="heading">譲渡車両</Fragment>
 
-		<Section id="ner" depth={2} headingType="b">
+		<Section id="ner" depth={2}>
 			<Fragment slot="heading">長野電鉄</Fragment>
 
 			<IndexTable>
@@ -497,7 +497,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="ueda" depth={2} headingType="b">
+		<Section id="ueda" depth={2}>
 			<Fragment slot="heading">上田電鉄</Fragment>
 
 			<IndexTable>
@@ -520,7 +520,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="ikk" depth={2} headingType="b">
+		<Section id="ikk" depth={2}>
 			<Fragment slot="heading">伊豆急行</Fragment>
 
 			<IndexTable>
@@ -548,7 +548,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="toyohashi" depth={2} headingType="b">
+		<Section id="toyohashi" depth={2}>
 			<Fragment slot="heading">豊橋鉄道</Fragment>
 
 			<IndexTable>
@@ -573,7 +573,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="toyama" depth={2} headingType="b">
+		<Section id="toyama" depth={2}>
 			<Fragment slot="heading">富山地方鉄道</Fragment>
 
 			<IndexTable>
@@ -608,7 +608,7 @@ const structuredData: StructuredData = {
 			</IndexTable>
 		</Section>
 
-		<Section id="yoro" depth={2} headingType="b">
+		<Section id="yoro" depth={2}>
 			<Fragment slot="heading">養老鉄道</Fragment>
 
 			<IndexTable>

--- a/astro/src/pages/tokyu/truck/ts1000.astro
+++ b/astro/src/pages/tokyu/truck/ts1000.astro
@@ -181,7 +181,7 @@ const structuredData: StructuredData = {
 	<Section id="ts1004">
 		<Fragment slot="heading">TS-1004 型</Fragment>
 
-		<Section id="ts1004-m" depth={2} headingType="b">
+		<Section id="ts1004-m" depth={2}>
 			<Fragment slot="heading">TS-1004 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -203,7 +203,7 @@ const structuredData: StructuredData = {
 	<Section id="ts1005">
 		<Fragment slot="heading">TS-1005 型</Fragment>
 
-		<Section id="ts1005-t" depth={2} headingType="b">
+		<Section id="ts1005-t" depth={2}>
 			<Fragment slot="heading">TS-1005 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -231,7 +231,7 @@ const structuredData: StructuredData = {
 	<Section id="ts1006">
 		<Fragment slot="heading">TS-1006 型</Fragment>
 
-		<Section id="ts1006-m" depth={2} headingType="b">
+		<Section id="ts1006-m" depth={2}>
 			<Fragment slot="heading">TS-1006 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -243,7 +243,7 @@ const structuredData: StructuredData = {
 			<p>地下鉄日比谷線乗入れ用として1988年に導入された1000系は、先代の乗入れ車である7000系と同じく床面高さが他の車種より 45mm 低い 1125mm となっています。そのため9000系の台車と比較すると、軸ばね寸法が変更されて側梁の位置が低くなったほか、肩部の形状が異なるなど若干の差異がみられます。</p>
 		</Section>
 
-		<Section id="ts1006a" depth={2} headingType="b">
+		<Section id="ts1006a" depth={2}>
 			<Fragment slot="heading">TS-1006A <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -259,7 +259,7 @@ const structuredData: StructuredData = {
 	<Section id="ts1007">
 		<Fragment slot="heading">TS-1007 型</Fragment>
 
-		<Section id="ts1007-t" depth={2} headingType="b">
+		<Section id="ts1007-t" depth={2}>
 			<Fragment slot="heading">TS-1007 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -285,7 +285,7 @@ const structuredData: StructuredData = {
 	<Section id="ts1010">
 		<Fragment slot="heading">TS-1010 型</Fragment>
 
-		<Section id="ts1010-m" depth={2} headingType="b">
+		<Section id="ts1010-m" depth={2}>
 			<Fragment slot="heading">TS-1010 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -305,7 +305,7 @@ const structuredData: StructuredData = {
 	<Section id="ts1011">
 		<Fragment slot="heading">TS-1011 型</Fragment>
 
-		<Section id="ts1011-t" depth={2} headingType="b">
+		<Section id="ts1011-t" depth={2}>
 			<Fragment slot="heading">TS-1011 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -331,7 +331,7 @@ const structuredData: StructuredData = {
 	<Section id="ts1019">
 		<Fragment slot="heading">TS-1019 型</Fragment>
 
-		<Section id="ts1019-m" depth={2} headingType="b">
+		<Section id="ts1019-m" depth={2}>
 			<Fragment slot="heading">TS-1019 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -349,7 +349,7 @@ const structuredData: StructuredData = {
 	<Section id="ts1020">
 		<Fragment slot="heading">TS-1020 型</Fragment>
 
-		<Section id="ts1020-t" depth={2} headingType="b">
+		<Section id="ts1020-t" depth={2}>
 			<Fragment slot="heading">TS-1020 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/truck/ts300.astro
+++ b/astro/src/pages/tokyu/truck/ts300.astro
@@ -181,7 +181,7 @@ const structuredData: StructuredData = {
 	<Section id="ts301">
 		<Fragment slot="heading">TS-301 型</Fragment>
 
-		<Section id="ts301-m" depth={2} headingType="b">
+		<Section id="ts301-m" depth={2}>
 			<Fragment slot="heading">TS-301 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -213,7 +213,7 @@ const structuredData: StructuredData = {
 			<p>旧5000系グループは譲渡車も含めて全車引退しましたが、最後まで残った熊本電気鉄道モハ5101A が北熊本車庫で動態保存されているほか、台車付きの静態保存車も複数存在します。</p>
 		</Section>
 
-		<Section id="ts301-t" depth={2} headingType="b">
+		<Section id="ts301-t" depth={2}>
 			<Fragment slot="heading">TS-301 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -277,7 +277,7 @@ const structuredData: StructuredData = {
 	<Section id="ts302">
 		<Fragment slot="heading">TS-302 型</Fragment>
 
-		<Section id="ts302-m" depth={2} headingType="b">
+		<Section id="ts302-m" depth={2}>
 			<Fragment slot="heading">TS-302 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -299,7 +299,7 @@ const structuredData: StructuredData = {
 	<Section id="ts315">
 		<Fragment slot="heading">TS-315 型</Fragment>
 
-		<Section id="ts315-m" depth={2} headingType="b">
+		<Section id="ts315-m" depth={2}>
 			<Fragment slot="heading">TS-315 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -323,7 +323,7 @@ const structuredData: StructuredData = {
 	<Section id="ts332">
 		<Fragment slot="heading">TS-332 型</Fragment>
 
-		<Section id="ts332-m" depth={2} headingType="b">
+		<Section id="ts332-m" depth={2}>
 			<Fragment slot="heading">TS-332 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -339,7 +339,7 @@ const structuredData: StructuredData = {
 			<p>1999年に登場した300系連接車両は、空気圧縮機など一部機器とともに台車も在来車から流用していますが、動力台車が不足したため2000年から2001年にかけて6台が付随台車から電動化され、さらに2004年には2台の追加新造が行われています。なお、在来車からの流用に際しスペーサが撤去されたほか、<AnchorPhoto image={image_TS332_301B_adhere} title="デハ301B 上り方海側"><!-- 撮影日: 2007-01-28 -->増粘着材噴射装置</AnchorPhoto>が設けられています。</p>
 		</Section>
 
-		<Section id="ts332t" depth={2} headingType="b">
+		<Section id="ts332t" depth={2}>
 			<Fragment slot="heading">TS-332T <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -361,7 +361,7 @@ const structuredData: StructuredData = {
 	<Section id="ts333">
 		<Fragment slot="heading">TS-333 型</Fragment>
 
-		<Section id="ts333-t" depth={2} headingType="b">
+		<Section id="ts333-t" depth={2}>
 			<Fragment slot="heading">TS-333 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -379,7 +379,7 @@ const structuredData: StructuredData = {
 	<Section id="ts334">
 		<Fragment slot="heading">TS-334 型</Fragment>
 
-		<Section id="ts334-t" depth={2} headingType="b">
+		<Section id="ts334-t" depth={2}>
 			<Fragment slot="heading">TS-334 <TruckIcon><small>中間台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/truck/ts700.astro
+++ b/astro/src/pages/tokyu/truck/ts700.astro
@@ -103,7 +103,7 @@ const structuredData: StructuredData = {
 	<Section id="ts701">
 		<Fragment slot="heading">TS-701 型<small>（PⅢ-701 型）</small></Fragment>
 
-		<Section id="ts701-m" depth={2} headingType="b">
+		<Section id="ts701-m" depth={2}>
 			<Fragment slot="heading">TS-701 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -119,7 +119,7 @@ const structuredData: StructuredData = {
 			<p>地方私鉄に譲渡された車両も徐々に置き換えが進んでいますが、弘南鉄道と水間鉄道で活躍が続いているほか、上毛電気鉄道大胡車庫などで仮台車として活用されている例も見られます。</p>
 		</Section>
 
-		<Section id="ts701-t" depth={2} headingType="b">
+		<Section id="ts701-t" depth={2}>
 			<Fragment slot="heading">TS-701 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -135,7 +135,7 @@ const structuredData: StructuredData = {
 	<Section id="ts708">
 		<Fragment slot="heading">TS-708 型<small>（PⅢ-708 型）</small></Fragment>
 
-		<Section id="ts708-t" depth={2} headingType="b">
+		<Section id="ts708-t" depth={2}>
 			<Fragment slot="heading">TS-708 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/truck/ts800.astro
+++ b/astro/src/pages/tokyu/truck/ts800.astro
@@ -240,7 +240,7 @@ const structuredData: StructuredData = {
 	<Section id="ts802">
 		<Fragment slot="heading">TS-802 型</Fragment>
 
-		<Section id="ts802-m" depth={2} headingType="b">
+		<Section id="ts802-m" depth={2}>
 			<Fragment slot="heading">TS-802 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -264,7 +264,7 @@ const structuredData: StructuredData = {
 			<NoteRefContent id="toyohashi-cerajet">豊橋鉄道モ1802, 1804, 1807 の3両。</NoteRefContent>
 		</Section>
 
-		<Section id="ts802a" depth={2} headingType="b">
+		<Section id="ts802a" depth={2}>
 			<Fragment slot="heading">TS-802A <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -490,7 +490,7 @@ const structuredData: StructuredData = {
 	<Section id="ts807">
 		<Fragment slot="heading">TS-807 型</Fragment>
 
-		<Section id="ts807-m" depth={2} headingType="b">
+		<Section id="ts807-m" depth={2}>
 			<Fragment slot="heading">TS-807, TS-807M <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -504,7 +504,7 @@ const structuredData: StructuredData = {
 			<p>1975年には8000系をマイナーチェンジした8500系が登場していますが、同じ年に製造されたデハ8200形6次車ともども、動力台車は ISO ネジを全面的に採用した M 型となりました。</p>
 		</Section>
 
-		<Section id="ts807a" depth={2} headingType="b">
+		<Section id="ts807a" depth={2}>
 			<Fragment slot="heading">TS-807A, TS-807C <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -520,7 +520,7 @@ const structuredData: StructuredData = {
 			<p>VVVF 車として新造された最終増備の21次車（デハ0718, 0818）は9000系と同じタイプの TKM-86 型主電動機を搭載しており、台車も C 型に変更されました。</p>
 		</Section>
 
-		<Section id="ts807b" depth={2} headingType="b">
+		<Section id="ts807b" depth={2}>
 			<Fragment slot="heading">TS-807B <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -540,7 +540,7 @@ const structuredData: StructuredData = {
 	<Section id="ts815">
 		<Fragment slot="heading">TS-815 型</Fragment>
 
-		<Section id="ts815m" depth={2} headingType="b">
+		<Section id="ts815m" depth={2}>
 			<Fragment slot="heading"><small>（TS-815M →）</small>TS-815C <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -562,7 +562,7 @@ const structuredData: StructuredData = {
 			<p>2枚目写真は軌条塗油器が設置されていた車両の台車です。<a href="/tokyu/truck/ts700">TS-700 系台車</a>では油噴口が台車の側梁に直接取り付けられていましたが、TS-800 系では左右の軸箱部からバーを渡し、その中央部に設ける形となったため外観も目立つものとなりました。M 型改造台車の油噴口付きは2006年までに廃車や他車への付け替えにより東急電鉄からは消滅しましたが、現在でも長野電鉄譲渡車で見ることができます。</p>
 		</Section>
 
-		<Section id="ts815a" depth={2} headingType="b">
+		<Section id="ts815a" depth={2}>
 			<Fragment slot="heading"><small>（TS-815A →）</small>TS-815C <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -576,7 +576,7 @@ const structuredData: StructuredData = {
 			<p>この台車を履いていた車両のうちサハ8300形（サハ8301〜8308 の8両）は1985年に電装化改造を受けましたが、その際台車は改めて新製され、それまで履いていた TS-815A 型は当時の新造車両へ流用されました。</p>
 		</Section>
 
-		<Section id="ts815b" depth={2} headingType="b">
+		<Section id="ts815b" depth={2}>
 			<Fragment slot="heading"><small>（TS-815B →）</small>TS-815E <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -588,7 +588,7 @@ const structuredData: StructuredData = {
 			<p>8090系用の付随台車は B 型で、動力台車（<a href="#ts807a">TS-807B 型</a>）と同じくブレーキシリンダ径の変更などが行われていますが、踏面清掃装置の設置はないためペデスタル部のボルト留め機構は存在しません。この形式もディスクブレーキ化を受けて E 型に変更されました。</p>
 		</Section>
 
-		<Section id="ts815c" depth={2} headingType="b">
+		<Section id="ts815c" depth={2}>
 			<Fragment slot="heading">TS-815C<small>（オリジナル）</small> <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -602,7 +602,7 @@ const structuredData: StructuredData = {
 			<p>多くの個体がペデスタル部のボルト留め機構を持っていますが、17次車のうちサハ8971, 8972の2両のみは非設置でした。1985年に行われたサハ8300形の電装化に伴う <a href="#ts815a">TS-815A型</a>発生品を流用していたものと思われます。</p>
 		</Section>
 
-		<Section id="ts815d" depth={2} headingType="b">
+		<Section id="ts815d" depth={2}>
 			<Fragment slot="heading">TS-815D <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -618,7 +618,7 @@ const structuredData: StructuredData = {
 			<NoteRefContent id="ts815d-clean">クハ8080, 8083, 8084, 8099 の4両。</NoteRefContent>
 		</Section>
 
-		<Section id="ts815f" depth={2} headingType="b">
+		<Section id="ts815f" depth={2}>
 			<Fragment slot="heading">TS-815F, <small>（TS-815F →）</small>TS-815T, <small>（TS-835 → TS-839 →）</small>TS-815T <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -640,7 +640,7 @@ const structuredData: StructuredData = {
 	<Section id="ts831">
 		<Fragment slot="heading">TS-831 型</Fragment>
 
-		<Section id="ts831-m" depth={2} headingType="b">
+		<Section id="ts831-m" depth={2}>
 			<Fragment slot="heading">TS-831 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -664,7 +664,7 @@ const structuredData: StructuredData = {
 	<Section id="ts832">
 		<Fragment slot="heading">TS-832 型</Fragment>
 
-		<Section id="ts832-m" depth={2} headingType="b">
+		<Section id="ts832-m" depth={2}>
 			<Fragment slot="heading">TS-832 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -690,7 +690,7 @@ const structuredData: StructuredData = {
 	<Section id="ts835">
 		<Fragment slot="heading">TS-835 型</Fragment>
 
-		<Section id="ts835-t" depth={2} headingType="b">
+		<Section id="ts835-t" depth={2}>
 			<Fragment slot="heading">TS-835 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>
@@ -720,7 +720,7 @@ const structuredData: StructuredData = {
 	<Section id="ts839">
 		<Fragment slot="heading">TS-839 型</Fragment>
 
-		<Section id="ts839-t" depth={2} headingType="b">
+		<Section id="ts839-t" depth={2}>
 			<Fragment slot="heading">TS-839 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
 			<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/yomoyama/7700_front.astro
+++ b/astro/src/pages/tokyu/yomoyama/7700_front.astro
@@ -524,13 +524,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700">
 		<Fragment slot="heading">デハ7700形</Fragment>
 
-		<Grid column="narrow" headingType="c">
+		<Grid column="medium">
 			<GridItem>
-				<Section id="mc-7701" depth={2} headingType="c">
+				<Section id="mc-7701" depth={2}>
 					<Fragment slot="heading">デハ7701<small>（1次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7701} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7701} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -538,11 +538,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7702" depth={2} headingType="c">
+				<Section id="mc-7702" depth={2}>
 					<Fragment slot="heading">デハ7702<small>（1次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7702} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7702} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-07 -->
 					</Embedded>
 
@@ -550,11 +550,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7703" depth={2} headingType="c">
+				<Section id="mc-7703" depth={2}>
 					<Fragment slot="heading">デハ7703<small>（2次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7703} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7703} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-21 -->
 					</Embedded>
 
@@ -562,11 +562,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7705" depth={2} headingType="c">
+				<Section id="mc-7705" depth={2}>
 					<Fragment slot="heading">デハ7705<small>（2次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7705} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7705} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-16 -->
 					</Embedded>
 
@@ -574,11 +574,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7706" depth={2} headingType="c">
+				<Section id="mc-7706" depth={2}>
 					<Fragment slot="heading">デハ7706<small>（2次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7706} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7706} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-02 -->
 					</Embedded>
 
@@ -586,11 +586,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7707" depth={2} headingType="c">
+				<Section id="mc-7707" depth={2}>
 					<Fragment slot="heading">デハ7707<small>（3次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7707} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7707} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-08 -->
 					</Embedded>
 
@@ -598,11 +598,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7708" depth={2} headingType="c">
+				<Section id="mc-7708" depth={2}>
 					<Fragment slot="heading">デハ7708<small>（2次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7708} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7708} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-08 -->
 					</Embedded>
 
@@ -610,11 +610,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7710" depth={2} headingType="c">
+				<Section id="mc-7710" depth={2}>
 					<Fragment slot="heading">デハ7710<small>（3次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7710} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7710} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-22 -->
 					</Embedded>
 
@@ -622,11 +622,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7712" depth={2} headingType="c">
+				<Section id="mc-7712" depth={2}>
 					<Fragment slot="heading">デハ7712<small>（4次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7712} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7712} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-09 -->
 					</Embedded>
 
@@ -634,11 +634,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7713" depth={2} headingType="c">
+				<Section id="mc-7713" depth={2}>
 					<Fragment slot="heading">デハ7713<small>（5次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7713} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7713} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -646,11 +646,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7714" depth={2} headingType="c">
+				<Section id="mc-7714" depth={2}>
 					<Fragment slot="heading">デハ7714<small>（5次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7714} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7714} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -658,11 +658,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-7715" depth={2} headingType="c">
+				<Section id="mc-7715" depth={2}>
 					<Fragment slot="heading">デハ7715<small>（5次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7715} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7715} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-21 -->
 					</Embedded>
 
@@ -679,13 +679,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900">
 		<Fragment slot="heading">クハ7900形</Fragment>
 
-		<Grid column="narrow" headingType="c">
+		<Grid column="medium">
 			<GridItem>
-				<Section id="tc-7901" depth={2} headingType="c">
+				<Section id="tc-7901" depth={2}>
 					<Fragment slot="heading">クハ7901<small>（1次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7901} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7901} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-11-23 -->
 					</Embedded>
 
@@ -693,11 +693,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7902" depth={2} headingType="c">
+				<Section id="tc-7902" depth={2}>
 					<Fragment slot="heading">クハ7902<small>（1次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7902} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7902} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-16 -->
 					</Embedded>
 
@@ -705,11 +705,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7903" depth={2} headingType="c">
+				<Section id="tc-7903" depth={2}>
 					<Fragment slot="heading">クハ7903<small>（2次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7903} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7903} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-07 -->
 					</Embedded>
 
@@ -717,11 +717,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7905" depth={2} headingType="c">
+				<Section id="tc-7905" depth={2}>
 					<Fragment slot="heading">クハ7905<small>（2次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7905} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7905} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-16 -->
 					</Embedded>
 
@@ -729,11 +729,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7906" depth={2} headingType="c">
+				<Section id="tc-7906" depth={2}>
 					<Fragment slot="heading">クハ7906<small>（2次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7906} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7906} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-28 -->
 					</Embedded>
 
@@ -741,11 +741,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7907" depth={2} headingType="c">
+				<Section id="tc-7907" depth={2}>
 					<Fragment slot="heading">クハ7907<small>（3次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7907} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7907} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-11-23 -->
 					</Embedded>
 
@@ -753,11 +753,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7908" depth={2} headingType="c">
+				<Section id="tc-7908" depth={2}>
 					<Fragment slot="heading">クハ7908<small>（2次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7908} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7908} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-28 -->
 					</Embedded>
 
@@ -767,11 +767,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7910" depth={2} headingType="c">
+				<Section id="tc-7910" depth={2}>
 					<Fragment slot="heading">クハ7910<small>（3次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7910} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7910} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-28 -->
 					</Embedded>
 
@@ -779,11 +779,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7912" depth={2} headingType="c">
+				<Section id="tc-7912" depth={2}>
 					<Fragment slot="heading">クハ7912<small>（4次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7912} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7912} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-28 -->
 					</Embedded>
 
@@ -793,11 +793,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7913" depth={2} headingType="c">
+				<Section id="tc-7913" depth={2}>
 					<Fragment slot="heading">クハ7913<small>（5次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7913} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7913} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -805,11 +805,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7914" depth={2} headingType="c">
+				<Section id="tc-7914" depth={2}>
 					<Fragment slot="heading">クハ7914<small>（5次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7914} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7914} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -817,11 +817,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-7915" depth={2} headingType="c">
+				<Section id="tc-7915" depth={2}>
 					<Fragment slot="heading">クハ7915<small>（5次車）</small></Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_7915} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_7915} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-23 -->
 					</Embedded>
 
@@ -838,13 +838,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700-towada">
 		<Fragment slot="heading">十和田観光電鉄 モハ7700形</Fragment>
 
-		<Grid column="narrow" headingType="c">
+		<Grid column="medium">
 			<GridItem>
-				<Section id="mc-towada7701" depth={2} headingType="c">
+				<Section id="mc-towada7701" depth={2}>
 					<Fragment slot="heading">モハ7701</Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_towada_7701} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_towada_7701} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2008-05-04 -->
 					</Embedded>
 
@@ -852,11 +852,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-towada7702" depth={2} headingType="c">
+				<Section id="mc-towada7702" depth={2}>
 					<Fragment slot="heading">モハ7702</Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_towada_7702} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_towada_7702} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2008-07-21 -->
 					</Embedded>
 
@@ -866,11 +866,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="mc-towada7703" depth={2} headingType="c">
+				<Section id="mc-towada7703" depth={2}>
 					<Fragment slot="heading">モハ7703</Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_towada_7703} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_towada_7703} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2008-05-04 -->
 					</Embedded>
 
@@ -889,13 +889,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900-towada">
 		<Fragment slot="heading">十和田観光電鉄 クハ7900形</Fragment>
 
-		<Grid column="narrow" headingType="c">
+		<Grid column="medium">
 			<GridItem>
-				<Section id="tc-towada7901" depth={2} headingType="c">
+				<Section id="tc-towada7901" depth={2}>
 					<Fragment slot="heading">クハ7901</Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_towada_7901} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_towada_7901} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2008-09-13 -->
 					</Embedded>
 
@@ -903,11 +903,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-towada7902" depth={2} headingType="c">
+				<Section id="tc-towada7902" depth={2}>
 					<Fragment slot="heading">クハ7902</Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_towada_7902} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_towada_7902} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-03 -->
 					</Embedded>
 
@@ -917,11 +917,11 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="tc-towada7903" depth={2} headingType="c">
+				<Section id="tc-towada7903" depth={2}>
 					<Fragment slot="heading">クハ7903</Fragment>
 
 					<Embedded border={true}>
-						<MyImage image={image_towada_7903} alt="写真拡大" width={216} height={270} link={true} slot="media" />
+						<MyImage image={image_towada_7903} alt="写真拡大" width={306} height={383} link={true} slot="media" />
 						<!-- 撮影日: 2007-04-30 -->
 					</Embedded>
 

--- a/astro/src/pages/tokyu/yomoyama/8000_amp.astro
+++ b/astro/src/pages/tokyu/yomoyama/8000_amp.astro
@@ -41,7 +41,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1次車（一部を除く）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -57,7 +57,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1次車（一部）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -71,7 +71,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">5次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -92,7 +92,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">6〜8次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -106,7 +106,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">9次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -120,7 +120,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">10次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -134,7 +134,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">11〜14次車など</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -155,7 +155,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">15〜20次車と8090系全車両</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -169,7 +169,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">21次車と8945, 8946</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -190,7 +190,7 @@ const slugger = new GithubSlugger();
 
 		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">田園都市線6〜11次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -204,7 +204,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2}>
+				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">田園都市線12〜14次車など</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/yomoyama/8000_amp.astro
+++ b/astro/src/pages/tokyu/yomoyama/8000_amp.astro
@@ -39,9 +39,9 @@ const slugger = new GithubSlugger();
 	<Section id="trumpet-1">
 		<Fragment slot="heading">トランペット型（1〜5次車）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">1次車（一部を除く）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -57,7 +57,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">1次車（一部）</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -71,7 +71,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">5次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -90,9 +90,9 @@ const slugger = new GithubSlugger();
 	<Section id="trumpet-6">
 		<Fragment slot="heading">トランペット型（6〜15次車）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">6〜8次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -106,7 +106,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">9次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -120,7 +120,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">10次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -134,7 +134,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">11〜14次車など</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -153,9 +153,9 @@ const slugger = new GithubSlugger();
 	<Section id="cone">
 		<Fragment slot="heading">コーン型</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">15〜20次車と8090系全車両</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -169,7 +169,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">21次車と8945, 8946</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -188,9 +188,9 @@ const slugger = new GithubSlugger();
 	<Section id="renewal">
 		<Fragment slot="heading">更新工事</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">田園都市線6〜11次車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -204,7 +204,7 @@ const slugger = new GithubSlugger();
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section slugger={slugger} depth={2} headingType="c">
+				<Section slugger={slugger} depth={2}>
 					<Fragment slot="heading">田園都市線12〜14次車など</Fragment>
 
 					<Embedded border={true} captionMeta={true}>

--- a/astro/src/pages/tokyu/yomoyama/8637.astro
+++ b/astro/src/pages/tokyu/yomoyama/8637.astro
@@ -170,7 +170,7 @@ const slugger = new GithubSlugger();
 		</Embedded>
 	</Section>
 
-	<Section slugger={slugger}>
+	<Section id={slugger}>
 		<Fragment slot="heading">写真提供者</Fragment>
 
 		<ListDescription>

--- a/astro/src/pages/tokyu/yomoyama/nosmoking.astro
+++ b/astro/src/pages/tokyu/yomoyama/nosmoking.astro
@@ -34,9 +34,9 @@ const structuredData: StructuredData = {
 	<Section id="string">
 		<Fragment slot="heading">文字のみのタイプ</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="bold-purple" depth={2} headingType="c">
+				<Section id="bold-purple" depth={2}>
 					<Fragment slot="heading">太フォント、英文紺字</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -49,7 +49,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="bold-black" depth={2} headingType="c">
+				<Section id="bold-black" depth={2}>
 					<Fragment slot="heading">太フォント、英文黒字</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -62,7 +62,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="bold-blue" depth={2} headingType="c">
+				<Section id="bold-blue" depth={2}>
 					<Fragment slot="heading">太フォント、英文青字</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -75,7 +75,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="thin-black" depth={2} headingType="c">
+				<Section id="thin-black" depth={2}>
 					<Fragment slot="heading">細フォント、英文黒字</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -93,9 +93,9 @@ const structuredData: StructuredData = {
 	<Section id="pictogram1">
 		<Fragment slot="heading">ピクトグラム（旧）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="pic-str" depth={2} headingType="c">
+				<Section id="pic-str" depth={2}>
 					<Fragment slot="heading">ピクトグラム + 文字</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -108,7 +108,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="pic-only" depth={2} headingType="c">
+				<Section id="pic-only" depth={2}>
 					<Fragment slot="heading">ピクトグラムのみ</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -126,9 +126,9 @@ const structuredData: StructuredData = {
 	<Section id="pictogram2">
 		<Fragment slot="heading">ピクトグラム（新）</Fragment>
 
-		<Grid column="wide" headingType="c">
+		<Grid column="wide">
 			<GridItem>
-				<Section id="3000" depth={2} headingType="c">
+				<Section id="3000" depth={2}>
 					<Fragment slot="heading">新3000系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -141,7 +141,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="y000" depth={2} headingType="c">
+				<Section id="y000" depth={2}>
 					<Fragment slot="heading">Y000系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -154,7 +154,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="300" depth={2} headingType="c">
+				<Section id="300" depth={2}>
 					<Fragment slot="heading">300系</Fragment>
 
 					<Embedded border={true} captionMeta={true}>
@@ -167,7 +167,7 @@ const structuredData: StructuredData = {
 				</Section>
 			</GridItem>
 			<GridItem>
-				<Section id="9000-renewal" depth={2} headingType="c">
+				<Section id="9000-renewal" depth={2}>
 					<Fragment slot="heading">9000系化粧板修繕車</Fragment>
 
 					<Embedded border={true} captionMeta={true}>


### PR DESCRIPTION
これに関連して以下のページの画像サイズを拡大する

- [東急7700系の先頭車正面バリエーション](https://w0s.jp/tokyu/yomoyama/7700_front)
- [久米田康治先生の X アイコン履歴](https://w0s.jp/kumeta/kumeta/x)