### PR TITLE
Flex / Grid コンポーネント改修

### DIFF
--- a/astro/src/components/Embedded.astro
+++ b/astro/src/components/Embedded.astro
@@ -27,10 +27,11 @@ const { width, border, captionMeta } = Astro.props;
 			--_border-width: 0px;
 
 			/* stylelint-disable property-layout-mappings */
-			max-width: calc(attr(data-width px) + var(--_border-width) * 2);
+			/* stylelint-disable-next-line declaration-property-value-no-unknown */
+			max-width: attr(data-width px);
 
 			@supports not (x: attr(x px)) {
-				max-width: calc(var(--_width) + var(--_border-width) * 2);
+				max-width: var(--_width);
 			}
 			/* stylelint-enable property-layout-mappings */
 
@@ -53,7 +54,6 @@ const { width, border, captionMeta } = Astro.props;
 			& > :global(:any-link::before) {
 				display: block flow;
 				position: absolute;
-				inset: 1px;
 				background-color: rgb(0 0 0 / 70%);
 				background-image: url('/assets/image/media-expansion.svg');
 				background-origin: content-box;
@@ -73,14 +73,16 @@ const { width, border, captionMeta } = Astro.props;
 			& :global(:is(img, video)) {
 				box-sizing: revert;
 				display: inline flow-root;
-				border: var(--_border-width) solid var(--color-black);
 				block-size: auto;
-				max-inline-size: calc(100% - var(--_border-width) * 2);
+				max-inline-size: 100%;
 				vertical-align: top;
 			} /* <audio> については block-size: auto を指定すると Chrome で非表示になる現象があるので、ブラウザのデフォルトスタイルに任せる */
 
+			& :global(:is(img, video):not(:focus)) {
+				outline: var(--_border-width) solid var(--color-black);
+			}
+
 			& :global(video) {
-				outline-offset: -1px;
 				outline-width: var(--outline-width-bold);
 			}
 
@@ -94,7 +96,7 @@ const { width, border, captionMeta } = Astro.props;
 
 				display: block flow;
 				margin-inline: auto;
-				border: var(--_border-width) solid var(--color-black);
+				outline: var(--_border-width) solid var(--color-black);
 				aspect-ratio: var(--aspect-ratio, auto);
 				block-size: auto;
 				inline-size: calc(100% - var(--_margin-inline) * 2);

--- a/astro/src/components/EmbeddedYouTube.astro
+++ b/astro/src/components/EmbeddedYouTube.astro
@@ -30,7 +30,7 @@ if (end >= 1) {
 }
 ---
 
-<Embedded border={true} captionMeta={true}>
+<Embedded border={true}>
 	<iframe src={`https://www.youtube-nocookie.com/embed/${id}?${embeddedSearchParams.toString()}`} allow="accelerometer;autoplay;clipboard-write;encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width={width} height={height} style=`--aspect-ratio: ${width}/${height}` slot="media"></iframe>
 	<Anchor href={`https://www.youtube.com/watch?${linkSearchParams.toString()}`} slot="caption">{title}</Anchor>
 </Embedded>

--- a/astro/src/components/Flex.astro
+++ b/astro/src/components/Flex.astro
@@ -5,12 +5,9 @@
 <style>
 	@layer component {
 		.flex {
-			--_gap-row: 1em;
-			--_gap-col: 50px;
-
 			display: block flex;
 			flex-wrap: wrap;
-			gap: var(--_gap-row) var(--_gap-col);
+			gap: var(--stack-margin-base) calc(var(--page-content-width) / 16);
 		}
 	}
 </style>

--- a/astro/src/components/Grid.astro
+++ b/astro/src/components/Grid.astro
@@ -1,39 +1,56 @@
 ---
 interface Props {
-	column: 'wide' | 'medium' | 'narrow';
+	column: 2 | 3 | 4 | 5;
+	sectionDepth?: 1 | 2 | 3;
 }
 
-const { column } = Astro.props;
+const { column, sectionDepth } = Astro.props;
 ---
 
-<div class:list={['grid', `-${column}`]}>
+<div class="grid" data-column={column} data-section-depth={sectionDepth}>
 	<slot />
 </div>
 
 <style>
 	@layer component {
 		.grid {
-			--_gap-row: 50px;
-			--_gap-col: 50px;
-			--_min-inline-size: auto;
+			--_gap-row: var(--stack-margin-base);
+			--_gap-column: calc(var(--page-content-width) / 32);
+			--_column: attr(data-column type(<number>));
 
 			display: block grid;
-			grid-template-columns: repeat(auto-fill, minmax(min(var(--_min-inline-size), 100%), 1fr));
-			gap: var(--_gap-row) var(--_gap-col);
+			grid-template-columns: repeat(auto-fill, minmax(min(calc((var(--page-content-width) - var(--_gap-column) * var(--_column)) / (var(--_column) + 1) + 1px), 100%), 1fr));
+			gap: var(--_gap-row) var(--_gap-column);
 
-			/* 2カラム */
-			&.-wide {
-				--_min-inline-size: 360px;
+			@supports not (x: attr(x type(<number>))) {
+				&[data-column='2'] {
+					--_column: 2;
+				}
+
+				&[data-column='3'] {
+					--_column: 3;
+				}
+
+				&[data-column='4'] {
+					--_column: 4;
+				}
+
+				&[data-column='5'] {
+					--_column: 5;
+				}
 			}
 
-			/* 3カラム */
-			&.-medium {
-				--_min-inline-size: 240px;
+			/* <Section> コンポーネントの margin-block と同じ値を設定 */
+			&[data-section-depth='1'] {
+				--_gap-row: 4.5rem;
 			}
 
-			/* 4カラム */
-			&.-narrow {
-				--_min-inline-size: 180px;
+			&[data-section-depth='2'] {
+				--_gap-row: 3.75rem;
+			}
+
+			&[data-section-depth='3'] {
+				--_gap-row: 3rem;
 			}
 		}
 	}

--- a/astro/src/layouts/page/CMMadoka.astro
+++ b/astro/src/layouts/page/CMMadoka.astro
@@ -12,7 +12,7 @@ import image_pictorial7 from '@image/madoka/dojin/pictorial7_cover.jpg';
 
 <div id="cm" class="l-cm">
 	<CM>
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<BookItem sectionDepth={2} title="マギアレコード海外版動向" summary="自費出版、2019年8月発売" link="/madoka/dojin/pictorial11">
 					<MyImage slot="image" image={image_pictorial11} alt="表紙: 複数並んだ駅のホームの一つに横長のマギレコポスターが掲出されており、隣の線路には路面電車が停車している写真" width={114} height={160} fetchPriority="low" />

--- a/astro/src/layouts/page/CMTokyu.astro
+++ b/astro/src/layouts/page/CMTokyu.astro
@@ -11,7 +11,7 @@ import image_7700_cover from '@image/tokyu/book/7700_cover.jpg';
 
 <div id="cm" class="l-cm">
 	<CM>
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<BookItem sectionDepth={2} title="私鉄車両ディテールガイド　東急9000系・1000系・2000系" summary="イカロス・ムック、2025年11月発売" link="https://www.amazon.co.jp/dp/4802216769/">
 					<ImageAmazon slot="image" src="https://m.media-amazon.com/images/I/811MJUZeFoL._SL160_.jpg" alt="表紙: 上部に黒文字で書名、下部に赤帯を巻いた9000系の先頭部写真 " width={115} height={160} fetchPriority="low" />

--- a/astro/src/pages/info.astro
+++ b/astro/src/pages/info.astro
@@ -161,7 +161,7 @@ const structuredData: StructuredData = {
 		<Section id="write-tokyu" depth={2}>
 			<Fragment slot="heading">東急電車</Fragment>
 
-			<Grid column="wide">
+			<Grid column={2}>
 				<GridItem>
 					<BookItem sectionDepth={3} title="私鉄車両ディテールガイド　東急9000系・1000系・2000系" summary="イカロス・ムック、2025年11月発売" link="https://www.amazon.co.jp/dp/4802216769/">
 						<ImageAmazon slot="image" src="https://m.media-amazon.com/images/I/811MJUZeFoL._SL160_.jpg" alt="表紙: 上部に黒文字で書名、下部に赤帯を巻いた9000系の先頭部写真 " width={115} height={160} />
@@ -199,7 +199,7 @@ const structuredData: StructuredData = {
 		<Section id="write-kumeta" depth={2}>
 			<Fragment slot="heading">久米田康治作品</Fragment>
 
-			<Grid column="wide">
+			<Grid column={2}>
 				<GridItem>
 					<BookItem sectionDepth={3} title="もにも〜ど3" summary="シャフト批評合同誌（同人誌）、2025年11月発刊" link="https://blog.w0s.jp/entry/753">
 						<MyImage slot="image" image={image_info_monimode3_cover} alt="表紙: 黄緑色の背景、中央部に「GO!!・50!!」の文字とそれを囲む正円形の装飾、右下には羽ばたく鳥が複数舞っている" width={114} height={160} />

--- a/astro/src/pages/kumeta/anime/kakushigoto/storyboard.astro
+++ b/astro/src/pages/kumeta/anime/kakushigoto/storyboard.astro
@@ -1,8 +1,8 @@
 ---
 import Layout from '@layouts/Kumeta.astro';
 import Embedded from '@components/Embedded.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import ListNote from '@components/ListNote.astro';
 import Section from '@components/Section.astro';
 import Stack from '@components/Stack.astro';
@@ -142,20 +142,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>校舎外壁の時計の針が削除<small>（TV 版は 15:35 頃を差していた）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv1_bd_000527} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 1話Aパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_000443} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="cross">なし</TickAndCross></td>
@@ -175,20 +175,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>鉄棒付近に置かれていたランドセルが削除<small>（原作は下校途中なので TV 版はそれに合わせたが、劇場版では休み時間という設定か?）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv1_bd_000541} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 1話Aパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_000456} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="cross">なし</TickAndCross></td>
@@ -244,20 +244,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>可久士の表情修正<small>（TV 版は<q>久米田作品ぽくなってない</q>との理由）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv1_bd_000840} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 1話Aパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_000754} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="tick">あり</TickAndCross></td>
@@ -277,20 +277,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p><q>やり直せ</q>のタイミングでズーム処理&amp;そこで初めて集中線が出るように&amp;可久士に影追加<small>（絵コンテのイラストは左右逆）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv1_bd_000935} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 1話Aパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_000849} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="cross">なし</TickAndCross></td>
@@ -364,20 +364,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>ペンの色が黄→緑に変更、可久士が話すとき指先に力を込める動きを追加</p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv1_bd_001310} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 1話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_001315} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td>力込めのみ</td>
@@ -451,20 +451,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>家族写真差し替え（原作12巻 p.139）、小物追加</p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv1_bd_002139} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 1話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_001945} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="tick">あり</TickAndCross></td>
@@ -718,20 +718,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>可久士作画し直し<small>（絵コンテには<q>羅砂SLIN追加</q><q>それに伴い羅砂も作画修正した方がバランスいいです</q>とあるが、実際は変更なし）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv6_bd_000948} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 6話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_002800} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="tick">あり</TickAndCross></td>
@@ -769,20 +769,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>振り向く前の可久士を目を瞑っている表情に変更<small>（カット順序変更に伴う前カットとの表情整合性確保のため）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv6_bd_001013} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 6話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_002843} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="tick">あり</TickAndCross></td>
@@ -856,20 +856,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>吹き出し内にエフェクト&amp;白枠追加、<q>聞いていない</q>のテロップが小型化</p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv6_bd_001456} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 6話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_003220} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td>テロップのみ</td>
@@ -1123,20 +1123,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>漫画の内容を変更<small>（TV 版は原作単行本4巻カラーページ準拠 → 劇場版は原作最終話で姫が“色を点けた”ページ）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv6_bd_002124} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 6話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_003855} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="tick">あり</TickAndCross></td>
@@ -1253,20 +1253,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>従業員「シャラポワ」のネームプレートの中身を省略せず表現</p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv10_bd_001723} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 10話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_004727} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="tick">あり</TickAndCross></td>
@@ -1304,20 +1304,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>影を描き直し&amp;ボカし表現&amp;揺れ方変更、入射光表現追加</p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv10_bd_002056} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 10話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_004848} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="cross">なし</TickAndCross></td>
@@ -1346,20 +1346,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>絵コンテには8話Bパート（18歳編）で使用された逗子マリーナの写真が貼られているが、実際はテーブル上の小物を写した構図になっている<small>（TV 版10話の同カットを意識して描き直されているが、「<cite>消えた漫画家</cite>」の本が置かれるなどの変更点がある）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv10_bd_002121} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 10話Bパート（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_004909} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="cross">なし</TickAndCross></td>
@@ -1397,20 +1397,20 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>1話アバン（18歳編）のカットを流用しているが、線路の橋の右側の草が江ノ電の車両の手前に来るようになった<small>（明らかに不自然で編集ミスと思われる）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv1_bd_000009} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 1話アバン（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-								<FlexItem>
-									<Embedded border={true}>
+								</GridItem>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_005009} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="cross">なし</TickAndCross></td>
@@ -1502,14 +1502,14 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>絵コンテには<q>僅かに肩が震えてる姫（泣いてる）</q>とあるが、実際は震えていない<small>（TV 版、劇場版とも）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_movie_bd_010330} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">劇場編集版（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 						</Stack>
 					</td>
 					<td><TickAndCross type="tick">あり</TickAndCross></td>
@@ -1565,14 +1565,14 @@ const structuredData: StructuredData = {
 						<Stack>
 							<p>モブ女生徒をミハルに差し替え<small>（首から上のみを描き直している）</small></p>
 
-							<Flex>
-								<FlexItem>
-									<Embedded border={true}>
+							<Grid column={3}>
+								<GridItem>
+									<Embedded width={320} border={true}>
 										<MyImage image={image_tv12_bd_002226} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 										<Fragment slot="caption">TV 版 12話（Blu-ray）</Fragment>
 									</Embedded>
-								</FlexItem>
-							</Flex>
+								</GridItem>
+							</Grid>
 
 							<ListNote>
 								<li>差し替え後のイラストは劇場編集版本編でご確認ください</li>

--- a/astro/src/pages/kumeta/anime/zetsubou/diff.astro
+++ b/astro/src/pages/kumeta/anime/zetsubou/diff.astro
@@ -2,8 +2,8 @@
 import Layout from '@layouts/Kumeta.astro';
 import Anchor from '@components/+phrasing/Anchor.astro';
 import Embedded from '@components/Embedded.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
 import ListNote from '@components/ListNote.astro';
 import Section from '@components/Section.astro';
@@ -92,20 +92,20 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:02:46">
 						<p>可符香のスカート部分の前田君モザイクが削除。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_000246} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_000246} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:02:52">
 						<p>可符香のスカート部分の前田君モザイクが削除。</p>
@@ -123,56 +123,56 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:04:38">
 						<p><q>桃色右大臣</q><q>桃色大魔王</q><q>桃色若社長</q>の文字色が黒から橙に変更（なお、 4′32″ の<q>桃色ガブリエル</q>は放送版も橙色）。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_000443} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_000443} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:05:57">
 						<p><q>絶望した</q>直前の4カットで望の目の虹彩の色が薄くなり、瞳孔が分かりやすくなった。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_000557} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_000557} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:06:53">
 						<p>背景にうろペンが追加。それに伴い、望がフレームインするタイミングと動作速度が遅くなった。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_000657} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_000657} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:08:20">
 						<p>放送版では望の右腕の袖先まで着物の柄が描かれていたが、無地に変更。</p>
@@ -186,38 +186,38 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:09:12">
 						<p>黒板文字<q>ゆとり教育で若者は土曜の半ドンで生まれる恋を失ったのです。</q>が大きくなった。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_000912} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_000912} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:10:46">
 						<p><q>「あ、そうだ!」</q>が<q>「麻生だ」</q>に変更。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001046} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001046} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:10:57">
 						<p><q>「ま、待ちなさい」</q>が<q>「ま、街がない」</q>に変更。</p>
@@ -225,20 +225,20 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:11:11">
 						<p>黒板の<q>糸　色望</q>の文字がやや左下がりになっていたのを修正。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001114} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001114} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 				</VideoDiff>
 			</Section>
@@ -256,38 +256,38 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:12:10">
 						<p>奈美以外の3人の女子生徒が描き直された。前田君モザイクの位置も変わり、途中で外れてゆくようになった。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001211} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001211} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:12:13">
 						<p>奥に女子生徒が2人増加。千里、晴美、あびる作画修正。あびるの包帯が増えた。湯に浮かぶおもちゃのアヒルの位置が一部変更。前田君モザイクが外れてゆくようになった。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001214} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001214} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:12:17">
 						<p>3人の女子生徒の身体に泡が追加。前田君モザイクが外れてゆくようになった。</p>
@@ -295,20 +295,20 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:12:24">
 						<p>左側の女子生徒は後ろ姿だったが横向きに変更、胸と腰回りに葉っぱが追加。前田君モザイクが外れてゆくようになった。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001220} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001220} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:12:31">
 						<p>黒板文字<q>中古のギャルゲーには手を出さないという処女信仰</q>が大きくなった。</p>
@@ -346,20 +346,20 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:14:47">
 						<p>望が TV で野球を見るカットの背景が白色ベースだったものが、ピンク色に多数の犬が描かれた模様に変更。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001447} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001447} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:14:49">
 						<p>背景が無地の白色だったものが、青色に模様入りのものに変更。</p>
@@ -373,20 +373,20 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:15:42">
 						<p><q>めんどくさい人　毎日きたら　どうしよう・・・</q>が<q>ストーカーの　八割は　顔見知り</q>に変更。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001542} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001542} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:16:06">
 						<p>画面全体が若干引き気味になった。</p>
@@ -409,20 +409,20 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:16:53">
 						<p>望と影郎、および後ろ姿のモブ生徒達が小さくなった。また、黒板に描かれた『<cite>神奈川沖浪裏</cite>』（富嶽三十六景）の絵が大きくなった。黒板の上に掲示された額縁が大きくなり、そこに書かれた文字のフォントも変更。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001653} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001653} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:17:03">
 						<p>望と後ろ姿のモブ生徒達が小さくなった。また、黒板に描かれた『<cite>神奈川沖浪裏</cite>』（富嶽三十六景）の絵が大きくなった（16′53″の絵とは異なる）。黒板の上に掲示された額縁が大きくなり、そこに書かれた文字のフォントも変更。</p>
@@ -433,56 +433,56 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:17:14">
 						<p>望の着物の柄が無地になっていたのが修正。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001714} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001714} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:17:20">
 						<p>望の着物の色が変更。黒板文字<q>人類のヒエラルキー</q>の文字と図が大きくなった。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001723} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001723} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:18:17">
 						<p><q>ふふ、　クセに　なっちゃう・・・</q>がアポクリン汗腺の説明文に変更。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001817} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001817} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:18:22">
 						<p>望と准、および後ろ姿のモブ生徒達が小さくなった。また、黒板に描かれた『<cite>神奈川沖浪裏</cite>』（富嶽三十六景）の絵が大きくなった（16′53″や 17′3″の絵とは異なる）。黒板の上に掲示された額縁が大きくなり、そこに書かれた文字のフォントも変更。</p>
@@ -493,20 +493,20 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:19:20">
 						<p>進路絶望調査の紙を持つ望の手の影が薄くなった。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_001921} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_001921} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 					<VideoDiffItem timeStart="00:19:47">
 						<p>モブ生徒達が暗くなった。黒板文字<q>フィンランドで虫歯になるという留学。</q>が大きくなった。</p>
@@ -526,20 +526,20 @@ const structuredData: StructuredData = {
 					<VideoDiffItem timeStart="00:20:51">
 						<p>廊下の窓に前田君が追加。</p>
 
-						<Flex>
-							<FlexItem>
-								<Embedded border={true}>
+						<Grid column={3}>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_tv_002051} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">TV 放送版</Fragment>
 								</Embedded>
-							</FlexItem>
-							<FlexItem>
-								<Embedded border={true}>
+							</GridItem>
+							<GridItem>
+								<Embedded width={320} border={true}>
 									<MyImage image={image_tv1_dvd_002051} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 									<Fragment slot="caption">DVD 版</Fragment>
 								</Embedded>
-							</FlexItem>
-						</Flex>
+							</GridItem>
+						</Grid>
 					</VideoDiffItem>
 				</VideoDiff>
 			</Section>

--- a/astro/src/pages/kumeta/index.astro
+++ b/astro/src/pages/kumeta/index.astro
@@ -30,7 +30,7 @@ const slugger = new GithubSlugger();
 		<Fragment slot="nav">
 			<TopNavText heading="サイトコンテンツ">
 				<Fragment slot="main">
-					<Grid column="wide">
+					<Grid column={2} sectionDepth={2}>
 						<GridItem>
 							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">漫画</Fragment>

--- a/astro/src/pages/kumeta/kumeta/media.astro
+++ b/astro/src/pages/kumeta/kumeta/media.astro
@@ -145,14 +145,14 @@ const slugger = new GithubSlugger();
 
 		<p>「<cite>あの子は漫画を読まない。</cite>」での初出演時は担当編集の竹田哲也さんが同席し、『<cite>かくしごと</cite>』を始めたきっかけや、逗子でロケハンをしたときの様子など、短い出演時間の中でも貴重な話がありました。</p>
 
-		<Embedded>
+		<Embedded width={720}>
 			<MyImage image={image_anokohamangawoyomanai_10} width={720} height={405} slot="media" />
 			<Fragment slot="caption">「<cite>あの子は漫画を読まない。</cite>」#10（左から岩井勇気、宇垣美里、花江夏樹、久米田康治、竹田哲也）</Fragment>
 		</Embedded>
 
 		<p>2022年にはアニメ専門チャンネル AT-X で『<cite>劇場編集版　かくしごと</cite>』の TV 初放送が行われ、その直後に久米田先生と村野監督をゲストに迎えた番組がありました。ここでは1時間もの放送時間を使って作品に関するトークが行われましたが、生放送の特性を活用してリアルタイムに Twitter<small>（現：X）</small>の感想投稿を取り上げるなど、視聴者参加型の側面もあったのが特徴です。</p>
 
-		<Embedded>
+		<Embedded width={720}>
 			<MyImage image={image_rselectanime_12} width={720} height={405} slot="media" />
 			<Fragment slot="caption">「<cite>R指定アニメ！</cite>」#12 第二部（左から松澤千晶、ROLAND、久米田康治、村野佑太）</Fragment>
 		</Embedded>
@@ -263,49 +263,49 @@ const slugger = new GithubSlugger();
 
 		<NoteRefContent id="jyoshiraku-commentary">コメンタリーの C パート部分で久米田先生が（おそらく丸京の顔を見て）<q>マル“<ruby>丸<rp>（</rp><rt>ガン</rt><rp>）</rp></ruby>”と描いてあるだけ</q>と仰っているので、原撮ですらない絵コンテ撮だった可能性もあります。</NoteRefContent>
 
-		<Embedded>
+		<Embedded width={480}>
 			<MyImage image={image_jyoshiraku_oad} width={480} height={270} slot="media" />
 			<Fragment slot="caption">『<cite>じょしらく</cite>』OAD Aパート（近所の漫画家と山下が出演するシーン）</Fragment>
 		</Embedded>
 
 		<p>動画形式での出演は TV アニメ『<cite>有頂天家族</cite>』が初の事例であり、Blu-ray&amp;DVD の映像特典として森見登美彦先生との対談が収録されました。久米田先生からはキャラクター原案の話にとどまらず、普段ギャグ作品を作るうえで重視していることや、原作者としての立ち位置から『<cite>じょしらく</cite>』の話に至るまで幅広い話題がありました。</p>
 
-		<Embedded>
+		<Embedded width={720}>
 			<MyImage image={image_uchoten_bd2_talk} width={720} height={405} slot="media" />
 			<Fragment slot="caption">『<cite>有頂天家族</cite>』Blu-ray 第二巻の作家対談（左から久米田康治、森見登美彦）</Fragment>
 		</Embedded>
 
 		<p>2020年3月には『<cite>かくしごと</cite>』アニメ放送の一環で神谷浩史さんとの対談動画が<Anchor href="https://www.youtube.com/user/avexpictures">エイベックス・ピクチャーズの YouTube アカウント</Anchor>で公開されました。神谷さんといえば『<cite>さよなら絶望先生</cite>』からの付き合いですが、その放送当時は久米田先生と制作スタッフ陣との対談は複数回行われていたものの、キャスト陣とは「<cite>アニカン</cite>」Vol.43（フリーペーパー）での対談が1回あったのみであり、動画で神谷さんと対談を行うのはこれが初めてのことです。</p>
 
-		<Embedded>
+		<Embedded width={720}>
 			<MyImage image={image_kakushugoto_kamiya_1} width={720} height={405} slot="media" />
 			<Fragment slot="caption">「<cite>TVアニメ『かくしごと』久米田康治×神谷浩史・スペシャル対談ムービー</cite>」#01（左から神谷浩史、久米田康治）</Fragment>
 		</Embedded>
 
 		<p>『<cite>かくしごと</cite>』放送終了後の2020年11月には画業30周年を記念したオンライントークショーが開催されました。有観客に対応した<Anchor href="https://hall.mixalivetokyo.com/">ホールミクサ</Anchor>での公演ながらオンライン形式での開催となったのは新型コロナウイルス流行の影響と思われますが、4人のゲストと2時間近い長さで、現在に至るまでもっとも豪華な配信イベントとなっています。</p>
 
-		<Embedded>
+		<Embedded width={720}>
 			<MyImage image={image_nakushigoto_1} width={720} height={405} slot="media" />
 			<Fragment slot="caption">「<cite>久米田康治画業30周年記念トークショー</cite>」第1部　漫画家対談（左から久米田康治、藤田和日郎、畑健二郎）</Fragment>
 		</Embedded>
 
 		<p>2020年12月に埼玉県川越で行われた『<cite>かくしごと</cite>』スペシャルイベントでは、夜の部の最後に久米田先生が登壇し、その御前で劇場編集版の制作発表が行われました。このイベントは会場に客を入れるリアルイベントでしたが、インターネット配信および後日発売された <Anchor href="https://www.amazon.co.jp/dp/B08KTV4QG9/">Blu-ray&amp;DVD</Anchor>にも収録されています。</p>
 
-		<Embedded>
+		<Embedded width={720}>
 			<MyImage image={image_kakushigoto_event_night} width={720} height={405} slot="media" />
 			<Fragment slot="caption">「<cite>TVアニメ『かくしごと』スペシャルイベント</cite>」夜の部（左から神谷浩史、久米田康治、大槻ケンヂ、高橋李依）</Fragment>
 		</Embedded>
 
 		<p>2021年7月に『<cite>かくしごと</cite>』の劇場編集版が公開されましたが、公開と同時に Blu-ray が発売、また週末の土日には3週連続でインターネット配信が行われ、<Anchor href="https://kakushigoto-anime.com/topics/96/">1週目</Anchor>は神谷浩史さん、<Anchor href="https://kakushigoto-anime.com/topics/127/">2週目</Anchor>は高橋李依さん、そして<Anchor href="https://kakushigoto-anime.com/topics/135/">3週目</Anchor>には久米田先生&amp;村野監督によるコメント映像が収録されました。</p>
 
-		<Embedded>
+		<Embedded width={720}>
 			<MyImage image={image_kakushigoto_haishin_3} width={720} height={405} slot="media" />
 			<Fragment slot="caption">『<cite>劇場編集版　かくしごと</cite>』週末配信チケット　第3弾　コメント映像（左から村野佑太、久米田康治）</Fragment>
 		</Embedded>
 
 		<p>2021年10月には『<cite>劇場編集版　かくしごと</cite>』の Blu-ray 全国発売に関連した特典映像の配信が行われました。これは楽天チケットでの Blu-ray 購入者を対象に配信されたもので、10月2日に行われたオンラインサイン会の前後に収録されています。インタビュアーは舞台挨拶での司会を5回とも務められ、青春時代が『<cite>かってに改蔵</cite>』で成り立っていたという松澤千晶さんで、「<cite>久米田康治先生へ10の質問</cite>」と題して劇場編集版を受けての感想やキービジュアル制作のエピソード、「<cite>全曝し展</cite>」の話などで盛り上がりました。</p>
 
-		<Embedded>
+		<Embedded width={720}>
 			<MyImage image={image_kakushigoto_sign_interview} width={720} height={405} slot="media" />
 			<Fragment slot="caption">『<cite>劇場編集版　かくしごと</cite>』Blu-ray 発売記念オンラインサイン会　特別インタビュー（左から松澤千晶、久米田康治）</Fragment>
 		</Embedded>

--- a/astro/src/pages/kumeta/kumeta/x.astro
+++ b/astro/src/pages/kumeta/kumeta/x.astro
@@ -55,154 +55,154 @@ const slugger = new GithubSlugger();
 	<Section id={slugger}>
 		<Fragment slot="heading">アイコン履歴<small>（新しい順）</small></Fragment>
 
-		<Grid column="narrow">
+		<Grid column={5}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1408410553228267521_TjA8u78P} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1408410553228267521_TjA8u78P} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2021年6月25日 〜</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1400351001018658816_qy5arqJH} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1400351001018658816_qy5arqJH} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2021年6月3日 〜 6月25日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1400348572097257473_e66MA7rG} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1400348572097257473_e66MA7rG} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2021年6月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1399911791325433857_v2gkYm9q} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1399911791325433857_v2gkYm9q} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2021年6月2日 〜 6月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1394152318157811713_oQ3JY4iy} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1394152318157811713_oQ3JY4iy} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2021年5月17日 〜 6月2日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1363740344886550529_QhDX9Hl1} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1363740344886550529_QhDX9Hl1} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2021年2月22日 〜 5月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1327851470780198913_Ye4TmCa} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1327851470780198913_Ye4TmCa} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年11月15日 〜 2021年2月22日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1287298632341848064_1VBcrVKq} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1287298632341848064_1VBcrVKq} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年7月26日 〜 11月15日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1284006685846233088_2ikV7Vsa} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1284006685846233088_2ikV7Vsa} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年7月17日 〜 7月26日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1264894156867948544_l3CY7neV} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1264894156867948544_l3CY7neV} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年5月25日 〜 7月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1245619057593700352_U1LMLxDn} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1245619057593700352_U1LMLxDn} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年4月2日 〜 5月25日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1240915754943262720_He1PQtk9} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1240915754943262720_He1PQtk9} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年3月20日 〜 4月2日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1223990059491160064_6d49eucZ} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1223990059491160064_6d49eucZ} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年2月3日 〜 3月20日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1222732605214183424_H79FeE20} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1222732605214183424_H79FeE20} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年1月30日 〜 2月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1222730357000138754_KmGpTlaZ} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1222730357000138754_KmGpTlaZ} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年1月30日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1219488655745548288_3SJhKPZ} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1219488655745548288_3SJhKPZ} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2020年1月21日 〜 1月30日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1201788717888704513_NGubWw_s} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1201788717888704513_NGubWw_s} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2019年12月3日 〜 2020年1月21日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1201784483592032256_6TRDw9cm} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1201784483592032256_6TRDw9cm} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2019年12月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1201778194950418432_WWx0YFb8} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1201778194950418432_WWx0YFb8} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2019年12月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1200300079791235074_8sEA4dWH} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1200300079791235074_8sEA4dWH} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2019年11月29日 〜 12月3日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1184690518933958656_5Qz57WpT} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1184690518933958656_5Qz57WpT} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2019年10月17日 〜 11月29日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1184672977167642624_JFdn0ynC} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1184672977167642624_JFdn0ynC} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2019年10月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1184653198239260672_GQN5feI} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1184653198239260672_GQN5feI} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2019年10月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1184428125045702656_ri24lRB9} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1184428125045702656_ri24lRB9} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">2019年10月16日 〜 10月17日</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_profile_images_1180045807350763520_cN1I7jBs} alt="アイコン画像" width={216} height={216} link={true} slot="media" />
+				<Embedded width={200} border={true}>
+					<MyImage image={image_profile_images_1180045807350763520_cN1I7jBs} alt="アイコン画像" width={200} height={200} link={true} slot="media" />
 					<Fragment slot="caption">〜 2019年10月16日</Fragment>
 				</Embedded>
 			</GridItem>

--- a/astro/src/pages/kumeta/yomoyama/pulp_daidanen.astro
+++ b/astro/src/pages/kumeta/yomoyama/pulp_daidanen.astro
@@ -26,8 +26,8 @@ const slugger = new GithubSlugger();
 		<Toggle>
 			<Fragment slot="summary">イラストを見る<small>（※最終話ネタバレ注意）</small></Fragment>
 
-			<Embedded border={true}>
-				<MyImage image={image_pulp15_daidanen} alt="画像拡大" width={1022} height={734} link={true} slot="media" />
+			<Embedded width={1024} border={true}>
+				<MyImage image={image_pulp15_daidanen} alt="画像拡大" width={1024} height={735} link={true} slot="media" />
 				<Fragment slot="caption">見開きの大団円イラスト（<cite>楽園</cite> 32号 pp.360–361 を加工）</Fragment>
 			</Embedded>
 		</Toggle>

--- a/astro/src/pages/madoka/dojin/pictorial10.astro
+++ b/astro/src/pages/madoka/dojin/pictorial10.astro
@@ -46,7 +46,7 @@ const structuredData: StructuredData = {
 
 		<Flex>
 			<FlexItem>
-				<Embedded border={true}>
+				<Embedded width={170} border={true}>
 					<MyImage image={image_pictorial10_cover} alt="建物内にある[新編]の告知イラストが書かれた大きなポスターと、券売機ディスプレイに流れる[新編]映像の写真" width={170} height={240} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>

--- a/astro/src/pages/madoka/dojin/pictorial11.astro
+++ b/astro/src/pages/madoka/dojin/pictorial11.astro
@@ -45,7 +45,7 @@ const structuredData: StructuredData = {
 
 		<Flex>
 			<FlexItem>
-				<Embedded border={true}>
+				<Embedded width={170} border={true}>
 					<MyImage image={image_pictorial11_cover} alt="複数並んだ駅のホームの一つに横長のマギレコポスターが掲出されており、隣の線路には路面電車が停車している写真" width={170} height={240} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>

--- a/astro/src/pages/madoka/dojin/pictorial6.astro
+++ b/astro/src/pages/madoka/dojin/pictorial6.astro
@@ -49,7 +49,7 @@ const slugger = new GithubSlugger();
 
 		<Flex>
 			<FlexItem>
-				<Embedded border={true}>
+				<Embedded width={170} border={true}>
 					<MyImage image={image_pictorial6_cover} alt="[新編]パッケージを取り囲むように大量の特典フィルムが並べられた写真" width={170} height={240} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>

--- a/astro/src/pages/madoka/dojin/pictorial7.astro
+++ b/astro/src/pages/madoka/dojin/pictorial7.astro
@@ -47,7 +47,7 @@ const slugger = new GithubSlugger();
 
 		<Flex>
 			<FlexItem>
-				<Embedded border={true}>
+				<Embedded width={170} border={true}>
 					<MyImage image={image_pictorial7_cover} alt="イベント会場での展示ブースの中央にあるディスプレイに『まどか☆マギカ』のアニメが流れている様子を写した写真" width={170} height={240} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>

--- a/astro/src/pages/madoka/dojin/pictorial8.astro
+++ b/astro/src/pages/madoka/dojin/pictorial8.astro
@@ -46,7 +46,7 @@ const structuredData: StructuredData = {
 
 		<Flex>
 			<FlexItem>
-				<Embedded border={true}>
+				<Embedded width={170} border={true}>
 					<MyImage image={image_pictorial8_cover} alt="教室のスクリーンにスライドを映しながらマイクを持って説明している写真" width={170} height={240} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>

--- a/astro/src/pages/madoka/dojin/pictorial9.astro
+++ b/astro/src/pages/madoka/dojin/pictorial9.astro
@@ -49,7 +49,7 @@ const structuredData: StructuredData = {
 
 		<Flex>
 			<FlexItem>
-				<Embedded border={true}>
+				<Embedded width={170} border={true}>
 					<MyImage image={image_pictorial9_cover} alt="駅の壁に掲出されたさやかポスターと、ホームに進入する東急電車の写真" width={170} height={240} slot="media" />
 					<Fragment slot="caption">表紙</Fragment>
 				</Embedded>

--- a/astro/src/pages/madoka/event/shop.astro
+++ b/astro/src/pages/madoka/event/shop.astro
@@ -341,7 +341,7 @@ const structuredData: StructuredData = {
 	<Section id="shop-map">
 		<Fragment slot="heading">地図で見る開催地</Fragment>
 
-		<Embedded>
+		<Embedded width={720}>
 			<img src="image/shop-map.svg" alt="都道府県ごとの開催回別に色分けされた日本白地図（札幌: 1回、青森: 1回、仙台: 3回、宇都宮: 1回、印西: 1回、吉祥寺: 2回、八景島: 1回、静岡: 1回、名古屋: 2回、山陽（姫路）: 1回、広島: 1回、福岡: 3回、熊本: 2回、鹿児島: 1回）" width="720" height="794" slot="media" />
 		</Embedded>
 

--- a/astro/src/pages/madoka/index.astro
+++ b/astro/src/pages/madoka/index.astro
@@ -27,7 +27,7 @@ const slugger = new GithubSlugger();
 		<Fragment slot="nav">
 			<TopNavText heading="サイトコンテンツ">
 				<Fragment slot="main">
-					<Grid column="wide">
+					<Grid column={2} sectionDepth={2}>
 						<GridItem>
 							<Section id={slugger} depth={2}>
 								<Fragment slot="heading">映像</Fragment>

--- a/astro/src/pages/madoka/video/connect.astro
+++ b/astro/src/pages/madoka/video/connect.astro
@@ -187,22 +187,22 @@ const slugger = new GithubSlugger();
 	<Section id="c001">
 		<Fragment slot="heading">#OP-C001　まどか遠景</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0109_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0109_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0109_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0109_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0088_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0088_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -217,28 +217,28 @@ const slugger = new GithubSlugger();
 	<Section id="c002">
 		<Fragment slot="heading">#OP-C002　まどかアップ（後ろ姿）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0113_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0113_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0113_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0113_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0091_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0091_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">パッケージ版</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0091_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0091_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -255,28 +255,28 @@ const slugger = new GithubSlugger();
 	<Section id="c003">
 		<Fragment slot="heading">#OP-C003　まどかアップ（スカート）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0229_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0229_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0229_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0229_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0184_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0184_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">パッケージ版</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0184_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0184_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -292,28 +292,28 @@ const slugger = new GithubSlugger();
 	<Section id="c004">
 		<Fragment slot="heading">#OP-C004　まどかアップ（正面）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0248_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0248_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0248_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0248_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0200_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0200_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">パッケージ版</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0200_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0200_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -331,28 +331,28 @@ const slugger = new GithubSlugger();
 	<Section id="c005">
 		<Fragment slot="heading">#OP-C005　まどか遠景</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0322_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0322_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0322_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0322_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0322_tbs_10} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0322_tbs_10} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">10話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0258_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0258_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -370,22 +370,22 @@ const slugger = new GithubSlugger();
 	<Section id="title-back">
 		<Fragment slot="heading">タイトルバック</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0660_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0660_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0660_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0660_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0529_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0529_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -401,16 +401,16 @@ const slugger = new GithubSlugger();
 	<Section id="c006">
 		<Fragment slot="heading">#OP-C006　悩むまどかアップ</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0683_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0683_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0547_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0547_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -424,28 +424,28 @@ const slugger = new GithubSlugger();
 	<Section id="c007">
 		<Fragment slot="heading">#OP-C007　悩むまどか</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0744_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0744_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0744_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0744_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0744_tbs_10} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0744_tbs_10} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">10話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0596_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0596_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -462,22 +462,22 @@ const slugger = new GithubSlugger();
 	<Section id="c008">
 		<Fragment slot="heading">#OP-C008　寝起きまどかアップ</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1001_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1001_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1001_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1001_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_0801_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_0801_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -495,22 +495,22 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">部屋を見上げる</Fragment>
 
-			<Grid column="medium">
+			<Grid column={3}>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1023_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1023_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">1話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1023_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1023_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">5話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_0819_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_0819_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">劇場版後編</Fragment>
 					</Embedded>
 				</GridItem>
@@ -527,28 +527,28 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">シーツに潜る</Fragment>
 
-			<Grid column="medium">
+			<Grid column={3}>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1089_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1089_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">1話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1089_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1089_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">3話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1089_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1089_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">5話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_0872_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_0872_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">劇場版後編</Fragment>
 					</Embedded>
 				</GridItem>
@@ -566,22 +566,22 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">ごろごろ</Fragment>
 
-			<Grid column="medium">
+			<Grid column={3}>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1193_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1193_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">1話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1193_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1193_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">5話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_0955_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_0955_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">劇場版後編</Fragment>
 					</Embedded>
 				</GridItem>
@@ -599,10 +599,10 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">まどか不在</Fragment>
 
-			<Grid column="medium">
+			<Grid column={3}>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1220_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1220_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">1話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
@@ -615,22 +615,22 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">もたれかかる</Fragment>
 
-			<Grid column="medium">
+			<Grid column={3}>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1229_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1229_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">1話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1229_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1229_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">5話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_0984_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_0984_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">劇場版後編</Fragment>
 					</Embedded>
 				</GridItem>
@@ -649,22 +649,22 @@ const slugger = new GithubSlugger();
 	<Section id="c010">
 		<Fragment slot="heading">#OP-C010　まどか変身</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1335_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1335_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1335_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1335_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1069_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1069_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -679,22 +679,22 @@ const slugger = new GithubSlugger();
 	<Section id="c011">
 		<Fragment slot="heading">#OP-C011　まどか変身</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1344_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1344_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1344_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1344_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1076_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1076_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -712,46 +712,46 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">分身登場</Fragment>
 
-			<Grid column="medium">
+			<Grid column={3}>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1363_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1363_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">本放送1話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1363_tbs_2} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1363_tbs_2} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">2話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1363_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1363_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">3話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1363_tbs_6} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1363_tbs_6} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">6話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1363_tbs_7} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1363_tbs_7} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">7話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1091_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1091_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">パッケージ版（1話、本放送6話と同一）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1091_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1091_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">劇場版後編</Fragment>
 					</Embedded>
 				</GridItem>
@@ -772,28 +772,28 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">変身開始</Fragment>
 
-			<Grid column="medium">
+			<Grid column={3}>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1499_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1499_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">1話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1499_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1499_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">3話（TBS）</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1200_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1200_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">パッケージ版</Fragment>
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_1200_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+					<Embedded width={320} border={true}>
+						<MyImage image={image_1200_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 						<Fragment slot="caption">劇場版後編</Fragment>
 					</Embedded>
 				</GridItem>
@@ -810,28 +810,28 @@ const slugger = new GithubSlugger();
 	<Section id="c013">
 		<Fragment slot="heading">#OP-C013　まどか変身</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1599_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1599_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1599_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1599_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1280_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1280_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">パッケージ版</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1280_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1280_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -847,28 +847,28 @@ const slugger = new GithubSlugger();
 	<Section id="c014">
 		<Fragment slot="heading">#OP-C014　まどか変身</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1618_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1618_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1618_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1618_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1295_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1295_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">パッケージ版</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1295_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1295_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -887,28 +887,28 @@ const slugger = new GithubSlugger();
 	<Section id="c015">
 		<Fragment slot="heading">#OP-C015　まどか変身</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1708_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1708_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1708_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1708_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1367_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1367_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">パッケージ版</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1367_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1367_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -925,16 +925,16 @@ const slugger = new GithubSlugger();
 	<Section id="c016">
 		<Fragment slot="heading">#OP-C016　まどかと家族</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1798_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1798_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1439_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1439_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -948,16 +948,16 @@ const slugger = new GithubSlugger();
 	<Section id="c017">
 		<Fragment slot="heading">#OP-C017　放課後のファーストフード</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1815_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1815_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1453_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1453_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -975,22 +975,22 @@ const slugger = new GithubSlugger();
 	<Section id="c018">
 		<Fragment slot="heading">#OP-C018　体育祭(?)記念撮影</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1839_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1839_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1839_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1839_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1472_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1472_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1005,28 +1005,28 @@ const slugger = new GithubSlugger();
 	<Section id="c019">
 		<Fragment slot="heading">#OP-C019　コンサート会場の恭介とさやか</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1841_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1841_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1841_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1841_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1841_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1841_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1473_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1473_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1042,28 +1042,28 @@ const slugger = new GithubSlugger();
 	<Section id="c020">
 		<Fragment slot="heading">#OP-C020　眠るマミとキュゥべえ</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1848_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1848_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1848_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1848_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1848_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1848_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1479_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1479_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1080,16 +1080,16 @@ const slugger = new GithubSlugger();
 	<Section id="c021">
 		<Fragment slot="heading">#OP-C021　佇む杏子</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1858_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1858_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1487_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1487_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1103,28 +1103,28 @@ const slugger = new GithubSlugger();
 	<Section id="c022">
 		<Fragment slot="heading">#OP-C022　雨の中のほむら</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1886_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1886_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1886_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1886_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1886_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1886_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1510_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1510_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1140,22 +1140,22 @@ const slugger = new GithubSlugger();
 	<Section id="c023">
 		<Fragment slot="heading">#OP-C023　まどか開眼</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1910_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1910_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1910_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1910_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1529_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1529_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1170,28 +1170,28 @@ const slugger = new GithubSlugger();
 	<Section id="c024">
 		<Fragment slot="heading">#OP-C024　走り出したまどか（下から）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1968_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1968_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1968_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1968_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1968_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1968_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1575_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1575_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1207,43 +1207,43 @@ const slugger = new GithubSlugger();
 	<Section id="c025">
 		<Fragment slot="heading">#OP-C025　走り出したまどか（横から）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1994_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1994_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1994_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1994_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1596_bd_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1596_bd_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">パッケージ版</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1596_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1596_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
 		</Grid>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<video src="/madoka/video/video/connect_OP-C025_tbs_1.webm" controls="" width="306" height="172" id="video-c025-tbs-1" slot="media"></video>
+				<Embedded width={320} border={true}>
+					<video src="/madoka/video/video/connect_OP-C025_tbs_1.webm" controls="" width="320" height="180" id="video-c025-tbs-1" slot="media"></video>
 					<Fragment slot="caption">【動画】1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<video src="/madoka/video/video/connect_OP-C025_tbs_3.webm" controls="" width="306" height="172" id="video-c025-tbs-3" slot="media"></video>
+				<Embedded width={320} border={true}>
+					<video src="/madoka/video/video/connect_OP-C025_tbs_3.webm" controls="" width="320" height="180" id="video-c025-tbs-3" slot="media"></video>
 					<Fragment slot="caption">【動画】3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1262,16 +1262,16 @@ const slugger = new GithubSlugger();
 	<Section id="c026">
 		<Fragment slot="heading">#OP-C026　覗き込む黒猫</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2235_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2235_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1789_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1789_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1285,28 +1285,28 @@ const slugger = new GithubSlugger();
 	<Section id="c027">
 		<Fragment slot="heading">#OP-C027　黒猫を抱えたまどか</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2300_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2300_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2300_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2300_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2300_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2300_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1841_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1841_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1322,22 +1322,22 @@ const slugger = new GithubSlugger();
 	<Section id="c028">
 		<Fragment slot="heading">#OP-C028　青空</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2350_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2350_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2350_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2350_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1881_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1881_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1352,22 +1352,22 @@ const slugger = new GithubSlugger();
 	<Section id="c029">
 		<Fragment slot="heading">#OP-C029　黒猫を抱えたまどか（アップ）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2439_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2439_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2439_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2439_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1952_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1952_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1382,22 +1382,22 @@ const slugger = new GithubSlugger();
 	<Section id="c030">
 		<Fragment slot="heading">#OP-C030　向き合うまどかとほむら（遠景）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2468_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2468_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2468_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2468_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1975_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1975_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1413,22 +1413,22 @@ const slugger = new GithubSlugger();
 	<Section id="c031">
 		<Fragment slot="heading">#OP-C031　向き合うまどかとほむら</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2494_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2494_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2494_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2494_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_1996_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_1996_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1445,22 +1445,22 @@ const slugger = new GithubSlugger();
 	<Section id="c032">
 		<Fragment slot="heading">#OP-C032　建物</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2507_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2507_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2507_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2507_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2006_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2006_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1475,43 +1475,43 @@ const slugger = new GithubSlugger();
 	<Section id="c033">
 		<Fragment slot="heading">#OP-C033　向き合うまどかとほむら（ほむらアップ）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2528_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2528_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2528_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2528_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2528_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2528_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2023_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2023_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
 		</Grid>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<video src="/madoka/video/video/connect_OP-C033_tbs_1.webm" controls="" width="306" height="172" id="video-c033-tbs-1" slot="media"></video>
+				<Embedded width={320} border={true}>
+					<video src="/madoka/video/video/connect_OP-C033_tbs_1.webm" controls="" width="320" height="180" id="video-c033-tbs-1" slot="media"></video>
 					<Fragment slot="caption">【動画】1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<video src="/madoka/video/video/connect_OP-C033_tbs_5.webm" controls="" width="306" height="172" id="video-c033-tbs-5" slot="media"></video>
+				<Embedded width={320} border={true}>
+					<video src="/madoka/video/video/connect_OP-C033_tbs_5.webm" controls="" width="320" height="180" id="video-c033-tbs-5" slot="media"></video>
 					<Fragment slot="caption">【動画】5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1531,43 +1531,43 @@ const slugger = new GithubSlugger();
 	<Section id="c034">
 		<Fragment slot="heading">#OP-C034　向き合うまどかとほむら（まどかアップ）</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2553_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2553_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2553_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2553_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2553_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2553_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2044_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2044_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
 		</Grid>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<video src="/madoka/video/video/connect_OP-C034_tbs_1.webm" controls="" width="306" height="172" id="video-c034-tbs-1" slot="media"></video>
+				<Embedded width={320} border={true}>
+					<video src="/madoka/video/video/connect_OP-C034_tbs_1.webm" controls="" width="320" height="180" id="video-c034-tbs-1" slot="media"></video>
 					<Fragment slot="caption">【動画】1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<video src="/madoka/video/video/connect_OP-C034_tbs_5.webm" controls="" width="306" height="172" id="video-c034-tbs-5" slot="media"></video>
+				<Embedded width={320} border={true}>
+					<video src="/madoka/video/video/connect_OP-C034_tbs_5.webm" controls="" width="320" height="180" id="video-c034-tbs-5" slot="media"></video>
 					<Fragment slot="caption">【動画】5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1587,40 +1587,40 @@ const slugger = new GithubSlugger();
 	<Section id="sub-title">
 		<Fragment slot="heading">サブタイトル</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2645_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2645_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2645_tbs_2} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2645_tbs_2} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">2話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2645_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2645_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2645_tbs_4} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2645_tbs_4} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">4話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2645_tbs_5} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2645_tbs_5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">5話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2117_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2117_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>
@@ -1641,34 +1641,34 @@ const slugger = new GithubSlugger();
 	<Section id="c035">
 		<Fragment slot="heading">#OP-C035　電波塔の上にいる魔法少女たち</Fragment>
 
-		<Grid column="medium">
+		<Grid column={3}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2695_tbs_1} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2695_tbs_1} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">1話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2687_tbs_3} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2687_tbs_3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">3話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2695_tbs_10} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2695_tbs_10} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">10話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2695_tbs_11} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2695_tbs_11} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">11話（TBS）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_2184_kouhen} alt="画像拡大" width={306} height={172} link={true} slot="media" />
+				<Embedded width={320} border={true}>
+					<MyImage image={image_2184_kouhen} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 					<Fragment slot="caption">劇場版後編</Fragment>
 				</Embedded>
 			</GridItem>

--- a/astro/src/pages/madoka/video/kouhen.astro
+++ b/astro/src/pages/madoka/video/kouhen.astro
@@ -125,16 +125,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:26:46">
 				<p>杏子とオクタヴィアの奥に並ぶ巨大な槍が少し小さくなった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_002650_tvcm3} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_002650_tvcm3} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">TV CM 3（前編BD/DVD収録）</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_002650_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_002650_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>

--- a/astro/src/pages/madoka/video/shinpen.astro
+++ b/astro/src/pages/madoka/video/shinpen.astro
@@ -194,10 +194,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:00:19" timeEnd="00:01:24">
 				<p>ソウルジェムの回転具合、近づいてくるタイミング、魔女文字の書かれた壁画がブレる処理などが変更。また、近づいてきたソウルジェムの濁り部分が画面いっぱいに広がった後、5秒ほどブラックアウトになるように。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000057_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000057_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -206,16 +206,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:01:35">
 				<p>ほむらの語りが終わった後、夜の街並みの静止画カット（6枚）の4枚目が高速道路のジャンクションの画に差し替え。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000135_tvtokyo} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000135_tvtokyo} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">テレビ東京特番</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000135_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000135_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -224,10 +224,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:01:52">
 				<p>背景の夜空がパッチワーク（布片）に変わるときにSEが追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000153_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000153_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -236,16 +236,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:03:14">
 				<p>杏子の作画修正。また高速で回転する槍の表現が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000316_tvtokyo} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000316_tvtokyo} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">テレビ東京特番</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000316_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000316_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -254,16 +254,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:03:36" timeEnd="00:04:25">
 				<p>魔法部屋にある椅子の背もたれ上部の柄が変更。マミがティーセットをべべの頭に乗せるカット（4′25″）が分かりやすい。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000336_tvtokyo} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000336_tvtokyo} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">テレビ東京特番</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000336_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000336_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -272,16 +272,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:03:52">
 				<p>ナイトメアが部屋に入ってきたまどかの方を振り向くカットで、椅子が削除。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000355_tvtokyo} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000355_tvtokyo} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">テレビ東京特番</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter1_000355_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter1_000355_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -290,16 +290,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:04:20">
 				<p>ナイトメアの時間を止める瞬間、フラッシュを焚いたように画面全体が白くなるコマが挿入。また、その直後のコマは画面がピンぼけし、若干上下方向に引き延ばされる処理が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<video src="/madoka/video/video/shinpen_chapter1_00-04-19_tvtokyo.webm" controls="" width="294" height="166" id="video-chapter1-000420-tvtokyo" slot="media"></video>
+						<Embedded width={320} border={true}>
+							<video src="/madoka/video/video/shinpen_chapter1_00-04-19_tvtokyo.webm" controls="" width="320" height="180" id="video-chapter1-000420-tvtokyo" slot="media"></video>
 							<Fragment slot="caption">テレビ東京特番</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<video src="/madoka/video/video/shinpen_chapter1_00-04-19_bd.webm" controls="" width="294" height="166" id="video-chapter1-000420-bd" slot="media"></video>
+						<Embedded width={320} border={true}>
+							<video src="/madoka/video/video/shinpen_chapter1_00-04-19_bd.webm" controls="" width="320" height="180" id="video-chapter1-000420-bd" slot="media"></video>
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -321,19 +321,19 @@ const structuredData: StructuredData = {
 
 				<p>座ったまどかの股が白く描かれてパンチラのように見えていたのを修正。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter2_000725_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter2_000725_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter2_000733_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter2_000733_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -349,10 +349,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:07:40">
 				<p>オープニングが始まるパンアップのカットで、日光のゴースト形状は上映版では正五角形だったが、パッケージ版では横長の形状に変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter3_000746_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter3_000746_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -368,16 +368,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:09:13">
 				<p>オープニング直後の静止画カット（3枚）の3枚目が林の中の遊歩道から親水公園的な場所の俯瞰の画に差し替え。なお、前編のOP直後も同じ流れで静止画カットが4枚あり、その3枚目が差し替え前の遊歩道と同じイラストである。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter4_000913_zenpenbd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter4_000913_zenpenbd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">【参考】前編・パッケージ版（4m47s）</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter4_000913_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter4_000913_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -386,10 +386,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:11:18">
 				<p>和子先生が妄想話をする中での他教室からのカットで、部屋や廊下の照明が消えている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter4_001118_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter4_001118_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -405,10 +405,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:13:42">
 				<p>屋上でほむらと他の魔法少女達が顔合わせをした次の静止画カット（計6枚）の6枚目、夜景を見下ろした画が差し替え。差し替え後も夜景の画だが、ピントをボカしたような処理が施されている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter5_001342_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter5_001342_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -424,10 +424,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:16:52">
 				<p>バスタオル姿で髪を解かすマミの鏡台に置かれている化粧品ケースに模様が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_001654_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_001654_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -436,10 +436,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:17:27" timeEnd="00:26:28">
 				<p>背景のパッチワークの柄が細かくなる。この変更はナイトメア戦が終わるまで続く。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_001735_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_001735_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -450,10 +450,10 @@ const structuredData: StructuredData = {
 
 				<p>モノレールの屋根でまどかとほむらが合流するシーン（後ろ姿の部分）の電柱の流れが逆向きに。上映版（奥から手前に）が正しく、パッケージ版（手前から奥に）が間違っている。なお、来場者特典フィルムはパッケージ版と同じ向きだった模様（<Anchor href="https://x.com/homuh0mu/status/486787749731528706">フィルムを入手された方の投稿</Anchor>）。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<video src="/madoka/video/video/shinpen_chapter6_00-18-11_bd.webm" controls="" width="294" height="166" slot="media"></video>
+						<Embedded width={320} border={true}>
+							<video src="/madoka/video/video/shinpen_chapter6_00-18-11_bd.webm" controls="" width="320" height="180" slot="media"></video>
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -462,10 +462,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:19:11" timeEnd="00:19:19">
 				<p>杏子変身シーンの前半、ソウルジェムを咥えてダンスする部分で背景の赤い丸模様が下から上に向かって動くようになる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_001914_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_001914_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -474,10 +474,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:19:40" timeEnd="00:19:57">
 				<p>さやか変身シーン、ブレイクダンスをする前後の部分で背景の青い結晶が下から上に向かって動くようになる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_001946_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_001946_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -486,10 +486,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:19:57">
 				<p>同じくさやか変身シーン、自身と混じり合った泡の中から出てくるさやかは上映版ではマントなども含め全体的に青く塗られていたが、白や金などの色付けが行われる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_001958_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_001958_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -505,10 +505,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:22:00">
 				<p>飛び回るまどかに合わせて変化する背景が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter7_002203_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter7_002203_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -517,10 +517,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:22:04">
 				<p>ティロ・デュエット直前のマミとまどかが手を繋ぎ舞い踊るところで、背景に描かれる黄色とピンクの帯の本数が増加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter7_002206_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter7_002206_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -529,10 +529,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:22:10">
 				<p>ティロ・デュエットの決めポーズでマミとまどかの作画修正、背景のマスケット銃が増加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter7_002210_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter7_002210_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -541,10 +541,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:22:36">
 				<p>ビルの上でナイトメアを包む煙に花模様が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter7_002236_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter7_002236_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -553,10 +553,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:23:43">
 				<p>落ちてくるラスベリーを食べようとしているナイトメアが首を傾けるタイミングが遅くなる。キャプチャー画像の時点で、上映版ではすでに首を傾けていた。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter7_002346_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter7_002346_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -565,10 +565,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:25:51" timeEnd="00:26:09">
 				<p>ヒトミタマシイから魔法少女達のソウルジェムへ降り注ぐ光のカーテンの効果が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter7_002554_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter7_002554_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -577,10 +577,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:26:24">
 				<p>結界が消えるときのSEが変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter7_002625_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter7_002625_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -596,10 +596,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:28:47">
 				<p><q>私たちの戦いって…これでよかったんだっけ?</q>の静止画カット（8枚）の4枚目が円筒形の池がある公園に変更。なお上映版は通学路の小川のカットで、これは「<cite>叛逆の物語　プロダクションノート</cite>」の p.202 に掲載されている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter8_002848_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter8_002848_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -608,10 +608,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:29:28" timeEnd="00:29:54">
 				<p>屋上で弁当を食べるシーンの前半（<q>ほむらちゃんも から揚げどう?</q>より前）のみ、画面手前に柵が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter8_002931_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter8_002931_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -627,10 +627,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:30:55">
 				<p>水上カフェで初めてほむらと杏子が遠景で写るカットの木の枝の描き込みが精巧に。上映版ではこのカットだけ細かい枝が描かれていなかった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter9_003058_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter9_003058_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -639,10 +639,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:31:36" timeEnd="00:31:59">
 				<p>上映版では杏子が<q>ちょっとちょっと 何 あんた?――</q>と言って姿勢を変えるところから若干椅子から浮き上がっていたが、パッケージ版で修正。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter9_003138_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter9_003138_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -652,10 +652,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:32:46">
 				<p><q>ただ行ってみるだけでいいんです</q>の部分でテーブルの下に偽街の子供達が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={chapter9_003248_bd} alt="画像拡大" width={294} height={166} link={true} />
+						<Embedded width={320} border={true}>
+							<MyImage image={chapter9_003248_bd} alt="画像拡大" width={320} height={180} link={true} />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -672,10 +672,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:34:20">
 				<p>バスが発車するとき、上映版では真横に動いていたが、斜め前に進むよう変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<video src="/madoka/video/video/shinpen_chapter10_00-34-20_bd.webm" controls="" width="294" height="166" slot="media"></video>
+						<Embedded width={320} border={true}>
+							<video src="/madoka/video/video/shinpen_chapter10_00-34-20_bd.webm" controls="" width="320" height="180" slot="media"></video>
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -691,10 +691,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:38:02" timeEnd="00:38:14">
 				<p>ほむらと杏子に迫る群衆の髪型が変更。ほむらのメガネや三つ編み、杏子のポニーテールがより本人に近い形に再現。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter11_003803_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter11_003803_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -710,10 +710,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:40:45">
 				<p>「魔女の井戸」の中で上を見上げるほむらに光が当たらなくなり、暗く描かれる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter12_004046_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter12_004046_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -729,10 +729,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:41:44">
 				<p>キュゥべえの奥にある棚の置物が修正。上映版ではここを含むいくつかのカットで棚に入っている物が異なっていた。また、上映版では棚が4段で描かれたカットが存在しており、パッケージ版ではすべて5段に修正されている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter13_004146_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter13_004146_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -745,10 +745,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:41:48">
 				<p>ベベが<q>チーズニナッチャウ!</q>と言って駆け回る背景に虎が追加。虎は<q>Be号</q>と書かれた腹巻き(?)を付けている。数匹の虎が駆け回ってバター（Ghee）になり、ホットケーキが作られる流れは童話『<cite>ちびくろサンボ</cite>』から来ている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter13_004149_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter13_004149_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -757,10 +757,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:42:06">
 				<p>ほむらが紅茶を飲むところ、上映版では紅茶を口に含んだ後、カップから口を離したが、パッケージ版では付いたまま。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter13_004207_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter13_004207_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -769,10 +769,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:43:16">
 				<p>上映版ではほむらが紅茶のカップを口に付けた体勢で5秒以上静止していたが（かなり不自然）、テーブルから少し持ち上げた体勢に変更。上映版では<q>ちょっとだけ気になって</q>直後のカットの使い回しをしていたものと思われる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter13_004317_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter13_004317_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -781,10 +781,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:44:41">
 				<p>ソウルジェムを取り出すほむらは、上映版では糸目の笑顔だったが、途中から目を開いた表情に変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter13_004443_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter13_004443_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -795,28 +795,28 @@ const structuredData: StructuredData = {
 
 				<p>窓の開閉ボタンを押した後のほむらの立ち位置が修正（キャプチャー3枚目）。上映版ではテーブルから少し離れていた。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter13_004529_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter13_004529_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter13_004547_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter13_004547_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter13_004553_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter13_004553_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -832,10 +832,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:46:08">
 				<p>TV版3話のお菓子の魔女空間内にもあった足場がカラフルになり、クッキーなどのお菓子が載せられている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter14_004609_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter14_004609_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -848,10 +848,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:46:12">
 				<p>ほむらが手前から奥に飛び立つカット（画像2枚目）では、新たに画面手前に足場が描かれている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter14_004614_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter14_004614_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -867,10 +867,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="00:59:57">
 				<p>三叉路の壁に動きが付く。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter17_010000_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter17_010000_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -886,10 +886,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:00:27">
 				<p>地面に映る輪回しの少女の影は、糸巻きを通過するときには隠れるように進む。上映版では影絵のように糸巻きに影が重なる描写だった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter18_010027_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter18_010027_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -898,10 +898,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:01:00">
 				<p>コーヒーカップに入った紙絵のマミとべべは画面中央付近に位置していたが、やや左寄りに変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter18_010102_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter18_010102_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -917,10 +917,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:07:45" timeEnd="01:08:20">
 				<p>ゲームセンターで「<cite>Dog Drug Reinforcement.</cite>」を踊る偽街の子供達はがに股でダンスをしていたが、内股に変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_010747_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_010747_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -929,10 +929,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:08:09">
 				<p>ほむらの足元が星の散らばる夜空のような模様に変更。上映版はこの直後のカットのような模様だった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_010810_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_010810_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -941,10 +941,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:08:54">
 				<p>杏子に向かって落ちてくる飛行船の目の部分の炎がより燃え盛る感じに変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_010856_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_010856_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -953,16 +953,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:09:49">
 				<p>バスの上で自分の右手を見つめるほむらの表情が変更。手のひらだけでなく、甲にもカラフルな模様が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_010951_tvcm5} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_010951_tvcm5} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">TV CM 5</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_010951_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_010951_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -973,10 +973,10 @@ const structuredData: StructuredData = {
 
 				<p>フクロウが増える。上映版ではバスの上の振り子時計に降りる3羽と、上空を舞う1羽の計4羽だった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_011001_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_011001_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -987,10 +987,10 @@ const structuredData: StructuredData = {
 
 				<p>地面から生えてくる建物が増える、外壁の色が変化する、巨大な生き物のようなオブジェが描かれるといった変化もある。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_011047_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_011047_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -999,10 +999,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:11:44">
 				<p>ほむらが自分が魔女であることに気づいた直後、炎をバックにガンコ、ヒガミ、オクビョウ、マヌケが写るカットで、キャラクターに動きが付き（とくにヒガミとオクビョウは内緒話をするカクカクした動き）、全体に影が付けられる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_011145_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_011145_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1011,10 +1011,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:12:07">
 				<p>マユの塔が出現した直後のアップのカットで、次のアルティメットまどか像のカットへの画面切り替え時に暗転エフェクトと水に潜るようなSEが追加。逆に、画面切り替えを表すSEは削除。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter20_011208_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter20_011208_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1030,19 +1030,19 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:12:32" timeEnd="01:20:55">
 				<p>戸棚の中にあるベッドでほむらが被っているシーツの色は上映版では白一色だったが、半透明になりところどころカラフルな模様が発光するように。周囲の壁（戸棚の内部）の模様も変更。キャプチャー1枚目のカットでは、ほむらの顔にかかる位置にレース模様が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011239_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011239_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011244_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011244_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1051,10 +1051,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:12:36">
 				<p>マユの塔の中で最初にキュゥべえが正面アップになるカットの床の模様が変更。上映版は白い模様で、前後のカットとの整合性が取れていなかった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011236_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011236_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1063,10 +1063,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:12:52">
 				<p>ほむらが被っていたシーツが取れて、喪服が披露されたカットの表情が変更。また、全身に影がかかる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011253_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011253_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1075,10 +1075,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:12:56">
 				<p>皿に黒トカゲの下半身が載ったカットで、床面の模様が変更。上映版は白い床だった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011258_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011258_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1087,10 +1087,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:13:57">
 				<p>現実世界で台座に横たわるほむらを多数のキュゥべえが観察しているカット、上映版ではほむらが比較的大きく写っていたが、引いた構図に。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011357_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011357_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1099,10 +1099,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:14:11">
 				<p>ロッテのいる戸棚にミラーボールや星、雪の結晶などクリスマスに関連した装飾が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011411_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011411_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1115,10 +1115,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:14:14">
 				<p>戸棚に並ぶロッテの前でレイケツ、マヌケ、ヒガミが動き回っているカット、およびその次のウソツキがロッテの後ろから覗いているカットの背景（戸棚の内部）が赤いものに変更。上映版ではほむらのベッドがある戸棚中心部の電飾のような背景だった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011415_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011415_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1127,10 +1127,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:14:28">
 				<p>現実世界で台座に横たわるほむらを真上から見たカット、多数のカラフルな長方形の浮遊物(?)が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011428_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011428_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1139,10 +1139,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:14:40" timeEnd="01:14:47">
 				<p>キュゥべえの説明中に流れる、偽街が造られるイメージ映像にほむらの手が追加。手が追加された静止画は4カットあり、手は建物を移動したり、街路灯を建てたりしている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011445_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011445_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1151,10 +1151,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:14:54">
 				<p>落ちる飛行船を背景にキュゥべえが手前を振り向くとき、キュゥべえに影がかかり、目だけが光るようになる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011455_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011455_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1163,10 +1163,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:14:59">
 				<p>マユの塔内部から上を見上げるカット、戸棚のほむらベッド以外の背景が黒に変更され、キラキラした効果が追加される。戸棚自体もより下から見上げたときのあおりを強調した形に修正されている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011500_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011500_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1175,10 +1175,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:15:56">
 				<p>キュゥべえの説明中に魔法少女達やよだれを垂らすベベが出てくるシーンで、廊下の両壁で回っている緑色の歯車の形状が変更され、配置が平面的になる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011559_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011559_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1187,10 +1187,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:17:01" timeEnd="01:17:08">
 				<p>ベッドで眠るまどかの仕上げがアニメ画から手描き画のような感じに変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011707_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011707_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1199,10 +1199,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:17:33">
 				<p>偽街の子供達がハンカチを持って泣く仕草が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter21_011735_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter21_011735_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1218,16 +1218,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:18:25">
 				<p>ほむらの全身に影がかかる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_011826_tvcm4} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_011826_tvcm4} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">TV CM 4</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_011826_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_011826_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1236,19 +1236,19 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:19:23">
 				<p>キュゥべえがまち針に囲われている一連のカットで、床の模様が変更。上映版は黒（キュゥべえが床に落ちる）→白（キュゥべえアップ、キャプチャー1枚目）→茶（まち針の中を回る、キャプチャー2枚目）→黒とカットによって変わっていた。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_011923_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_011923_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_011930_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_011930_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1257,10 +1257,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:19:39">
 				<p>偽街の子供達の動きが変更。上映版ではカクカクしたパターンの動きを繰り返していたが、複雑な動きになる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_011941_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_011941_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1271,28 +1271,28 @@ const structuredData: StructuredData = {
 
 				<p>ホムリリィの口元のリボンが上映版では1本、パッケージ版では3本に増加し、形状も中空タイプになっている。「<cite>叛逆の物語　プロダクションノート</cite>」付属の「<cite>劇団イヌカレー イメージノート2</cite>」の p.172 に両タイプの絵柄が掲載されている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_012222_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_012222_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_012223_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_012223_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_012231_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_012231_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1301,10 +1301,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:23:36">
 				<p><q>最後にお別れを言えなくて――ごめんね…</q>の部分で涙を流すトカゲの身体が紫色に変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter22_012339_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter22_012339_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1320,10 +1320,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:23:59">
 				<p>ほむらの描写がモノクロに近くなる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter23_012401_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter23_012401_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1332,19 +1332,19 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:24:25">
 				<p>巨大ギロチン台が出現するシーン、上映版ではギロチン台の後方にマユの塔とそこからの道が写っていたが、パッケージ版で削除。マユの塔は直前のホムリリィ出現時に半壊しているので、上映版で無傷で描かれているのはおかしい。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter23_012426_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter23_012426_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter23_012430_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter23_012430_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1355,10 +1355,10 @@ const structuredData: StructuredData = {
 
 				<p>街中にお菓子や楽器などの小物類が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter23_012440_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter23_012440_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1374,10 +1374,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:25:54">
 				<p>背景に描かれている水道橋のオブジェの位置と傾き方向が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012556_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012556_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1386,10 +1386,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:26:17">
 				<p>オクタヴィアが現れる時に、円形をした五線譜の中に音楽記号がある模様（黒色）が煙の表面に複数出現するようになる。オクタヴィアの周囲にも巨大な五線譜が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012617_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012617_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1398,10 +1398,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:26:42">
 				<p>オクタヴィアの腕の開き具合、剣の角度が変更。上映版では剣は外側に開く向きだった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012644_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012644_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1410,10 +1410,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:27:13">
 				<p>アントニー（薔薇園の魔女の手下）達が持つ武器が精巧に。先端部はバラの模様。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012716_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012716_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1422,10 +1422,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:27:28">
 				<p>手前のベッド(?)の位置がホムリリィとオクタヴィアにかからないように左にずれる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012729_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012729_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1434,10 +1434,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:27:30">
 				<p>オクタヴィアが持つ剣の角度が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012733_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012733_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1446,10 +1446,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:27:34">
 				<p>オクタヴィアが攻撃する時に、円形をした五線譜の中に音楽記号がある模様（白色）が周囲に複数出現。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012735_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012735_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1458,10 +1458,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:27:44">
 				<p>奥に多数の家具類が山のように積み上がったものが追加。まどかがマミの空中ブランコに抱えられて飛ぶのカット（1h27′48″）の右側にも描かれている。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012744_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012744_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1470,10 +1470,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:27:57">
 				<p>弓を放つまどかの周囲に家具やお菓子の小物が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012800_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012800_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1482,16 +1482,16 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:29:08">
 				<p>オクタヴィアのマント周りが変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012910_tvcm4} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012910_tvcm4} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">TV CM 4</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012910_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012910_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1500,10 +1500,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:29:13">
 				<p>上映版ではさやかがいったん瞳のみ正面を向いた後、後ろにいる杏子に向かって振り向く動きがあったが、パッケージ版では静止したまま。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012914_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012914_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1512,10 +1512,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:29:33">
 				<p>オクタヴィアは上映版では横スライドの動きだったが、上下に波打つ動きや尾を動かす動作が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012934_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012934_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1524,10 +1524,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:29:56">
 				<p>オクタヴィアは上映版では杏子の槍を両手で持っていたが、左手のみで持つ形に変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_012956_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_012956_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1537,10 +1537,10 @@ const structuredData: StructuredData = {
 				<p>ホムリリィの頭部の周りに白い歯が円形に配置。この後もいくつかのシーンで同様の追加が行われている（正面以外のカットでは描かれていない）。</p>
 				<!--<p>緑色の歯車の数が増加。</p>-->
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_013010_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_013010_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1549,10 +1549,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:30:11">
 				<p>オクタヴィアの動き（左向きに横スライド）が速くなる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_013012_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_013012_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1561,10 +1561,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:30:25">
 				<p>「ティロ・フィナーレ」直前にマミが出す巨大な砲弾に手毬のような描き込みが行われる。出現するときのSEが追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_013026_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_013026_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1573,10 +1573,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:30:36">
 				<p>背景右側に描かれている、ホムリリィから伸びる枝の形状が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_013038_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_013038_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1585,10 +1585,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:30:44">
 				<p>オクタヴィアの周囲に、円形をした五線譜の中に音楽記号がある模様（白色）が複数描き込まれる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_013045_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_013045_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1599,10 +1599,10 @@ const structuredData: StructuredData = {
 
 				<p>オクタヴィアから巨大な円形の五線譜（黒色）が出現する。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter24_013046_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter24_013046_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1618,10 +1618,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:33:23">
 				<p>ホムリリィの結界が消滅するときの効果が変更され、画面全体が揺れ動く感じに。花火の弾け具合も変わっており、弾けるSEが追加された。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter25_013324_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter25_013324_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1637,10 +1637,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:33:51">
 				<p>鹿目家の3人のベンチにダニエル&amp;ジェニファー（ハコの魔女の手下）が追加。ベンチを下ろしつつ、手を振っている。次のカットでマミが手を振っているが、上映版では誰に振っているのか分からない状態だった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter26_013352_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter26_013352_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1649,10 +1649,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:35:11">
 				<p>ほむらのソウルジェムの色が上映版では青（1h33m39sと同じ）、パッケージ版は濃い青と紫に変更。またソウルジェム内部に泡が流れる表現が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter26_013512_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter26_013512_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1661,10 +1661,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:35:53" timeEnd="01:36:45">
 				<p>ほむらから発生する黒い煙に赤、青、緑などの色効果が付く。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter26_013556_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter26_013556_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1673,19 +1673,19 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:37:54">
 				<p>ソウルジェムが一瞬で細かい泡のようなものに変化し、ライン状に集まる一連の動きが表現される。上映版では最初から泡がライン状になっており、ソウルジェムが変化したものということが分からなかった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter26_013754_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter26_013754_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter26_013754_2_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter26_013754_2_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1696,10 +1696,10 @@ const structuredData: StructuredData = {
 
 				<p>一部のカットではキュゥべえの配置が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter26_013828_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter26_013828_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1708,10 +1708,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:39:17">
 				<p>ほむらが<q>愛よ</q>とつぶやくシーン、上映版ではセリフに合わせて口が動いていたが、ダークオーブを飲み込んだ後は口を閉じたままに変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter26_013918_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter26_013918_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1720,10 +1720,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:39:36">
 				<p>悪魔ほむらの衣装が披露されるシーンで、背中の翼が生える時に羽が飛び散るようになる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter26_013936_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter26_013936_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1741,10 +1741,10 @@ const structuredData: StructuredData = {
 
 				<p>ピョートル（お菓子の魔女の手下）を隠す花びらの形状や舞い方が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014059_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014059_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1753,10 +1753,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:41:01" timeEnd="01:43:04">
 				<p>ほむらが座っているパラソルの柱に魔女文字が描かれる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014102_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014102_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1765,10 +1765,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:41:39">
 				<p>ほむらは上映版では首を2回横に振っていたが、ゆっくり1回に変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014141_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014141_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1781,10 +1781,10 @@ const structuredData: StructuredData = {
 
 				<p>ほむらの座っている位置が変更。上映版は向かって右側の椅子、パッケージ版では左側。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014156_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014156_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1793,10 +1793,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:42:43">
 				<p>上映版ではほむらとさやかに影が付いていたが、明るくなる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014244_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014244_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1809,19 +1809,19 @@ const structuredData: StructuredData = {
 
 				<p>オクタヴィアにエフェクトが追加され、もやもやと輝くようになった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014252_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014252_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
 				</Grid>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014253_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014253_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1830,10 +1830,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:43:05">
 				<p>紫色の液体の流れ方が変更。上映版は画面右上から先端部がギザギザを描く形で流れてきた。また、液体が透過して路面の模様がうっすら見えるようになった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014307_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014307_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1842,10 +1842,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:43:11">
 				<p>オクタヴィアが消える時、波打つようなエフェクトがかかるようになる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014311_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014311_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1860,10 +1860,10 @@ const structuredData: StructuredData = {
 
 				<p>さやか作画修正（髪型や制服の後ろリボンの形状など）。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter27_014416_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter27_014416_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1879,10 +1879,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:45:11">
 				<p>教室で頬杖をつくほむらの奥にいたモブキャラ男子がいなくなる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014511_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014511_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1891,10 +1891,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:45:12">
 				<p>和子先生に頬の斜線表現が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014514_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014514_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1905,10 +1905,10 @@ const structuredData: StructuredData = {
 
 				<p>一部生徒の髪型が変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014552_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014552_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1917,10 +1917,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:46:42">
 				<p>ほむらの口元アップのカットで、口唇の境界線の表現がソフトに。上映版では口紅をしている感が強かった。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014643_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014643_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1929,10 +1929,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:46:44">
 				<p>廊下のモブキャラが変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014645_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014645_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1941,10 +1941,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:46:58">
 				<p>上映版ではまどかのリボンが赤色だったが、黄色に修正。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014701_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014701_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1953,10 +1953,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:47:27">
 				<p>ほむらに案内されて校内の廊下を歩くカットで、まどかの頭上から見下ろしたカットが差し替え。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014727_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014727_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1967,10 +1967,10 @@ const structuredData: StructuredData = {
 
 				<p>まどかから発生する宇宙空間のようなものがカラフルに。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014800_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014800_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1979,10 +1979,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:48:03" timeEnd="01:48:14">
 				<p>まどかの背景に出現した宇宙空間のようなものがカラフルに。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014805_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014805_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -1991,10 +1991,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:48:10" timeEnd="01:48:19">
 				<p>宇宙空間のような背景模様は、上映版では煙と共に消えていたが、パッケージ版では煙が消えた後も残る。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014815_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014815_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2009,10 +2009,10 @@ const structuredData: StructuredData = {
 
 				<p>背景の雲が右方向に動くようになる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014916_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014916_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2021,10 +2021,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:49:34">
 				<p>木が2本生えた場所の壁面に家具やお菓子などの絵が描かれる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014934_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014934_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2033,10 +2033,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:49:43">
 				<p>瓶に描かれた魔女文字 <span class="u-madoka-font-witch">GERTRUD WIE</span> が白色から黒色に変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014944_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014944_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2045,10 +2045,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:49:44" timeEnd="01:49:46">
 				<p>ショッピングをするマミの服に斑点模様が、なぎさの服に水玉模様が追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014948_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014948_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2059,10 +2059,10 @@ const structuredData: StructuredData = {
 
 				<p>なお、この直後の標識アップのカットでは上映版でも文字が描かれていた。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014949_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014949_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2071,10 +2071,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:49:58">
 				<p>エンディングに入る直前、街の上空で浮遊回転する、円環マークの描かれた茶色い石のようなものが追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_014959_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_014959_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2083,10 +2083,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:50:03">
 				<p>魔女文字が変更。上映版は <span class="u-madoka-font-witch">WER TRÄUMT?</span> 、パッケージ版は <span class="u-madoka-font-witch">WER HATGETRÄUMT?</span> 。また、文字がかすれたようなエフェクトが追加。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter28_015003_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter28_015003_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2102,10 +2102,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:50:05" timeEnd="01:55:00">
 				<p>エンディング「<cite>君の銀の庭</cite>」のシルエットの色が全編にわたって変更。一部、タイミングが変更された部分もある。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter29_015038_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter29_015038_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2123,10 +2123,10 @@ const structuredData: StructuredData = {
 
 				<p>雲が流れる方向も逆になる。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter30_015529_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter30_015529_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>
@@ -2135,10 +2135,10 @@ const structuredData: StructuredData = {
 			<VideoDiffItem timeStart="01:55:35">
 				<p>草むらから出てくるキュゥべえは、上映版では通常のように身体が白く描かれていたが、光が当たっていないためか暗く変更。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter30_015539_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter30_015539_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>

--- a/astro/src/pages/madoka/video/zenpen.astro
+++ b/astro/src/pages/madoka/video/zenpen.astro
@@ -118,16 +118,16 @@ const structuredData: StructuredData = {
 
 				<p>魔法少女服の襟の内側が黄色く塗られていたミスを修正。</p>
 
-				<Grid column="medium">
+				<Grid column={3}>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_001713_trailer} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_001713_trailer} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">予告編1（後編BD/DVD収録）</Fragment>
 						</Embedded>
 					</GridItem>
 					<GridItem>
-						<Embedded border={true}>
-							<MyImage image={image_chapter6_001713_bd} alt="画像拡大" width={294} height={166} link={true} slot="media" />
+						<Embedded width={320} border={true}>
+							<MyImage image={image_chapter6_001713_bd} alt="画像拡大" width={320} height={180} link={true} slot="media" />
 							<Fragment slot="caption">パッケージ版</Fragment>
 						</Embedded>
 					</GridItem>

--- a/astro/src/pages/madoka/yomoyama/aj2017_magireco_jiho.astro
+++ b/astro/src/pages/madoka/yomoyama/aj2017_magireco_jiho.astro
@@ -17,7 +17,7 @@ const slugger = new GithubSlugger();
 ---
 
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
-	<Embedded border={true}>
+	<Embedded width={640} border={true}>
 		<video src="/madoka/yomoyama/video/aj2017_magireco_jiho_1100.webm" controls="" width="640" height="360" slot="media">
 			<track kind="captions" label="セリフ字幕" src="/madoka/yomoyama/video/aj2017_magireco_jiho_1100.vtt" />
 		</video>

--- a/astro/src/pages/madoka/yomoyama/monoga-modoka.astro
+++ b/astro/src/pages/madoka/yomoyama/monoga-modoka.astro
@@ -168,17 +168,17 @@ const structuredData: StructuredData = {
 
 			<p>また、展示エリアを出たところにあるエンドカードゾーンの一角に、6人のキャラクターボードが展示されていました。</p>
 
-			<Grid column="medium">
+			<Grid column={2}>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_kanazawa1} alt="写真拡大" width={306} height={306} link={true} slot="media" />
+					<Embedded width={540} border={true}>
+						<MyImage image={image_kanazawa1} alt="写真拡大" width={540} height={540} link={true} slot="media" />
 						<Fragment slot="caption"><cite>MADOGATARI GALLERY</cite> でのキャラクターボード展示</Fragment>
 						<!-- 2016-12-22 IMG_5289 -->
 					</Embedded>
 				</GridItem>
 				<GridItem>
-					<Embedded border={true}>
-						<MyImage image={image_kanazawa2} alt="写真拡大" width={306} height={204} link={true} slot="media" />
+					<Embedded width={540} border={true}>
+						<MyImage image={image_kanazawa2} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<Fragment slot="caption">キャラクターボードが展示されていたエリアの様子</Fragment>
 						<!-- 2016-12-22 IMG_5296 -->
 					</Embedded>

--- a/astro/src/pages/madoka/yomoyama/umeten_guide.astro
+++ b/astro/src/pages/madoka/yomoyama/umeten_guide.astro
@@ -25,22 +25,22 @@ const structuredData: StructuredData = {
 	<Section id="guidelist">
 		<Fragment slot="heading">各会場のガイドリスト</Fragment>
 
-		<Grid column="narrow">
+		<Grid column={4}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_list_tokyo} alt="画像拡大" width={155} height={220} link={true} slot="media" />
+				<Embedded width={225} border={true}>
+					<MyImage image={image_list_tokyo} alt="画像拡大" width={225} height={320} link={true} slot="media" />
 					<Fragment slot="caption">ガイドリスト（東京）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_list_osaka} alt="画像拡大" width={155} height={220} link={true} slot="media" />
+				<Embedded width={225} border={true}>
+					<MyImage image={image_list_osaka} alt="画像拡大" width={225} height={320} link={true} slot="media" />
 					<Fragment slot="caption">ガイドリスト（大阪）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_opus_click} alt="写真拡大" width={147} height={220} link={true} slot="media" />
+				<Embedded width={213} border={true}>
+					<MyImage image={image_opus_click} alt="写真拡大" width={213} height={320} link={true} slot="media" />
 					<!-- 2016-03-19 057C10068 -->
 					<Fragment slot="caption">マルチメディアガイド機オーパス</Fragment>
 				</Embedded>

--- a/astro/src/pages/tokyu/an/iketama_compare.astro
+++ b/astro/src/pages/tokyu/an/iketama_compare.astro
@@ -26,7 +26,7 @@ const slugger = new GithubSlugger();
 
 		<p>池上線、多摩川線では、始発駅と旗の台、雪が谷大塚発車時にワンマン運転の案内放送が行われますが、このうち旗の台発車時においては、1000系のみ<q>お降りになりましたら…</q>の文言が用いられています。以下に下り列車の例を示します。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
@@ -57,7 +57,7 @@ const slugger = new GithubSlugger();
 
 		<p>池上線雪が谷大塚止まりの列車は、下り列車のみ一部駅の停車中に注意放送が流れます。7600系、7700系は旗の台と石川台、1000系は旗の台のみですが、車内放送に続いて車外放送も流れるのが特徴です。以下に旗の台停車中の例を示します。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
@@ -86,7 +86,7 @@ const slugger = new GithubSlugger();
 
 		<p>蒲田駅で折り返し池上線 – 多摩川線を通し運転する列車は、始発駅発車時などに蒲田折り返し後の行先を案内しますが、7600系、7700系は後に続くはずのワンマン案内が省略されます。以下に五反田発、蒲田折り返し、多摩川行き列車における旗の台発車時の例を示します。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>

--- a/astro/src/pages/tokyu/an/menu.astro
+++ b/astro/src/pages/tokyu/an/menu.astro
@@ -27,7 +27,7 @@ const slugger = new GithubSlugger();
 	<Section id="portable">
 		<Fragment slot="heading">携帯電話<small>（通常時）</small></Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
@@ -52,7 +52,7 @@ const slugger = new GithubSlugger();
 	<Section id="trans">
 		<Fragment slot="heading">全国交通安全運動<small>（例年4月上旬、9月下旬）</small></Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
@@ -77,7 +77,7 @@ const slugger = new GithubSlugger();
 	<Section id="summer">
 		<Fragment slot="heading">夏季の輸送対策と安全運動<small>（例年7月下旬）</small></Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
@@ -102,7 +102,7 @@ const slugger = new GithubSlugger();
 	<Section id="fire">
 		<Fragment slot="heading">全国火災予防運動<small>（例年11月中旬、3月上旬）</small></Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
@@ -127,7 +127,7 @@ const slugger = new GithubSlugger();
 	<Section id="year">
 		<Fragment slot="heading">年末年始輸送安全総点検<small>（例年12月下旬〜1月上旬）</small></Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>

--- a/astro/src/pages/tokyu/book/7700.astro
+++ b/astro/src/pages/tokyu/book/7700.astro
@@ -29,7 +29,7 @@ const structuredData: StructuredData = {
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<Flex>
 		<FlexItem>
-			<Embedded border={true}>
+			<Embedded width={170} border={true}>
 				<MyImage image={imageCover} alt="上部に赤文字で書名、下部に7700系の正面写真が12枚並んでいる" width={170} height={240} slot="media" />
 				<Fragment slot="caption">表紙</Fragment>
 			</Embedded>

--- a/astro/src/pages/tokyu/book/index.astro
+++ b/astro/src/pages/tokyu/book/index.astro
@@ -26,7 +26,7 @@ const structuredData: StructuredData = {
 	<Section id="book">
 		<Fragment slot="heading">図書</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<BookItem sectionDepth={2} title="私鉄車両ディテールガイド　東急9000系・1000系・2000系" summary="イカロス・ムック、2025年11月発売" link="https://www.amazon.co.jp/dp/4802216769/">
 					<ImageAmazon slot="image" src="https://m.media-amazon.com/images/I/811MJUZeFoL._SL160_.jpg" alt="表紙: 上部に黒文字で書名、下部に赤帯を巻いた9000系の先頭部写真 " width={115} height={160} />
@@ -65,7 +65,7 @@ const structuredData: StructuredData = {
 	<Section id="tetsupic">
 		<Fragment slot="heading">鉄道ピクトリアル</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<BookItem sectionDepth={2} title="地方私鉄へ譲渡された元東急の車両の近況" summary="2011年8月号 【特集】地方私鉄の現状" link="/tokyu/book/tetsupic851/tokyu_transfer">
 					<MyImage slot="image" image={imageTetsupic851} alt="表紙: 上部に誌名と特集名、下部に東急(旧)5000系（東急グリーン塗装）の正面がちの駅停車中写真" width={114} height={160} />

--- a/astro/src/pages/tokyu/book/tamagawa1067.astro
+++ b/astro/src/pages/tokyu/book/tamagawa1067.astro
@@ -30,7 +30,7 @@ const structuredData: StructuredData = {
 <Layout astroFilePath={Astro.self.moduleId} structuredData={structuredData}>
 	<Flex>
 		<FlexItem>
-			<Embedded border={true}>
+			<Embedded width={170} border={true}>
 				<MyImage image={imageCover} alt="クリーム色の背景に縦書きの書名、左下に公文書の本文（一部分）と青焼き図面の写真が1枚ずつ" width={170} height={240} slot="media" />
 				<Fragment slot="caption">表紙</Fragment>
 			</Embedded>

--- a/astro/src/pages/tokyu/machine/aci.astro
+++ b/astro/src/pages/tokyu/machine/aci.astro
@@ -27,13 +27,13 @@ const structuredData: StructuredData = {
 	<Section id="original">
 		<Fragment slot="heading">オリジナルタイプ（製造時）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="inv049" depth={2}>
 					<Fragment slot="heading">INV-049</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV049} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV049} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-07-18 -->
 						<Fragment slot="caption">クハ1022（5次車）海側</Fragment>
 					</Embedded>
@@ -47,8 +47,8 @@ const structuredData: StructuredData = {
 				<Section id="inv088" depth={2}>
 					<Fragment slot="heading">INV-088</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV088} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV088} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-02-14 -->
 						<Fragment slot="caption">デハ2251（1次車）海側</Fragment>
 					</Embedded>
@@ -64,13 +64,13 @@ const structuredData: StructuredData = {
 	<Section id="renewal2014">
 		<Fragment slot="heading">2014年更新後</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc220" depth={2}>
 					<Fragment slot="heading">TCE-220</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_TCE220} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_TCE220} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2019-04-26 -->
 						<Fragment slot="caption">クハ9021（1次車）海側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/aps.astro
+++ b/astro/src/pages/tokyu/machine/aps.astro
@@ -5,8 +5,8 @@ import AnchorPhoto from '@components/+phrasing/AnchorPhoto.astro';
 import DocBook from '@components/+phrasing/DocBook.astro';
 import DocMagazine from '@components/+phrasing/DocMagazine.astro';
 import Embedded from '@components/Embedded.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
 import ListNote from '@components/ListNote.astro';
 import NoteRef from '@components/+phrasing/NoteRef.astro';
@@ -458,22 +458,22 @@ const structuredData: StructuredData = {
 		<Section id="clg107" depth={2}>
 			<Fragment slot="heading">CLG107<small>（東京芝浦電気、2.5kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CLG107_matsumoto5005} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CLG107_matsumoto5005} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2010-06-20 -->
 						<Fragment slot="caption">松本電気鉄道モハ5005（東急デハ5055）</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CLG107_3043} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CLG107_3043} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2006-03-20 -->
 						<Fragment slot="caption">デワ3043 海側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>旧5000系グループに搭載され、デハ3700形やデハ3450形など一部の吊り掛け車にも採用された MG です。</p>
 
@@ -489,13 +489,13 @@ const structuredData: StructuredData = {
 		<Section id="clg308" depth={2}>
 			<Fragment slot="heading">CLG308<small>（東京芝浦電気、1.5kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="485" height="243" slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="540" height="270" slot="media" />
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>玉川線のデハ200形に搭載された MG は交流出力の電圧が 200V となりました。</p>
 
@@ -507,13 +507,13 @@ const structuredData: StructuredData = {
 		<Section id="clg316" depth={2}>
 			<Fragment slot="heading">CLG316<small>（東京芝浦電気、5kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="485" height="243" slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="540" height="270" slot="media" />
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>5200系には空調装置として天井に軸流送風機が設置されており、その電源としてサハ5250形に専用の MG が搭載されたのが特徴でしたが、1972年の扇風機化で撤去されました<NoteRef type="ref" by="pic269" />。</p>
 
@@ -523,15 +523,15 @@ const structuredData: StructuredData = {
 		<Section id="tdk381" depth={2}>
 			<Fragment slot="heading">TDK381<small>（東洋電機製造、6kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_TDK381_konan6007} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_TDK381_konan6007} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-03 -->
 						<Fragment slot="caption">弘南鉄道デハ6007（東急デハ6007）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>旧6000系、旧7000系の東洋電機車に搭載されていた MG です。</p>
 
@@ -545,13 +545,13 @@ const structuredData: StructuredData = {
 		<Section id="clg320" depth={2}>
 			<Fragment slot="heading">CLG320<small>（東京芝浦電気、7kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="485" height="243" slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="540" height="270" slot="media" />
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>旧6000系の東芝車に搭載されていた MG です。</p>
 
@@ -569,15 +569,15 @@ const structuredData: StructuredData = {
 		<Section id="hg533" depth={2}>
 			<Fragment slot="heading">HG533<small>（日立製作所、7.5kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HG533_konan7031} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HG533_konan7031} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-05-05 -->
 						<Fragment slot="caption">弘南鉄道デハ7031（東急デハ7031）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>旧7000系の日立車に搭載されていた MG で、東洋電機車と同じく交流出力の周波数は 400Hz です。</p>
 
@@ -587,22 +587,22 @@ const structuredData: StructuredData = {
 		<Section id="clg339" depth={2}>
 			<Fragment slot="heading">CLG339<small>（東京芝浦電気、7.5kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CLG339_7290} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CLG339_7290} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-17 -->
 						<Fragment slot="caption">デヤ7290 山側</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_SC102_toyohashi1809} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_SC102_toyohashi1809} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2023-03-03 -->
 						<Fragment slot="caption"><b>【自動調整器】</b>豊橋鉄道モ1809（東急デハ7256）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>7200系に搭載されていた MG で、旧7000系に引き続き交流出力の周波数は 400Hz です。</p>
 
@@ -622,15 +622,15 @@ const structuredData: StructuredData = {
 		<Section id="clg319" depth={2}>
 			<Fragment slot="heading">CLG319<small>（東京芝浦電気、5.5kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CLG319_7290} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CLG319_7290} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-12 -->
 						<Fragment slot="caption">デヤ7290 山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>旧3000形グループは1970年代にその多くが目蒲線と池上線に集結し、3両固定化改造を受けますが、このうち中間に付随車が挟まった Mc–T–Mc の編成は先頭電動車の MG を撤去し、付随車に（3000形としては）容量の大きな 7.5kVA SIV ないし 5.5kVA MG を搭載することで補助電源装置を編成で1基に集約する工事が1972年より行われました<NoteRef type="ref" by="pic271" />。</p>
 
@@ -652,15 +652,15 @@ const structuredData: StructuredData = {
 		<Section id="clg333" depth={2}>
 			<Fragment slot="heading">CLG333<small>（東京芝浦電気、9kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CLG333_hakone107} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CLG333_hakone107} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2011-06-26 -->
 						<Fragment slot="caption">箱根登山鉄道モハ107</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>旧5000系の譲渡車のうち、福島交通は電車線電圧が 750V（当時）、熊本電気鉄道は 600V なため、降圧化のため CP などとともに MG の換装が行われました。福島交通譲渡車は阪急電鉄からの転用品で 600V / 1500V 複電圧対応の CLG333 型<NoteRef type="ref" by="rj170" />、熊本電気鉄道のうち1981年に導入された最初の入線車（モハ5043–モハ5044）もやはり CLG333 型が搭載されていました。</p>
 
@@ -676,15 +676,15 @@ const structuredData: StructuredData = {
 		<Section id="tdk359" depth={2}>
 			<Fragment slot="heading">TDK359<small>（東洋電機製造、9kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_TDK359_kumamoto5102} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_TDK359_kumamoto5102} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-01-02 -->
 						<Fragment slot="caption">熊本電気鉄道モハ5102A（東急デハ5032）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>旧5000系の熊本電気鉄道譲渡車のうち、1985年追加導入の両運改造車（モハ5101〜5104）は最初の2両とは異なり東洋電機製造製の複電圧 MG が搭載されました<NoteRef type="ref" by="rj229" />。</p>
 
@@ -698,15 +698,15 @@ const structuredData: StructuredData = {
 		<Section id="tdk366" depth={2}>
 			<Fragment slot="heading">TDK366<small>（東洋電機製造、5.5kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_TDK366_hokuriku7112} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_TDK366_hokuriku7112} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2006-11-04 -->
 						<Fragment slot="caption">北陸鉄道モハ7112（東急デハ7055）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>北陸鉄道に譲渡された旧7000系は走り装置をはじめ各種機器が一新されていますが、MG も南海電気鉄道からの転用品<NoteRef type="ref" by="pic701" />に交換されました。</p>
 
@@ -722,15 +722,15 @@ const structuredData: StructuredData = {
 		<Section id="bs33" depth={2}>
 			<Fragment slot="heading">BS33<small>（東京芝浦電気、10kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_BS33_8201} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_BS33_8201} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2006-12-10 -->
 						<Fragment slot="caption">デハ8201（1次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>補助電源装置として量産型 SIV を最初に採用したのは1968年の東京都交通局6000系ですが、東急電鉄でも翌年に登場した8000系に東京芝浦電気（現: 東芝）が開発した 10kVA の SIV が搭載されました。</p>
 
@@ -748,15 +748,15 @@ const structuredData: StructuredData = {
 		<Section id="inv009" depth={2}>
 			<Fragment slot="heading">INV009<small>（東芝、2kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV009_8641} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV009_8641} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-03-22 -->
 						<Fragment slot="caption">デハ8641（18-2次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>8500系18次車のうち、1986年に田玉線と大井町線との共通予備車として 5 + 5 両に分割できる編成で新造された 8638F×⑩R は分割時に編成中の SIV が1基になってしまうのを防ぐため、上り向き先頭車のデハ8600形（デハ8638, 8639）に小容量 SIV が搭載されていました。続けて大井町線に新製投入された 8640F×⑤R、8641F×⑤R も同様です。</p>
 
@@ -772,15 +772,15 @@ const structuredData: StructuredData = {
 		<Section id="s11" depth={2}>
 			<Fragment slot="heading">S11<small>（小糸工業、1kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_S11_konan7031} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_S11_konan7031} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-08-05 -->
 						<Fragment slot="caption">弘南鉄道デハ7031（東急デハ7031）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>旧7000系は当初室内天井に送風機を装備していましたが、後に交流駆動の扇風機に更新され、MG の交流出力（200V・400Hz）を 60Hz に変換するコンバーター装置が MG 搭載車の床下に設置されました。</p>
 
@@ -796,15 +796,15 @@ const structuredData: StructuredData = {
 		<Section id="clg350" depth={2}>
 			<Fragment slot="heading">CLG350<small>（東京芝浦電気、140kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CLG350_8015} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CLG350_8015} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2006-07-08 -->
 						<Fragment slot="caption">クハ8015（2次車）海側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>東急電鉄では8000系2次車のうち1971年の東横線 8019F より冷房装置が搭載されました。前述のとおり、当時すでに <a href="#bs33">10kVA SIV</a> が実用化されていたものの、冷房用の大容量・三相交流出力に対応した SIV は開発されていなかったため、冷房電源は MG とされました。</p>
 
@@ -816,15 +816,15 @@ const structuredData: StructuredData = {
 		<Section id="hg554" depth={2}>
 			<Fragment slot="heading">HG554<small>（日立製作所、90kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HG554_toyohashi2807} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HG554_toyohashi2807} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-11-25 -->
 						<Fragment slot="caption">豊橋鉄道ク2807（東急クハ7554）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>7200系のうち1972年に冷房車として目蒲線に登場した5次車（7260F）および非冷房車のうち最初に冷改された田園都市線の2編成（7251F、7253F）には中間組み込み車を除くクハ7500形、すなわちクハ7552, 7554, 7560 に 90kVA の MG が搭載されました。写真は東急時代基準で海側から見たところです。</p>
 
@@ -834,15 +834,15 @@ const structuredData: StructuredData = {
 		<Section id="tdk3725" depth={2}>
 			<Fragment slot="heading">TDK3725<small>（東洋電機製造、75kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_TDK3725_mizuma1002} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_TDK3725_mizuma1002} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2015-04-18 -->
 						<Fragment slot="caption">水間鉄道デハ1002（東急デハ7009）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>水間鉄道に譲渡された7000系は2006年より順次1000形へのリニューアルが行われましたが、最初に更新されたデハ1001–デハ1002 の編成は同時に冷房化がなされ、デハ1002（旧デハ7102） の MG が大容量タイプに換装されました。これは 600V / 1500V の複電圧対応タイプで、南海電気鉄道が昇圧準備のために用意した個体と思われます。</p>
 
@@ -858,13 +858,13 @@ const structuredData: StructuredData = {
 		<Section id="bs443" depth={2}>
 			<Fragment slot="heading">BS443<small>（東京芝浦電気、170kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="485" height="243" slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="540" height="270" slot="media" />
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>冷房電源に対応した大容量・三相交流出力の SIV は、インバーター回路の入力に使用する直流を電車線電圧から 600V へ降圧させる際にチョッパ回路を使用した<dfn>チョッパインバーター</dfn>が開発され、140kVA の試作 SIV を 8029F のクハ8029 に搭載しての現車試験が行われました。半導体スタックや軸流コンデンサが収められた本体箱と変圧器箱は強制風冷式で、本体箱にブロアーを内蔵し、巨大なダクトを通じて変圧器にも風を送る仕組みになっていました<NoteRef type="ref" by="toshiba301" />。</p>
 
@@ -880,22 +880,22 @@ const structuredData: StructuredData = {
 		<Section id="bs477" depth={2}>
 			<Fragment slot="heading">BS477<small>（東京芝浦電気、50kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_BS477_7200} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_BS477_7200} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-01-20 -->
 						<Fragment slot="caption">デヤ7200 山側</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_BS477_mizuma1004} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_BS477_mizuma1004} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-20 -->
 						<Fragment slot="caption">水間鉄道デハ1004（東急デハ7007）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>逆導通サイリスタの大容量 SIV 量産が進む中、GTO サイリスタの開発が進んだことで1978年には 2500V–600A の大容量タイプが登場し<NoteRef type="ref" by="toshiba351" />、これを SIV のインバーターに使用した現車試験がサハ8915 にて実施。1980年にはインバーターを電車線電圧に直接接続し、チョッパ部を省略した<dfn>直列分圧形</dfn>の 50kVA SIV が登場しました。冷却方式はそれまでの強制冷却から密閉式の自然冷却となり、前面が3枚の蓋で閉じられているため中身を伺うことはできませんが、向かって右側のやや狭い部屋には制御部、中央と左側の2部屋には半導体スタックが収められています。</p>
 
@@ -915,15 +915,15 @@ const structuredData: StructuredData = {
 		<Section id="bs482" depth={2}>
 			<Fragment slot="heading">BS482<small>（東京芝浦電気、170kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_BS482_8097} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_BS482_8097} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-03-01 -->
 						<Fragment slot="caption">クハ8097（16-2次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>1982年には直列分圧形 170kVA SIV の量産が開始され、8000系グループ13次車より（クハ8090形は16次車から）採用されました。</p>
 
@@ -937,13 +937,13 @@ const structuredData: StructuredData = {
 		<Section id="inv003" depth={2}>
 			<Fragment slot="heading">INV003<small>（東芝、120kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="485" height="243" slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="540" height="270" slot="media" />
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>1986年に登場した VVVF インバーター車両9000系では、冷房装置の入力電源がそれまでの三相交流 200V から 440V へ変更され、また空気圧縮機（CP）が<a href="/tokyu/machine/cp#誘導電動機hs20-1">誘導電動機駆動</a>となったことにより SIV の三相交流出力電圧が 440V に変更されました。容量については、従来8500系の8両ないし10両編成で 170kVA SIV を2基搭載していましたが、9000系では CP 1基ごとに各 SIV で給電するため、CP の数に合わせて8両編成で SIV 3基搭載となり、容量は 120kVA に抑えられています。</p>
 
@@ -957,22 +957,22 @@ const structuredData: StructuredData = {
 		<Section id="inv006" depth={2}>
 			<Fragment slot="heading">INV006<small>（東芝、90kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV006_7602} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV006_7602} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-09-04 -->
 						<Fragment slot="caption">クハ7602（1次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV006_toyohashi2806} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV006_toyohashi2806} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-01-10 -->
 						<Fragment slot="caption">豊橋鉄道ク2806（東急クハ7505）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>前述のとおり、7200系の冷房改造にあたっては初期の改造車2編成には <a href="#hg554">90kVA MG</a> が搭載されたのですが、10年以上の中断ののち1984年に再開された折、当初は転用品の <a href="#bs477">50kVA SIV</a> が、1986年の目蒲線 7201F 以降は新製品の 90kVA SIV が搭載されました。また、同じ1986年に登場した改造車7600系もデハ7600形（後のクハ7600形）に本タイプが搭載されています。</p>
 
@@ -984,15 +984,15 @@ const structuredData: StructuredData = {
 		<Section id="inv008" depth={2}>
 			<Fragment slot="heading">INV008<small>（東芝、170kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV008_8977} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV008_8977} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-02-11 -->
 						<Fragment slot="caption">サハ8977（18-2次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>8500系では、18次車の編成車（8637F）より冷房装置が後述する9000系と同じ交流 440V タイプへ変更されたことにより、 SIV も三相交流出力が従来の 200V から昇圧されました。</p>
 
@@ -1002,15 +1002,15 @@ const structuredData: StructuredData = {
 		<Section id="inv020" depth={2}>
 			<Fragment slot="heading">INV020<small>（東芝、120kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV020_9310} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV020_9310} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-03-08 -->
 						<Fragment slot="caption">デハ9310（3次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>1987年に登場した7700系には9000系1次車の <a href="#inv003">INV003 型</a>と同仕様ながら新形式の INV020 型が搭載されました。</p>
 
@@ -1020,15 +1020,15 @@ const structuredData: StructuredData = {
 		<Section id="rg467" depth={2}>
 			<Fragment slot="heading">RG467 (SVH120-467)<small>（東洋電機製造、120kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_SVH120_7914} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_SVH120_7914} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-09-02 -->
 						<Fragment slot="caption">クハ7914（5次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>7700系はクハ7900形に SIV が搭載されましたが、そのうち2両は東急電車としては異色の東洋電機製造による SIV を搭載していました。出力容量は東芝製と同じ 120kVA ですが、当時の東洋電機 SIV としては標準的な<dfn>ブースター式</dfn>、すなわち電車線電圧の変動に対して直流電圧を一定に保つ調整機能を持つブースター部にて制御を行うことで対処する方式となっています<NoteRef type="ref" by="toyo56" />。</p>
 
@@ -1044,22 +1044,22 @@ const structuredData: StructuredData = {
 		<Section id="inv029" depth={2}>
 			<Fragment slot="heading">INV029<small>（東芝、170kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV029_8398} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV029_8398} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-01-31 -->
 						<Fragment slot="caption">サハ8398（16-2次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV029_toyama17482} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV029_toyama17482} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2013-11-04 -->
 						<Fragment slot="caption">富山地方鉄道モハ17482（東急デハ8692）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>東横線の8000系は上り方先頭車のクハ8000形奇数車に大容量 MG または SIV が搭載されていましたが、1988年より1990年にかけて二電源化のため8両編成の6号車（デハ8200形）に SIV が追設されました。9000系搭載の <a href="#inv020">INV020 型</a>と比べて出力容量が 170kVA にアップされています。</p>
 
@@ -1075,15 +1075,15 @@ const structuredData: StructuredData = {
 		<Section id="inv095" depth={2}>
 			<Fragment slot="heading">INV095<small>（東芝、170kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV095_8932} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV095_8932} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-05 -->
 						<Fragment slot="caption">サハ8932（10-1次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>前述のとおり、8500系の<a href="#bs443">逆導通サイリスタ SIV（BS443 型）</a> の更新は、1990年の置き換え開始当初は GTO サイリスタ式の <a href="#inv029">INV029 型</a>へ交換されていましたが、1993年には主回路素子に IGBT を使用したこの INV095 型が登場し、1996年までに置き換えが完了しました。</p>
 
@@ -1095,15 +1095,15 @@ const structuredData: StructuredData = {
 		<Section id="inv127" depth={2}>
 			<Fragment slot="heading">INV127<small>（東芝、210kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV127_3262} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV127_3262} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-05-18 -->
 						<Fragment slot="caption">デハ3262（2次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>1999年に登場した新3000系には、出力容量を 210kVA に増加した SIV が搭載されました。</p>
 
@@ -1113,15 +1113,15 @@ const structuredData: StructuredData = {
 		<Section id="inv104" depth={2}>
 			<Fragment slot="heading">INV104<small>（東芝、100kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV104_8296} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV104_8296} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-27 -->
 						<Fragment slot="caption">デハ8296（13次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>大井町線の8090系5両編成は、1号車（クハ8090形）に <a href="#bs482">170kVA SIV</a>、3号車（デハ8290形）に <a href="#bs33">10kVA SIV</a> がそれぞれ1基ずつ搭載されていましたが、2000年に2編成が二電源化工事を施工され、デハ8296 と 8282 が 100kVA の新型に交換されました。</p>
 
@@ -1131,15 +1131,15 @@ const structuredData: StructuredData = {
 		<Section id="inv146" depth={2}>
 			<Fragment slot="heading">INV146<small>（東芝、250kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV146_8031} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV146_8031} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2005-01-21 -->
 						<Fragment slot="caption">クハ8031（4次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>2001年に東横線クハ8031の 140kVA MG が 250kVA SIV に換装されました。翌年に登場した新5000系で本格的に採用されており、その試験的な意味合いだったものと思われます。</p>
 
@@ -1149,15 +1149,15 @@ const structuredData: StructuredData = {
 		<Section id="inv153" depth={2}>
 			<Fragment slot="heading">INV153<small>（東芝、100kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV153_8290} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV153_8290} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-22 -->
 						<Fragment slot="caption">デハ8290（17-1次車）山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>大井町線8090系の二電源化工事は2000年に2編成のみに行われ、デハ8290形の 10kVA SIV が 100kVA の <a href="#inv104">INV104 型</a>に置き換えられていましたが、2005年にはさらに2編成が進行し、デハ8298 と 8290 が交換対象になりましたが、SIV 機器は新型タイプに変更されました。</p>
 
@@ -1169,22 +1169,22 @@ const structuredData: StructuredData = {
 		<Section id="inv205" depth={2}>
 			<Fragment slot="heading">INV205<small>（東芝、260kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV205_9322_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV205_9322_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2023-01-19 -->
 						<Fragment slot="caption">デハ9322 海側</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_INV205_9322_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_INV205_9322_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2019-05-19 -->
 						<Fragment slot="caption">デハ9322 山側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>2000系のうち 2003F は2018年に機器更新が行われ、SIV も換装されました。</p>
 
@@ -1196,15 +1196,15 @@ const structuredData: StructuredData = {
 		<Section id="cda021" depth={2}>
 			<Fragment slot="heading">CDA021<small>（富士電機、30kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CDA021_towada7204} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CDA021_towada7204} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-04-30 -->
 						<Fragment slot="caption">十和田観光電鉄デハ7204（東急デハ7211）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>7200系の補助電源装置は電動車に小容量 MG が、制御車に冷房用の大容量 MG ないし SIV が搭載されていましたが、2002年の十和田観光電鉄への譲渡に際しては電動車のみの2連ないし単行で運転されるため、従来の <a href="#clg339">7.5kVA MG（CLG339 型）</a> を撤去して富士電機製の大容量 SIV が新設されました。</p>
 
@@ -1218,15 +1218,15 @@ const structuredData: StructuredData = {
 		<Section id="bs483" depth={2}>
 			<Fragment slot="heading">BS483<small>（東京芝浦電気、90kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_BS483_toyohashi2810} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_BS483_toyohashi2810} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-04-04 -->
 						<Fragment slot="caption">豊橋鉄道ク2810（東急クハ7551）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>上田電鉄7200系のうち 7251–7551 の2両は2008年に豊橋鉄道へ再譲渡されましたが、その際クハ7551（→豊橋鉄道ク2810）に搭載されていた冷房電源用の <a href="#bs477">50kVA SIV（BS477 型）</a> はこの 90kVA タイプへ換装されました。また、豊橋鉄道ク2807〜2809 は東急時代より <a href="#hg554">90kVA MG（HG554 型）</a> を搭載していましたが、2009年に置き換えが行われ、やはり当 SIV に換装されています。</p>
 
@@ -1236,15 +1236,15 @@ const structuredData: StructuredData = {
 		<Section id="rg5096" depth={2}>
 			<Fragment slot="heading">RG5096<small>（東洋電機製造）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RG5096_yoro7914} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RG5096_yoro7914} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2022-10-18 -->
 						<Fragment slot="caption">養老鉄道ク7914（東急クハ7914）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>養老鉄道7700系のうちク7901, 7914 の2両は、譲渡に際し SIV が新型タイプへ換装されました。</p>
 
@@ -1285,15 +1285,15 @@ const structuredData: StructuredData = {
 			<Section id="rg660" depth={2}>
 				<Fragment slot="heading">RG660<small>（東洋電機製造、140kVA）</small></Fragment>
 
-				<Flex>
-					<FlexItem>
-						<Embedded border={true} captionMeta={true}>
-							<MyImage image={image_RG660_7715} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				<Grid column={2}>
+					<GridItem>
+						<Embedded width={540} border={true} captionMeta={true}>
+							<MyImage image={image_RG660_7715} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 							<!-- 撮影日: 2009-05-12 -->
 							<Fragment slot="caption">デハ7715（5次車）山側</Fragment>
 						</Embedded>
-					</FlexItem>
-				</Flex>
+					</GridItem>
+				</Grid>
 
 				<p>サハ7950形を改造した車両を集めて1996年に池上線に登場した 7915F は、デハ7715 に主制御器の VVVF インバーターと一体になった SIV が搭載されました。</p>
 
@@ -1307,15 +1307,15 @@ const structuredData: StructuredData = {
 			<Section id="svf041" depth={2}>
 				<Fragment slot="heading">SVF041<small>（東芝、80kVA）</small></Fragment>
 
-				<Flex>
-					<FlexItem>
-						<Embedded border={true} captionMeta={true}>
-							<MyImage image={image_SVF041_Y012} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				<Grid column={2}>
+					<GridItem>
+						<Embedded width={540} border={true} captionMeta={true}>
+							<MyImage image={image_SVF041_Y012} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 							<!-- 撮影日: 2006-07-09 -->
 							<Fragment slot="caption">デハY012 海側</Fragment>
 						</Embedded>
-					</FlexItem>
-				</Flex>
+					</GridItem>
+				</Grid>
 
 				<p>こどもの国線用として2両編成で登場したY000系も、VVVF 主制御器（2群）と SIV（1群）が一体となったデュアルモードシステムが採用されました。</p>
 
@@ -1325,15 +1325,15 @@ const structuredData: StructuredData = {
 			<Section id="svf091" depth={2}>
 				<Fragment slot="heading">SVF091<small>（東芝、150kVA）</small></Fragment>
 
-				<Flex>
-					<FlexItem>
-						<Embedded border={true} captionMeta={true}>
-							<MyImage image={image_SVF091_1602} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				<Grid column={2}>
+					<GridItem>
+						<Embedded width={540} border={true} captionMeta={true}>
+							<MyImage image={image_SVF091_1602} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 							<!-- 撮影日: 2016-10-18 -->
 							<Fragment slot="caption">デハ1602 海側</Fragment>
 						</Embedded>
-					</FlexItem>
-				</Flex>
+					</GridItem>
+				</Grid>
 
 				<p>東横線と日比谷線の相互直通運転取り止めに伴い余剰になった1000系を改造して2014年に登場した1000系1500番台では、新7000系と同じタイプのデュアルモード VVVF / SIV システムが採用されました。</p>
 
@@ -1352,15 +1352,15 @@ const structuredData: StructuredData = {
 		<Section id="da61t" depth={2}>
 			<Fragment slot="heading">DA61T<small>（三菱電機、20kVA）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_DA61T_306B} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_DA61T_306B} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2013-09-07 -->
 						<Fragment slot="caption">デハ306B（2次車）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>世田谷線の300系は、三菱電機製の空調制御装置が A 車、B 車のそれぞれ屋根上に設置されています。</p>
 

--- a/astro/src/pages/tokyu/machine/atc.astro
+++ b/astro/src/pages/tokyu/machine/atc.astro
@@ -35,13 +35,13 @@ const structuredData: StructuredData = {
 	<Section id="dento">
 		<Fragment slot="heading">田園都市線、こどもの国線</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="dento-2" depth={2}>
 					<Fragment slot="heading">8590系、2000系<small>（三菱電機）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CMRDC129} alt="写真拡大" width={485} height={244} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CMRDC129} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-02-28 -->
 						<Fragment slot="caption">デハ8695（20次車）海側</Fragment>
 					</Embedded>
@@ -55,8 +55,8 @@ const structuredData: StructuredData = {
 				<Section id="kodomo-2" depth={2}>
 					<Fragment slot="heading">Y000系<small>（日立製作所）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_ATCS21TK16} alt="写真拡大" width={485} height={244} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_ATCS21TK16} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-02 -->
 						<Fragment slot="caption">クハY001（1次車）海側</Fragment>
 					</Embedded>
@@ -70,13 +70,13 @@ const structuredData: StructuredData = {
 	<Section id="toyoko">
 		<Fragment slot="heading">東横線</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="toyoko-1" depth={2}>
 					<Fragment slot="heading">8000系（一部）<small>（日立製作所）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_toyoko_ATSP_1} alt="写真拡大" width={485} height={244} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_toyoko_ATSP_1} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2006-03-20 -->
 						<Fragment slot="caption">クハ8024（3-1次車）山側</Fragment>
 					</Embedded>
@@ -90,8 +90,8 @@ const structuredData: StructuredData = {
 				<Section id="toyoko-2" depth={2}>
 					<Fragment slot="heading">8000系、9000系、1000系<small>（日立製作所）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_ATCS21TK11} alt="写真拡大" width={485} height={244} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_ATCS21TK11} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-02-28 -->
 						<Fragment slot="caption">クハ9101（1次車）海側</Fragment>
 					</Embedded>
@@ -105,13 +105,13 @@ const structuredData: StructuredData = {
 	<Section id="meguro">
 		<Fragment slot="heading">目黒線</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="meguro-1" depth={2}>
 					<Fragment slot="heading">新3000系<small>（三菱電機）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CMRDC117} alt="写真拡大" width={485} height={244} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CMRDC117} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-05 -->
 						<Fragment slot="caption">クハ3010（2次車）海側</Fragment>
 					</Embedded>
@@ -125,13 +125,13 @@ const structuredData: StructuredData = {
 	<Section id="oimachi-ats">
 		<Fragment slot="heading">大井町線（ATS時代）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="dento-1" depth={2}>
 					<Fragment slot="heading">8000系、8090系、9000系<small>（日立製作所）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_ATCS21TK5} alt="写真拡大" width={485} height={244} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_ATCS21TK5} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-08 -->
 						<Fragment slot="caption">クハ8098（16-2次車）山側</Fragment>
 					</Embedded>
@@ -147,13 +147,13 @@ const structuredData: StructuredData = {
 	<Section id="oimachi-atc">
 		<Fragment slot="heading">大井町線（ATC-P化）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="oimachi-1" depth={2}>
 					<Fragment slot="heading">8090系（一部）、9000系（一部）<small>（日立製作所）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_ATCS21TK17} alt="写真拡大" width={485} height={244} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_ATCS21TK17} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-04-27 -->
 						<Fragment slot="caption">クハ8085（16-2次車）海側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/bce.astro
+++ b/astro/src/pages/tokyu/machine/bce.astro
@@ -36,13 +36,13 @@ const structuredData: StructuredData = {
 	<Section id="hsc">
 		<Fragment slot="heading">電磁直通ブレーキ</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="hd23" depth={2}>
 					<Fragment slot="heading">7200系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HD23} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HD23} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-12 -->
 						<Fragment slot="caption">デヤ7200（2次車）山側</Fragment>
 					</Embedded>
@@ -58,13 +58,13 @@ const structuredData: StructuredData = {
 	<Section id="electric">
 		<Fragment slot="heading">電気指令式ブレーキ</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="e6" depth={2}>
 					<Fragment slot="heading">8000系グループ、サヤ7590</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_E6M} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_E6M} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2005-12-24 -->
 						<Fragment slot="caption">デハ8115（2次車）山側</Fragment>
 					</Embedded>
@@ -78,8 +78,8 @@ const structuredData: StructuredData = {
 				<Section id="e30" depth={2}>
 					<Fragment slot="heading">9000系、1000系、2000系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_E30A} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_E30A} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-04-21 -->
 						<Fragment slot="caption">デハ9311（3次車）山側</Fragment>
 					</Embedded>
@@ -95,8 +95,8 @@ const structuredData: StructuredData = {
 				<Section id="e53" depth={2}>
 					<Fragment slot="heading">7600系、7700系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_E53} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_E53} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-08-19 -->
 						<Fragment slot="caption">デハ7713（5次車）山側</Fragment>
 					</Embedded>
@@ -110,8 +110,8 @@ const structuredData: StructuredData = {
 				<Section id="e78" depth={2}>
 					<Fragment slot="heading">新3000系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_E78M1} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_E78M1} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-05-18 -->
 						<Fragment slot="caption">デハ3212（2次車）山側</Fragment>
 					</Embedded>
@@ -125,14 +125,14 @@ const structuredData: StructuredData = {
 				<Section id="e80" depth={2}>
 					<Fragment slot="heading">300系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_E80} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_E80} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2005-11-30 -->
 						<Fragment slot="caption">デハ304A（2次車）山側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_BSR70} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_BSR70} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-21 -->
 						<Fragment slot="caption">デハ309A（2次車）山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/bt.astro
+++ b/astro/src/pages/tokyu/machine/bt.astro
@@ -39,13 +39,13 @@ const slugger = new GithubSlugger();
 	<Section id="series7200">
 		<Fragment slot="heading">7200系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7200系<small>（100V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7200_100V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7200_100V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-09-17 -->
 						<Fragment slot="caption">デヤ7290（2次車）海側</Fragment>
 					</Embedded>
@@ -57,13 +57,13 @@ const slugger = new GithubSlugger();
 	<Section id="series8000">
 		<Fragment slot="heading">8000系グループ、7600系、7700系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">8000系<small>（100V・20Ah、100V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8000_100V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8000_100V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2005-11-14 -->
 						<Fragment slot="caption">デハ8232（6次車）海側</Fragment>
 					</Embedded>
@@ -73,8 +73,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">8500系、8090系、7600系、7700系<small>（100V・40Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8500_100V40Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8500_100V40Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-09-28 -->
 						<Fragment slot="caption">デハ8281（16-2次車）海側</Fragment>
 					</Embedded>
@@ -84,8 +84,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7700系<small>（100V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800_100V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800_100V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-01-20 -->
 						<Fragment slot="caption">デハ7801（1次車）海側</Fragment>
 					</Embedded>
@@ -95,8 +95,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">8500系、8090系<small>（24V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8500_24V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8500_24V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2005-11-16 -->
 						<Fragment slot="caption">サハ8977（18-2次車）海側</Fragment>
 					</Embedded>
@@ -106,8 +106,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">7600系、7700系<small>（24V・20Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7600_24V20Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7600_24V20Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-08-19 -->
 						<Fragment slot="caption">デハ7714（5次車）山側</Fragment>
 					</Embedded>
@@ -119,13 +119,13 @@ const slugger = new GithubSlugger();
 	<Section id="series9000">
 		<Fragment slot="heading">9000系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">9000系<small>（100V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_9000_100V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_9000_100V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2005-11-14 -->
 						<Fragment slot="caption">サハ9810（3次車）海側</Fragment>
 					</Embedded>
@@ -135,8 +135,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">9000系<small>（100V・30Ah / 24V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_9000_100V30Ah_24V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_9000_100V30Ah_24V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2005-11-14 -->
 						<Fragment slot="caption">クハ9010（3次車）海側</Fragment>
 					</Embedded>
@@ -148,13 +148,13 @@ const slugger = new GithubSlugger();
 	<Section id="series1000">
 		<Fragment slot="heading">1000系、2000系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1000系、2000系<small>（100V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000_100V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000_100V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-07-18 -->
 						<Fragment slot="caption">クハ1024（5次車）海側</Fragment>
 					</Embedded>
@@ -164,8 +164,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1000系、2000系<small>（100V・30Ah / 24V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000_100V30Ah_24V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000_100V30Ah_24V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-04-17 -->
 						<Fragment slot="caption">デハ1223（4次車）海側</Fragment>
 					</Embedded>
@@ -177,13 +177,13 @@ const slugger = new GithubSlugger();
 	<Section id="series3000">
 		<Fragment slot="heading">新3000系、Y000系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">新3000系、Y000系<small>（100V・60Ah / 24V・30Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_3000_100V60Ah_24V30Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_3000_100V60Ah_24V30Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-08-19 -->
 						<Fragment slot="caption">サハ3510（2次車）海側</Fragment>
 					</Embedded>
@@ -195,13 +195,13 @@ const slugger = new GithubSlugger();
 	<Section id="series300">
 		<Fragment slot="heading">300系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">300系<small>（100V・20Ah / 24V・80Ah）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_300_100V20Ah_24V80Ah} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_300_100V20Ah_24V80Ah} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-09-23 -->
 						<Fragment slot="caption">デハ305B（2次車）山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/cont_fcc.astro
+++ b/astro/src/pages/tokyu/machine/cont_fcc.astro
@@ -5,8 +5,8 @@ import DateWareki from '@components/+phrasing/DateWareki.astro';
 import DocMagazine from '@components/+phrasing/DocMagazine.astro';
 import Embedded from '@components/Embedded.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import List from '@components/List.astro';
 import ListNote from '@components/ListNote.astro';
 import NoteRef from '@components/+phrasing/NoteRef.astro';
@@ -140,36 +140,36 @@ const structuredData: StructuredData = {
 	<Section id="mmc-htr-20a">
 		<Fragment slot="heading">MMC-HTR-20A<small>（8000系1〜4次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MMCHTR20A_8117} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MMCHTR20A_8117} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2005-11-20 -->
 					<Fragment slot="caption"><b>【主制御器】</b>デハ8117（2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_CHS_8102} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_CHS_8102} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-07-21 -->
 					<Fragment slot="caption"><b>【界磁チョッパ装置】</b>デハ8102（1次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_URBPH_8102} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_URBPH_8102} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-08-18 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>デハ8102（1次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_izukyu8107} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_izukyu8107} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2023-10-20 -->
 					<Fragment slot="caption"><b>【限流抵抗器&amp;主抵抗器】</b>伊豆急行モハ8107（東急デハ8115）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1968" />の7200系による現車試験<NoteRef type="ref" by="hitachi50" />の後、8000系に最初に搭載されたのは MMC-HTR-20A 型で、4次車までがこのタイプとなっています。8500系、8090系を含む8000系グループでは23年間にわたる増備の中で制御装置のマイナーチェンジが何度か行われていますが、基本的な機器構成は VVVF 車を除き同一で、M<span class="u-tokyu-unit">1</span> 車の海側に界磁チョッパ装置、主制御器、断流器箱が横並びで配置され、山側には多数の抵抗器がずらっと並ぶ配置となっています。</p>
 
@@ -192,7 +192,7 @@ const structuredData: StructuredData = {
 
 			<p>譲渡車では、伊豆急行に譲渡された8000系第1陣のうち2両編成車が 1M1T 構成とされ、伊豆急下田寄りのクモハ8151（東急デハ8155、11-1次車）が当初単独 M<span class="u-tokyu-unit">1</span>c 車とされましたが、運用開始後まもなくして相方の電装化に伴いユニット車となりました。また、モデルカーとされたデハ8723（7-2次車）は伊豆急行クモハ8152 として単独 M<span class="u-tokyu-unit">1</span>c 車のまま出場したものの、現地での営業入りまでにユニット化されています。</p>
 
-			<Embedded border={true}>
+			<Embedded width={360} border={true}>
 				<MyImage image={image_tokyu8103} alt="" width={360} height={240} slot="media" />
 				<!-- 撮影日: 2005-08-14 -->
 				<Fragment slot="caption">大井町線で最後まで残った単独 M<span class="u-tokyu-unit">1</span> 車のデハ8103 </Fragment>
@@ -203,29 +203,29 @@ const structuredData: StructuredData = {
 	<Section id="mmc-htr-20c">
 		<Fragment slot="heading">MMC-HTR-20C<small>（8000系5〜11次車、8500系6〜11次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MMCHTR20C_8519} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MMCHTR20C_8519} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-04-27 -->
 					<Fragment slot="caption"><b>【主制御器】</b>デハ8519（8次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_CHSF101C_8736} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_CHSF101C_8736} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-02-10 -->
 					<Fragment slot="caption"><b>【界磁チョッパ装置】</b>デハ8736（9-1次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_URBPH_8514} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_URBPH_8514} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-11-19 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>デハ8514（7-1次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1974" />の5次車は田園都市線（大井町 – すずかけ台）向けに④両編成で登場しましたが、2M2T で 編成中に M<span class="u-tokyu-unit">1</span> 車が1両しかないためデハ8100形が2丁パンタとされ、MT 比が低いため主抵抗器が容量増加により従来の8個に対して10個に増やされるなど、さまざまなバリエーションがあった8000系グループの中でもとくに異端のシステムとされました。</p>
 
@@ -243,29 +243,29 @@ const structuredData: StructuredData = {
 	<Section id="mmc-htr-20f">
 		<Fragment slot="heading">MMC-HTR-20F<small>（8000系12〜18次車、8500系12〜20次車、8090系12〜20次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MMCHTR20F_8181} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MMCHTR20F_8181} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-06-08 -->
 					<Fragment slot="caption"><b>【主制御器】</b>デハ8181（16-2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_CHSF111_8497} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_CHSF111_8497} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-06-08 -->
 					<Fragment slot="caption"><b>【界磁チョッパ装置、GTO】</b>デハ8497（16-2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_URBPH_8180} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_URBPH_8180} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-08-18 -->
 					<Fragment slot="caption"><b>【断流器箱、小型】</b>デハ8180（16-2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1980" />に12次車として登場した8090系ではカム段数を増加（直列 13→15段、並列全界磁 11→13段）させた MMC-HTR-20F 型となりました。8000系、8500系も同様に変更され、<a href="#mmc-htr-10d">単独 M 車</a>を除き20次車まで続きます。界磁チョッパ装置も IC 化の推進などの改良が行われたものの<NoteRef type="ref" by="pic387" />、この時点では外観に変更はありません（写真は省略）。</p>
 
@@ -285,22 +285,22 @@ const structuredData: StructuredData = {
 	<Section id="mmc-htr-10d">
 		<Fragment slot="heading">MMC-HTR-10D<small>（8000系グループ・単 M 車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MMCHTR10D_8495} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MMCHTR10D_8495} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-06-08 -->
 					<Fragment slot="caption"><b>【主制御器】</b>デハ8495（16-2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_8497} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_8497} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-12-03 -->
 					<Fragment slot="caption"><b>【限流抵抗器&amp;主抵抗器】</b>デハ8497（16-2次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>1981年度の13次車では、東横線の編成増強に伴う⑥連→⑦連化ないし⑦連→⑧連化が一部の編成で行われ、単独 M 車のデハ8400形が登場しました<NoteRef by="deha8400-kaiban" />。同時期に8090系の 8093F〜8095F が⑧両編成で新製され、同様に新登場のデハ8490形が組み込まれています。</p>
 

--- a/astro/src/pages/tokyu/machine/cont_gto.astro
+++ b/astro/src/pages/tokyu/machine/cont_gto.astro
@@ -6,8 +6,8 @@ import DateWareki from '@components/+phrasing/DateWareki.astro';
 import DocBook from '@components/+phrasing/DocBook.astro';
 import DocMagazine from '@components/+phrasing/DocMagazine.astro';
 import Embedded from '@components/Embedded.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
 import List from '@components/List.astro';
 import ListNote from '@components/ListNote.astro';
@@ -227,22 +227,22 @@ const slugger = new GithubSlugger();
 	<Section id="vf-hr107">
 		<Fragment slot="heading">VF-HR107<small>（9000系1次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_VFHR107_9301} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_VFHR107_9301} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-03-28 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ9301（1次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_GCMR137A_9607} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_GCMR137A_9607} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-01-20 -->
 					<Fragment slot="caption"><b>【ゲート制御装置】</b>デハ9607（2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>旧6000系での2年以上にわたる現車試験を経て、<DateWareki value="1986" />に日立製作所製の VVVF インバーター装置を搭載した新造車9000系がデビューしました。</p>
 
@@ -266,22 +266,22 @@ const slugger = new GithubSlugger();
 	<Section id="rg614-a-m">
 		<Fragment slot="heading">RG614-A-M<small>（7600系1次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG614AM_7681} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG614AM_7681} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-04-21 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ7681（1次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RL8177AM_7681} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RL8177AM_7681} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-06-16 -->
 					<Fragment slot="caption"><b>【継電器箱】</b>デハ7681（1次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>9000系とほぼ同時期に（約2か月遅れ）7200系を VVVF インバーター化改造した7600系が登場しました。</p>
 
@@ -301,22 +301,22 @@ const slugger = new GithubSlugger();
 	<Section id="rg617-a-m">
 		<Fragment slot="heading">RG617-A-M<small>（7700系）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG617AM_7801} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG617AM_7801} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-04-13 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ7801（1次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RL8186AM_7808} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RL8186AM_7808} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-09-24 -->
 					<Fragment slot="caption"><b>【継電器箱】</b>デハ7808（2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>7600系の翌年、旧7000系を VVVF インバーター化改造した7700系が登場し、当初は暫定的に4+2連で大井町線に投入されました。</p>
 
@@ -330,15 +330,15 @@ const slugger = new GithubSlugger();
 	<Section id="vf-hr112">
 		<Fragment slot="heading">VF-HR112<small>（9000系2〜5次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_VFHR112_9205} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_VFHR112_9205} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-03-08 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ9205（2次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>9000系の本格的な量産は1次車デビューから1年半ほどの期間を空けてのこととなり、2次車以降のインバーター装置はマイナーチェンジされた VF-HR112 型となりました。</p>
 
@@ -348,15 +348,15 @@ const slugger = new GithubSlugger();
 	<Section id="rg617-b-m">
 		<Fragment slot="heading">RG617-B-M<small>（7600系2〜3次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG617BM_7661} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG617BM_7661} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-07-07 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ7661（2次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><a href="#rg614-a-m">前述</a>のとおり、7600系は当時の VVVF インバーター車両としては前例のない 1C8M 制御で竣工し、当初は大井町線に 2M1T を2本繋いだ6両編成1本が、目蒲線には抵抗制御のデハ7200形との混結である全電動車の3両編成1本が投入されました。しかし当初より目蒲・池上線における短編成での運用を視野に入れたものであり、まもなく目蒲線に集結した後、<DateWareki value="1988" />には全車両が池上線に転籍となります。</p>
 
@@ -569,22 +569,22 @@ const slugger = new GithubSlugger();
 	<Section id="rg621-a-m">
 		<Fragment slot="heading">RG621-A-M<small>（1000系、1000N系、1000N′系）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG621AM_1322} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG621AM_1322} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-12-29 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ1322（5次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RL8196AM_1212} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RL8196AM_1212} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2005-11-25 -->
 					<Fragment slot="caption"><b>【継電器箱】</b>デハ1212（3次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>9000系や7700系の増備が続く中、<DateWareki value="1988" />には日比谷線直通用として1000系がデビューします。</p>
 
@@ -741,29 +741,29 @@ const slugger = new GithubSlugger();
 	<Section id="vf-hr121z">
 		<Fragment slot="heading">VF-HR121Z<small>（デハ8799–デハ0802）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_VFHR121Z_8799_VW} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_VFHR121Z_8799_VW} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-06-22 -->
 					<Fragment slot="caption"><b>【インバーター装置本体、V・W 相側】</b>デハ8799（18-1次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_VFHR121Z_8799_U} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_VFHR121Z_8799_U} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-02-27 -->
 					<Fragment slot="caption"><b>【インバーター装置本体、U 相側】</b>デハ8799（18-1次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_GCMR148A_8799} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_GCMR148A_8799} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-01-25 -->
 					<Fragment slot="caption"><b>【ゲート制御装置】</b>デハ8799（18-1次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1989" />に 8637F×⑩R のうちデハ0802–デハ8799–サハ8974 の3両が東急車輛製造<small>（現：総合車両製作所）</small>に送られ VVVF 化改造が行われました。機器本体の形状はこれまでとは大きく異なり、枕木方向の車体全幅に渡るもので、海側に V・W 層、山側に U 層が配置されています。</p>
 
@@ -779,36 +779,36 @@ const slugger = new GithubSlugger();
 	<Section id="vf-hr132">
 		<Fragment slot="heading">VF-HR132, VFG-HR1820D<small>（8500系21次車、2000系）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_VFHR132_2203_VW} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_VFHR132_2203_VW} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2014-05-10 -->
 					<Fragment slot="caption"><b>【インバーター装置本体、V・W 相側】</b>デハ2203（2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_VFHR132_0718_U} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_VFHR132_0718_U} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-02-27 -->
 					<Fragment slot="caption"><b>【インバーター装置本体、U 相側】</b>デハ0718（21次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_GCMR157_0718} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_GCMR157_0718} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-09-13 -->
 					<Fragment slot="caption"><b>【ゲート制御装置、8500系用】</b>デハ0718（21次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_GCMR164_2201} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_GCMR164_2201} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-09-12 -->
 					<Fragment slot="caption"><b>【ゲート制御装置、2000系用】</b>デハ2201（1次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1991" />に東横線の 8642F×⑧R が⑩連化のうえ田玉線へ転籍することとなり、8000系グループの最終増備車（21次車）としてデハ0718–デハ0818 が製造されましたが、このユニットには先の<a href="#vf-hr121z">デハ8799–デハ0802 での試作タイプ</a>を元に 170kW 主電動機8台制御の量産タイプが搭載されました。転籍に際し 8637F に組み込まれていた VVVF 車を 8642F に集約する編成替えが行われ、8642F は抵抗制御 + VVVF 試作<small>（VF-HR121Z）</small>+ VVVF 量産<small>（VF-HR132）</small>の3タイプの制御装置を搭載する特異な編成となったのは周知のとおりです。</p>
 
@@ -826,22 +826,22 @@ const slugger = new GithubSlugger();
 	<Section id="rg636-a-m">
 		<Fragment slot="heading">RG636-A-M<small>（1000N′系・単 M 車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG636AM_1222} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG636AM_1222} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-06-16 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ1222（4次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RL8225AM_1217} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RL8225AM_1217} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-09-23 -->
 					<Fragment slot="caption"><b>【継電器箱】</b>デハ1217（4次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>1000系は当初は日比谷線直通列車用として東横線に投入されましたが、<DateWareki value="1991" />には池上線向けとして1000N′系がデビューしました。</p>
 

--- a/astro/src/pages/tokyu/machine/cont_high.astro
+++ b/astro/src/pages/tokyu/machine/cont_high.astro
@@ -6,8 +6,8 @@ import DateWareki from '@components/+phrasing/DateWareki.astro';
 import DocBook from '@components/+phrasing/DocBook.astro';
 import DocMagazine from '@components/+phrasing/DocMagazine.astro';
 import Embedded from '@components/Embedded.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
 import ListNote from '@components/ListNote.astro';
 import NoteRef from '@components/+phrasing/NoteRef.astro';
@@ -225,36 +225,36 @@ const structuredData: StructuredData = {
 	<Section id="pe-11">
 		<Fragment slot="heading">PE-11A<small>（旧5000系・デハ5001〜5020）</small>、PE-11B<small>（旧5000系・デハ5021〜、5200系）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_PE11A_nagano2510} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_PE11A_nagano2510} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-12-09 -->
 					<Fragment slot="caption"><b>【主制御器、PE11-A】</b>長野電鉄モハ2510（東急デハ5015）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_PE11B_kumamoto5102A} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_PE11B_kumamoto5102A} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-05-06 -->
 					<Fragment slot="caption"><b>【主制御器、PE11-B】</b>熊本電気鉄道モハ5102A（東急デハ5032）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_JP15A_gakunan5102} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_JP15A_gakunan5102} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2005-11-15 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>岳南鉄道モハ5002（東急デハ5028）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_matsumoto5005} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_matsumoto5005} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2010-06-20 -->
 					<Fragment slot="caption"><b>【主抵抗器&amp;MG】</b>松本電気鉄道モハ5005（東急デハ5055）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>黎明期の高性能車両として名高い旧5000系ですが、制御装置は東京芝浦電気<small>（現：東芝）</small>の MPE 型が使用されました。MPE 型制御装置はカム軸が抵抗短絡用と直並列切り換えや弱め界磁用などの2軸に分かれており、これらをフリーホイールを介し一つの電動機で操作するタイプであり、同じ年の京阪神急行電鉄<small>（現：阪急電鉄）</small>1000形にも導入されています。PE-11 型の運転上の主な特徴としては「弱め界磁」「マスコン操作による高加速」「発電ブレーキと制動ノッチ選択」が挙げられます。</p>
 
@@ -278,13 +278,13 @@ const structuredData: StructuredData = {
 	<Section id="ab-54-6mdb">
 		<Fragment slot="heading">AB-54-6MDB<small>（デハ200形）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="485" height="243" slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="540" height="270" slot="media" />
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1955" />に登場した軌道線（玉川線）用デハ200形はそれまでの手動進段車とは一線を画し、間接制御による自動進段式となりました。</p>
 
@@ -308,36 +308,36 @@ const structuredData: StructuredData = {
 	<Section id="es753-a">
 		<Fragment slot="heading">ACRF-H4100-753A<small>（旧6000系・A編成）</small>、ACRF-H4120-754A<small>（旧6000系・C編成）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_ES754A_konan6006} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_ES754A_konan6006} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-04-30 -->
 					<Fragment slot="caption"><b>【主制御器】</b>弘南鉄道デハ6006（東急デハ6006）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG305B_konan6006} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG305B_konan6006} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-07-23 -->
 					<Fragment slot="caption"><b>【界磁調整器】</b>弘南鉄道デハ6006（東急デハ6006）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_SA_konan6008} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_SA_konan6008} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-09-03 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>弘南鉄道デハ6008（東急デハ6008）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_konan6008} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_konan6008} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-09-03 -->
 					<Fragment slot="caption"><b>【限流抵抗器&amp;主抵抗器】</b>弘南鉄道デハ6008（東急デハ6008）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1960" />に登場した旧6000系は主電動機に複巻電動機を使用した平坦線向け電力回生ブレーキ電車で、東急電鉄の鉄道線車両では初めて電動車が2両ユニット構成となりましたが、主電動機は<a href="/tokyu/truck/ts300#ts315">台車</a>の中央にひとつ搭載され2軸駆動を行うモノモータータイプのため、ユニット車でありながら主制御器が担当する主電動機は4台となります。また主電動機は永久直列とされ、組み合わせ制御は行われません。</p>
 
@@ -366,35 +366,35 @@ const structuredData: StructuredData = {
 
 			<NoteRefContent id="rj626"><DocMagazine name="鉄道ジャーナル" date="2018年12月号" no={626} article="譲渡車両の知られざる現実　福島交通飯坂線1000系導入秘話" authors={['三浦祥兒']} pages={[58]} url="https://www.amazon.co.jp/dp/B07HSK3H4M/" /></NoteRefContent>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true}>
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={360} border={true}>
 						<MyImage image={image_RG305B_fukushima7105} alt="写真拡大" width={360} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2017-08-26 -->
 						<Fragment slot="caption">旧7000系の界磁調整器（福島交通デハ7105 ← 東急デハ7158） </Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true}>
+				</GridItem>
+				<GridItem>
+					<Embedded width={360} border={true}>
 						<MyImage image={image_TA_fukushima7105} alt="写真拡大" width={360} height={240} link={true} slot="media" />
 						<!-- 撮影日: 2017-08-26 -->
 						<Fragment slot="caption">旧7000系の磁気増幅器ユニット（IC 化後）、左端が FR 用（福島交通デハ7105 ← 東急デハ7158） </Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 		</Section>
 	</Section>
 
 	<Section id="mm-101a">
 		<Fragment slot="heading">MM-101A<small>（旧6000系・B編成）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="485" height="243" slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<img src="/assets/image/noimage-485x243.svg" alt="No Image" lang="en" width="540" height="270" slot="media" />
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>旧6000系は<a href="#es753-a">前述</a>のとおり電機品メーカーにより制御方式に違いがあり、東洋電機車（A, C編成）では分巻界磁電流を界磁調整器で制御していたのに対し、東芝車（B編成）では<a href="/tokyu/machine/aps#clg320">電動発電機（MG）</a>の軸端に設置されたブースターによる制御が行われていた違いがあります。このブースターはアンプリスタット（磁気増幅器）によってその界磁電流が制御されます。</p>
 
@@ -497,51 +497,51 @@ const structuredData: StructuredData = {
 
 			<NoteRefContent id="gijyutushi28"><Anchor href="https://shiraimuseum.nagoyara.com/gijyutushi28.htm"><cite>電鉄技術史情報２８</cite>（白井昭）</Anchor></NoteRefContent>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true}>
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={360} border={true}>
 						<MyImage image={image_MC11_meitetsu7028} alt="写真拡大" width={360} height={180} link={true} slot="media" />
 						<!-- 撮影日: 2023-10-21 -->
 						<Fragment slot="caption">東芝 MC-11 型（名古屋鉄道モ7028）</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true}>
+				</GridItem>
+				<GridItem>
+					<Embedded width={360} border={true}>
 						<MyImage image={image_MM10B_fukui2031} alt="写真拡大" width={360} height={180} link={true} slot="media" />
 						<!-- 撮影日: 2009-07-20 -->
 						<Fragment slot="caption">東芝 MM-10 型（福井鉄道モハ203-1）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 		</Section>
 	</Section>
 
 	<Section id="es754-a">
 		<Fragment slot="heading">ACRF-H860-754A<small>（旧7000系・東洋車 1〜2次車）</small>、ACRF-H860-757A<small>（旧7000系・東洋車 3〜10次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_ES754A_mizuma7003} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_ES754A_mizuma7003} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-09-02 -->
 					<Fragment slot="caption"><b>【主制御器】</b>水間鉄道デハ7003（東急デハ7012）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG305B_konan7021} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG305B_konan7021} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-07-23 -->
 					<Fragment slot="caption"><b>【界磁調整器】</b>弘南鉄道デハ7021（東急デハ7158）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_SA_mizuma1001} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_SA_mizuma1001} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-11-25 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>水間鉄道デハ1001（東急デハ7010）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1962" />に登場したオールステンレスカー・旧7000系は1〜2次車の時点では旧6000系東洋電機車のシステムが踏襲されています。主電動機は永久直列（直並列制御なし）で分巻界磁電流の制御は界磁調整器（FR）で行うといった基本的な制御方式は変わっていませんが、旧6000系は1電動機2軸駆動方式だったのに対し、旧7000系は<a href="/tokyu/truck/ts700#ts701">パイオニアⅢ台車</a>を履用し主電動機は1軸ごとにある一般的な方式のため、ひとつの主制御器には8台の主電動機が接続されます。</p>
 
@@ -553,36 +553,36 @@ const structuredData: StructuredData = {
 	<Section id="mmc-htr-10a">
 		<Fragment slot="heading">MMC-HTR-10A<small>（旧7000系・日立車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MMCHTR10A_konan7040} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MMCHTR10A_konan7040} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-04-30 -->
 					<Fragment slot="caption"><b>【主制御器】</b>弘南鉄道デハ7040（東急デハ7040）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_FC_konan7034} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_FC_konan7034} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-10-07 -->
 					<Fragment slot="caption"><b>【界磁制御器】</b>弘南鉄道デハ7034（東急デハ7034）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_URBPH_konan7034} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_URBPH_konan7034} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-10-07 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>弘南鉄道デハ7034（東急デハ7034）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_konan7032} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_konan7032} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-05-05 -->
 					<Fragment slot="caption"><b>【主抵抗器ほか】</b>弘南鉄道デハ7032（東急デハ7032）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>旧7000系は当初は電機品が東洋電機製造によるものでしたが、<DateWareki value="1963" />の5次車より日立製作所が参入し、以降は東洋電機車とともに増備が行われました。</p>
 
@@ -602,36 +602,36 @@ const structuredData: StructuredData = {
 	<Section id="mmc-htr-10b">
 		<Fragment slot="heading">MMC-HTR-10B<small>（7200系・日立車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MMCHTR10B_7290} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MMCHTR10B_7290} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2010-03-16 -->
 					<Fragment slot="caption"><b>【主制御器】</b>デヤ7290（2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_FCCH5B_toyohashi1803} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_FCCH5B_toyohashi1803} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-04-01 -->
 					<Fragment slot="caption"><b>【界磁制御器】</b>豊橋鉄道モ1803（東急デハ7210）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_URBPH_toyohashi1806} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_URBPH_toyohashi1806} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2005-12-11 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>豊橋鉄道モ1806（東急デハ7205）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_toyohashi1804} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_toyohashi1804} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-09-17 -->
 					<Fragment slot="caption"><b>【主抵抗器ほか】</b>豊橋鉄道モ1804（東急デハ7212）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><DateWareki value="1967" />に登場した7200系は、旧7000系と同じく電機メーカーが日立製作所の車両と東洋電機製造の車両が存在します。日立車のシステム自体は旧7000系日立車を踏襲していますが、ユニット車ではなく 1M 方式に戻ったため主電動機は4台制御となりました。</p>
 
@@ -647,36 +647,36 @@ const structuredData: StructuredData = {
 	<Section id="es764-a">
 		<Fragment slot="heading">ACRF-H4110-764A<small>（7200系・東洋電機車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_ES764A_ueda7255} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_ES764A_ueda7255} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-01-26 -->
 					<Fragment slot="caption"><b>【主制御器】</b>上田電鉄モハ7255（東急デハ7258）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG303B_ueda7254} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG303B_ueda7254} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-01-27 -->
 					<Fragment slot="caption"><b>【界磁調整器】</b>上田電鉄モハ7254（東急デハ7254）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_SA_ueda7252} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_SA_ueda7252} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-05-03 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>上田電鉄モハ7252（東急デハ7252）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_ueda7255} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_ueda7255} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2005-03-29 -->
 					<Fragment slot="caption"><b>【主抵抗器ほか】</b>上田交通モハ7255（東急デハ7258）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>7200系の東洋電機製造車は、弱め界磁制御に界磁調整器（FR）を用いた方式は踏襲しつつも、旧7000系までの永久直列制御から日立車と同じく直並列制御を行うように変更されています。</p>
 		{/* <p>旧7000系と異なり日立車と東洋電機車の混結は日常的に行われ、現在も大井川鐵道で見られます。</p> */}
@@ -686,36 +686,36 @@ const structuredData: StructuredData = {
 	<Section id="cs-20a">
 		<Fragment slot="heading">CS-20A<small>（旧7000系北陸鉄道譲渡車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_CS20A_hokuriku7102} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_CS20A_hokuriku7102} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2023-10-22 -->
 					<Fragment slot="caption"><b>【主制御器】</b>北陸鉄道モハ7102（東急デハ7056）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_SA_hokuriku7201} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_SA_hokuriku7201} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-11-23 -->
 					<Fragment slot="caption"><b>【断流器箱】</b>北陸鉄道モハ7201（東急デハ7136）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_WFL_hokuriku7202} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_WFL_hokuriku7202} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2023-03-02 -->
 					<Fragment slot="caption"><b>【弱め界磁リアクトル】</b>北陸鉄道モハ7202（東急デハ7138）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_hokuriku7202} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_hokuriku7202} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2023-10-22 -->
 					<Fragment slot="caption"><b>【主抵抗器】</b>北陸鉄道モハ7202（東急デハ7138）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>旧7000系のうち北陸鉄道石川線に譲渡された車両は台車や床下機器、集電装置など主要機器の多くが換装され、主制御器は JR 103系初期車（試作車を除く）の CS20A 型となりました。</p>
 

--- a/astro/src/pages/tokyu/machine/cont_igbt.astro
+++ b/astro/src/pages/tokyu/machine/cont_igbt.astro
@@ -5,8 +5,8 @@ import AnchorPhoto from '@components/+phrasing/AnchorPhoto.astro';
 import DateWareki from '@components/+phrasing/DateWareki.astro';
 import DocMagazine from '@components/+phrasing/DocMagazine.astro';
 import Embedded from '@components/Embedded.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
 import ListNote from '@components/ListNote.astro';
 import NoteRef from '@components/+phrasing/NoteRef.astro';
@@ -177,22 +177,22 @@ const structuredData: StructuredData = {
 	<Section id="rg654-a-m">
 		<Fragment slot="heading">RG654-A-M<small>（デハ7815）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG654AM_7815} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG654AM_7815} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-05-12 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ7815（4次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RL8249AM_7815} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RL8249AM_7815} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-07-07 -->
 					<Fragment slot="caption"><b>【継電器箱】</b>デハ7815（4次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>池上線のワンマン化に向けた車両転配により、7700系のうち目蒲線の4両×3編成を池上線用3両×4編成に組成替えすることになり、電動車の増加に対して東洋電機製造による IGBT タイプの VVVF インバーター装置が開発されています。まず<DateWareki value="1995" />には 7912F に組み込まれていたサハ7962 の電装化（新車号はデハ7815）が実施され、4両編成のまま目蒲線で営業運転が行われました。</p>
 
@@ -208,22 +208,22 @@ const structuredData: StructuredData = {
 	<Section id="rg660-a-m">
 		<Fragment slot="heading">RG660-A-M<small>（デハ7715）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG660AM_7715_VVVF} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG660AM_7715_VVVF} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-04-21 -->
 					<Fragment slot="caption"><b>【インバーター装置、VVVF 側】</b>デハ7715（5次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_RG660AM_7715_SIV} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_RG660AM_7715_SIV} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-05-12 -->
 					<Fragment slot="caption"><b>【インバーター装置、SIV 側】</b>デハ7715（5次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>前述のサハ7962 の電装化に続き、<DateWareki value="1996" />にはサハ7963、7964 の先頭化改造が東急車輛製造<small>（現：総合車両製作所）</small>にて行われ、このうちサハ7964（→デハ7715）は電装化により SIV 一体型の IGBT VVVF インバーター装置が搭載されました。</p>
 
@@ -239,22 +239,22 @@ const structuredData: StructuredData = {
 	<Section id="vfi-hr4820e">
 		<Fragment slot="heading">VFI-HR4820E、VFI-HR2420B<small>（新3000系・日立車 1〜3次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_VFIHR2420B_3403_12} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_VFIHR2420B_3403_12} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-04-21 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>旧デハ3403（現デハ3703、2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_VFIHR2420B_3413_34} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_VFIHR2420B_3413_34} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-06-07 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>旧デハ3413（現デハ3713、3次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>目蒲線の運転系統変更に先駆けて<DateWareki value="1999" />にデビューした新3000系の VVVF インバーター制御装置は奇数車が日立製作所製、偶数車が東芝製と2つのメーカーが混在しており、機器形状は大きく異なりますが基本性能は同一とされました。</p>
 
@@ -272,22 +272,22 @@ const structuredData: StructuredData = {
 	<Section id="svf038-a0">
 		<Fragment slot="heading">SVF038-A0、SVF038-B0<small>（新3000系・東芝車 1〜3次車）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_SVF038B0_3404_12} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_SVF038B0_3404_12} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-01-31 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>旧デハ3404（現デハ3704、2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_SVF038B0_3412_34} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_SVF038B0_3412_34} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-05-18 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>旧デハ3412（現デハ3704、2次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>新3000系の偶数車は旧6000系試験車以来となる東芝製の VVVF インバーター制御装置が搭載されており、インバーター装置はもちろんのこと断流器やフィルタリアクトルも日立車とは異なります。</p>
 
@@ -299,22 +299,22 @@ const structuredData: StructuredData = {
 	<Section id="map-064-60v82">
 		<Fragment slot="heading">MAP-064-60V82<small>（300系）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MAP06460V82_310A} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MAP06460V82_310A} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-06-24 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ310A（2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_MR_307A} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_MR_307A} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2023-09-29 -->
 					<Fragment slot="caption"><b>【抵抗器】</b>デハ307A（2次車）山側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>世田谷線のリニューアル車両として<DateWareki value="1999" />にデビューした300系は、東急電鉄としては<a href="/tokyu/machine/cont_high#ab-54-6mdb">玉川線200形</a>以来となる三菱電機製の主制御器が搭載されました。300系は台車を旧型車から流用していますが（不足分は同型を新製）、主電動機は誘導電動機のものが新製され、2両連接の連接部を除いた編成両端の4台分を2群で制御しています。</p>
 
@@ -330,15 +330,15 @@ const structuredData: StructuredData = {
 	<Section id="svf041-a0">
 		<Fragment slot="heading">SVF041-A0<small>（Y000系）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_SVF041A0_Y012} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_SVF041A0_Y012} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-07-09 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハY012海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>こどもの国線の通勤線化に向けて<DateWareki value="1999" />にデビューしたY000系は、車体や台車は同年の新3000系とほぼ同じ構造をしていますが、短編成（②両編成）のため主制御器は 1C2M2群方式で、<a href="#rg660-a-m">デハ7715</a> に続き SIV 一体型のデュアルモードタイプが搭載されました。</p>
 
@@ -354,15 +354,15 @@ const structuredData: StructuredData = {
 	<Section id="svf091-b0">
 		<Fragment slot="heading">SVF091-B0<small>（1000系1500番台）</small></Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_SVF091B0_1602} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_SVF091B0_1602} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2016-10-18 -->
 					<Fragment slot="caption"><b>【インバーター装置】</b>デハ1602海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>東横線と日比谷線の相互直通運転取り止めに伴い余剰になった1000系を改造して<DateWareki value="2014" />に登場した1000系1500番台では、新7000系と同じタイプのデュアルモード VVVF / SIV システムが採用されました。なお主電動機は換装されず、1000系オリジナルの 130kW タイプが引き続き使用されています（新7000系は 190kW）。</p>
 

--- a/astro/src/pages/tokyu/machine/cont_old.astro
+++ b/astro/src/pages/tokyu/machine/cont_old.astro
@@ -6,8 +6,8 @@ import DocBook from '@components/+phrasing/DocBook.astro';
 import DocMagazine from '@components/+phrasing/DocMagazine.astro';
 import DocOfficial from '@components/+phrasing/DocOfficial.astro';
 import Embedded from '@components/Embedded.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
 import List from '@components/List.astro';
 import ListNote from '@components/ListNote.astro';
@@ -217,15 +217,15 @@ const structuredData: StructuredData = {
 
 		<p>また、合併前に伯陽電鉄<small>（後の日ノ丸自動車）</small>へ譲渡された乙号車のうち1両は鉄道路線廃止後も現地で保存されており、マスコンは東洋電機製 DB1 式 K4 型が残されています。ただし両端の運転台で固有番号が連続しておらず形状も異なることから、少なくとも一方は製造当初からのオリジナルではなく交換されたものと思われます。</p>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true}>
-					<MyImage image={image_DB1K4_hinomaru203} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true}>
+					<MyImage image={image_DB1K4_hinomaru203} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2024-03-19 -->
 					<Fragment slot="caption">東洋電機製造 DB1 式 K4 型マスコン（日ノ丸自動車デハ203 ← 池上乙号車）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>この他、目黒蒲田電鉄と東京横浜電鉄では<DateWareki value="1923" />から<DateWareki value="1925" />にかけて有蓋電動貨車・デワ1形が2両、無蓋電動貨車・デト1形が6両製造されましたが、これらも直接制御で製造されました。このうち、東急改番後のデワ3002, 3003 のみ晩年の時点で K-14 型を装備していたとの記録が残されていますが<NoteRef type="ref" by="tokyu1950-04-25" />、その他の車両のマスコン形式は不明です。</p>
 
@@ -326,32 +326,32 @@ const structuredData: StructuredData = {
 
 		<NoteRefContent id="kenkyushuho"><DocBook name="目蒲東横電鉄業務研究彙報" authors={['目黒蒲田電鉄', '東京横浜電鉄']} year={1934} article="電車制御装置PR150型よりPR1Y1型への發達" pages={[48]} url="https://dl.ndl.go.jp/pid/1146676/1/30" linkScope="page" /></NoteRefContent>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true}>
-					<MyImage image={image_PR150} alt="" width={485} height={243} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true}>
+					<MyImage image={image_PR150} alt="" width={540} height={270} slot="media" />
 					<Fragment slot="caption">電空カム軸制御器 PR-150 型<NoteRef by="pr150-photo-source" /></Fragment>
 				</Embedded>
 
 				<NoteRefContent id="pr150-photo-source"><Anchor href="https://dl.ndl.go.jp/pid/1146676/1/5">目蒲東横電鐵業務研究彙報（昭和9年2月）</Anchor>より転載</NoteRefContent>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true}>
-					<MyImage image={image_PR200} alt="" width={485} height={243} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true}>
+					<MyImage image={image_PR200} alt="" width={540} height={270} slot="media" />
 					<Fragment slot="caption">電空カム軸制御器 PR-200 型<NoteRef by="pr200-photo-source" /></Fragment>
 				</Embedded>
 
 				<NoteRefContent id="pr200-photo-source"><Anchor href="https://dl.ndl.go.jp/pid/1146676/1/5">目蒲東横電鐵業務研究彙報（昭和9年2月）</Anchor>より転載</NoteRefContent>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true}>
-					<MyImage image={image_PR1Y1} alt="" width={485} height={243} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true}>
+					<MyImage image={image_PR1Y1} alt="" width={540} height={270} slot="media" />
 					<Fragment slot="caption">メンテナンスフリーを目指して開発された PR-1Y1 型（試作品）<NoteRef by="pr1y1-photo-source" /></Fragment>
 				</Embedded>
 
 				<NoteRefContent id="pr1y1-photo-source"><Anchor href="https://dl.ndl.go.jp/pid/1146676/1/5">目蒲東横電鐵業務研究彙報（昭和9年2月）</Anchor>より転載</NoteRefContent>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 	</Section>
 
 	<Section id="dk-system">
@@ -427,15 +427,15 @@ const structuredData: StructuredData = {
 
 		<p>東急デハ3250形の供出車はすべて解体されたものと思われますが、名古屋鉄道と北陸鉄道の保存車に同型の現存例があります。</p>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true}>
-					<MyImage image={image_ES155_meitetsu755} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true}>
+					<MyImage image={image_ES155_meitetsu755} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2024-03-20 -->
 					<Fragment slot="caption">現存する ES-155 型（名古屋鉄道モ755）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>一方、<a href="#direct">直接制御式</a>だったモハ1形は<DateWareki value="1932" />に連結運転のため ES-158 型を搭載し、<DateWareki value="1941" />には<a href="#ministry-mekama">鉄道省払い下げ車</a>の半鋼体化改造の後期改造車（モハ156〜161）と互いに制御装置を交換されました。モハ150形は東京急行電鉄成立後にデハ3300形となり、デハ3250形が地方譲渡された後も活躍を続けましたが、やがて日立 MMC に統一されて東急線からディッカーシステムは消滅しました。ところで<DateWareki value="1958" />に東横車輛工業<small>（現：東急テクノシステム）</small>の碑文谷工場で江ノ島鎌倉観光<small>（現：江ノ島電鉄）</small>の100形が車体更新を受けて304号連接車に改造されましたが、その際に間接制御化が行われて ES-158 型を搭載、続けて<DateWareki value="1960" />に新造扱いで登場した305編成も同様に ES-158 型が搭載されました。当時の江ノ電は単行車100形が直接制御、その他の車両は間接制御の ES-251 型に統一されていた中で<NoteRef type="ref" by="enoden60" />、碑文谷工場で改造された車両だけが旧式の ES-158 型を搭載したことからも、東急デハ3300形の発生品を転用したとは考えられないでしょうか。</p>
 
@@ -451,16 +451,16 @@ const structuredData: StructuredData = {
 
 		<NoteRefContent id="rail16"><DocMagazine name="レイル" date="1979年7月号" no={16} article="東横電鉄、目蒲電鉄　初期の車輛" authors={['荻原二郎']} pages={[34]} /></NoteRefContent>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true}>
-					<MyImage image={image_ES504} alt="" width={485} height={162} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true}>
+					<MyImage image={image_ES504} alt="" width={540} height={180} slot="media" />
 					<Fragment slot="caption">新京阪鉄道 P-6 形電車にも搭載された ES-504 型<NoteRef by="es504-photo-source" /></Fragment>
 				</Embedded>
 
 				<NoteRefContent id="es504-photo-source"><Anchor href="https://dl.ndl.go.jp/pid/1190932/1/91">交通電氣博ポスター選集</Anchor>より転載</NoteRefContent>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<Section id="moha150-transition" depth={2} box={true}>
 			<Fragment slot="heading">モハ150形（デハ3300形）の制御装置の変遷</Fragment>
@@ -540,29 +540,29 @@ const structuredData: StructuredData = {
 
 		<NoteRefContent id="toyoko-enkaku"><DocBook name="東京横浜電鉄沿革史" authors={['東京急行電鉄']} year={1943} article="第六編第三章第四節二　車輛の主なる改造工事" pages={[515]} url="https://dl.ndl.go.jp/pid/1124913/1/344" linkScope="page" /></NoteRefContent>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true}>
-					<MyImage image={image_MMC200} alt="" width={485} height={243} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true}>
+					<MyImage image={image_MMC200} alt="" width={540} height={270} slot="media" />
 					<!-- 撮影日: 2006-04-30 -->
 					<Fragment slot="caption">多段式制御を実現した MMC-200 型<NoteRef by="mmc200-photo-source" /></Fragment>
 				</Embedded>
 
 				<NoteRefContent id="mmc200-photo-source"><Anchor href="https://dl.ndl.go.jp/pid/1141487/1/92">電氣工學年報　昭和十五年版</Anchor>より転載</NoteRefContent>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>戦後の新車としては後述する<a href="#cs5">デハ3700形</a>が<DateWareki value="1948" />に新製された一方、同じ頃に日立では MMC-200 型の改良型である MMC-10 型（昇圧後は MMC-H-10 型）が開発され、デハ3700形を含め在来型を置き換えてゆきます。これにより1970年代中には旧3000形グループの主制御器は MMC-H-10 型への統一が図られました。</p>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true}>
-					<MyImage image={image_MMCH10K_towada3603} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true}>
+					<MyImage image={image_MMCH10K_towada3603} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-04-30 -->
 					<Fragment slot="caption">旧性能車で最後に導入された MMC-H-10K 型、機器単体で見れば8000系1次車より新しい（十和田観光電鉄モハ3603 ← 東急デハ3655）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>MMC-H-10 型は東急電鉄から旧性能車が引退した後も十和田観光電鉄などの譲渡先のほか、変わったところだと豊橋鉄道経由で京福電気鉄道・福井本社に送られたと推測される個体がモハ1101形に搭載され、えちぜん鉄道になった後もMC1102号が<DateWareki value="2014" />10月まで活躍していましたが<NoteRef type="ref" by="echizen1101" />、現在は実稼働個体は消滅し、保存車や博物館展示品に数台が残るのみとなっています。</p>
 

--- a/astro/src/pages/tokyu/machine/cp.astro
+++ b/astro/src/pages/tokyu/machine/cp.astro
@@ -5,8 +5,8 @@ import Anchor from '@components/+phrasing/Anchor.astro';
 import AnchorPhoto from '@components/+phrasing/AnchorPhoto.astro';
 import DocMagazine from '@components/+phrasing/DocMagazine.astro';
 import Embedded from '@components/Embedded.astro';
-import Flex from '@components/Flex.astro';
-import FlexItem from '@components/FlexItem.astro';
+import Grid from '@components/Grid.astro';
+import GridItem from '@components/GridItem.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
 import ListNote from '@components/ListNote.astro';
 import NoteRef from '@components/+phrasing/NoteRef.astro';
@@ -196,22 +196,22 @@ const slugger = new GithubSlugger();
 	<Section id="d2n">
 		<Fragment slot="heading">D2N</Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_D2N_510} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_D2N_510} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-05-19 -->
 					<Fragment slot="caption">モハ510 復元車</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_D2N_kumamoto5102A} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_D2N_kumamoto5102A} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-05-06 -->
 					<Fragment slot="caption">熊本電気鉄道モハ5102A（東急デハ5032）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>モハ510形（デハ3450形）の一部をはじめ旧性能車に広く搭載されていたギヤ式の CP で、当初から昇圧を見込み複電圧対応として製作されました。そのため1952年〜1958年にかけての鉄道線 1500V 昇圧後も引き続き使用され、1993年のデハ3450形、デヤ3000形引退まで長く使用されました。また、唯一の電気機関車であったデキ1形（デキ3021 形）も本タイプを搭載していました。</p>
 
@@ -223,22 +223,22 @@ const slugger = new GithubSlugger();
 	<Section id="3ys">
 		<Fragment slot="heading">3YS</Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_3YS_matsumoto5005} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_3YS_matsumoto5005} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2010-03-21 -->
 					<Fragment slot="caption">松本電気鉄道モハ5005（東急デハ5055）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_3YS_nagano2510} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_3YS_nagano2510} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-05-05 -->
 					<Fragment slot="caption">長野電鉄モハ2510（東急デハ5015）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>旧5000系グループで採用された CP は従来のギヤ式に変わり、独立した電動機と圧縮機がベルトで結合された方式となりました。CP を裏側から見ると<AnchorPhoto image={image_3YS_gakunan5004_belt} title="岳南鉄道モハ5004"><!-- 撮影日: 2006-11-25 -->プーリーとベルトの様子</AnchorPhoto>が窺えますが、圧縮機側の大プーリーは冷却ファンの羽根を兼ねていることが分かります。</p>
 
@@ -250,15 +250,15 @@ const slugger = new GithubSlugger();
 	<Section id="c1000">
 		<Fragment slot="heading">C1000</Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_C1000_konan6005} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_C1000_konan6005} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-09-03 -->
 					<Fragment slot="caption">弘南鉄道デハ6005（東急デハ6005）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><a href="#3ys">3YS 型</a>の改良タイプであり、旧6000系から7200系（デハ7300形）まで搭載され、後にデハ3450形やデハ3500形などにも広く普及しました。</p>
 
@@ -268,29 +268,29 @@ const slugger = new GithubSlugger();
 	<Section id="hb1500">
 		<Fragment slot="heading">HB1500</Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_HB1500_ueda7255} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_HB1500_ueda7255} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2005-03-29 -->
 					<Fragment slot="caption"><b>【7200系タイプ】</b>上田交通モハ7255（東急デハ7258）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_HB1500_fukushima7202} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_HB1500_fukushima7202} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2013-07-07 -->
 					<Fragment slot="caption"><b>【7000系タイプ】</b>福島交通デハ7202（東急デハ7125）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_HB1500_hokuriku7211} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_HB1500_hokuriku7211} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-04-13 -->
 					<Fragment slot="caption"><b>【京阪タイプ】</b>北陸鉄道クハ7211（東急デハ7137）</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p><a href="#3ys">3YS 型</a>、<a href="#c1000">C1000 型</a>からさらに構造が変わり、電動機と圧縮機をゴム可とう継手で繋ぎ、高圧・低圧それぞれ2つのシリンダを対向に配したもの（水平対向4気筒）となりました。この基本構造は後の <a href="#hb2000">HB2000 型</a>や <a href="#hs20">HS20 型</a>にも引き継がれています。</p>
 
@@ -306,36 +306,36 @@ const slugger = new GithubSlugger();
 	<Section id="hb2000">
 		<Fragment slot="heading">HB2000</Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_HB2000_8879} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_HB2000_8879} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-04-05 -->
 					<Fragment slot="caption"><b>【神鋼電機】</b>デハ8879（15次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_HB2000_8281} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_HB2000_8281} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2008-09-06 -->
 					<Fragment slot="caption"><b>【日立製作所】</b>デハ8281（16-2次車）海側 #1</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_HB2000_izukyu8252} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_HB2000_izukyu8252} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2006-05-28 -->
 					<Fragment slot="caption"><b>【神鋼電機、反転】</b>伊豆急行クモハ8252（東急デハ8049）</Fragment>
 				</Embedded>
-			</FlexItem>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_HB2000_8881_frame} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			</GridItem>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_HB2000_8881_frame} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2009-05-22 -->
 					<Fragment slot="caption">デハ8881（15次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>8000系に搭載された HB2000 型の基本構造は7200系で採用された <a href="#hb1500">HB1500 型</a>と同様ですが、容積や出力がアップされています。</p>
 
@@ -356,22 +356,22 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機<small>（HS20-1）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS20_9101} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS20_9101} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-01-24 -->
 						<Fragment slot="caption">クハ9101（1次車）海側</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS20_9010} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS20_9010} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2013-06-16 -->
 						<Fragment slot="caption">クハ9010（3次車）海側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>低騒音、小型軽量化、低振動化を図るために開発された機種で、弁部から発生する音を軽減したり、フレーム構造を廃して圧縮機と電動機を直結したりすることにより、 <a href="#hb2000">HB2000 型</a>と比較して重量 40% 減、車内騒音値 11% 減を達成しています<NoteRef type="ref" by="nabuco57-2" />。</p>
 
@@ -389,15 +389,15 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機<small>（HS20G）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS20_8641} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS20_8641} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-12-29 -->
 						<Fragment slot="caption">デハ8641（18-2次車）海側</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>7600系や8000系グループ18次車以降も HS20 型が採用されましたが、こちらは直流駆動式とされました。</p>
 
@@ -411,22 +411,22 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機</Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS10_1223} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS10_1223} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-04-17 -->
 						<Fragment slot="caption">デハ1223（4次車）海側</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS10_iga101} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS10_iga101} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-12-20 -->
 						<Fragment slot="caption">伊賀鉄道ク101（東急クハ1010）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p><a href="#hs20">HS20 型</a>を元に開発された小容量タイプで、全体的にコンパクトになり、ちりこしが横向きに配されるなど印象も異なります。</p>
 
@@ -440,15 +440,15 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機</Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS10_fukushima1208} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS10_fukushima1208} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-04-17 -->
 						<Fragment slot="caption">福島交通クハ1208（東急デハ1257）</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>1000系の福島交通譲渡車はクハ1200形の CP が新品の HS10 型に換装されました。この際、種車と同じく交流駆動とされ、東急では見られなかった誘導電動機による HS10 型となっています。</p>
 		</Section>
@@ -460,15 +460,15 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">直流電動機<small>（HS5）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS5_310B} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS5_310B} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-02-22 -->
 						<Fragment slot="caption">デハ310B（2次車）山側 #2</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>路面電車など小型車両用に開発されたもので、シリンダ配列は <a href="#hs10">HS10 型</a>までの水平対向4気筒から V型2気筒へ変更されています。</p>
 
@@ -478,22 +478,22 @@ const slugger = new GithubSlugger();
 		<Section id={slugger} depth={2}>
 			<Fragment slot="heading">誘導電動機<small>（HS5-1）</small></Fragment>
 
-			<Flex>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS5_Y001} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+			<Grid column={2}>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS5_Y001} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-04-06 -->
 						<Fragment slot="caption">クハY001（1次車）海側 #1</Fragment>
 					</Embedded>
-				</FlexItem>
-				<FlexItem>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_HS5_Y002} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+				</GridItem>
+				<GridItem>
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_HS5_Y002} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-03-22 -->
 						<Fragment slot="caption">クハY002（2次車）海側 #1</Fragment>
 					</Embedded>
-				</FlexItem>
-			</Flex>
+				</GridItem>
+			</Grid>
 
 			<p>こどもの国線用のY000系には交流駆動タイプが搭載されています。本体は枕木方向に配されており、圧縮機が外側を向いているので2気筒である様子がよく分かります。</p>
 
@@ -504,15 +504,15 @@ const slugger = new GithubSlugger();
 	<Section id="c2500">
 		<Fragment slot="heading">C2500L</Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_C2500L_3510} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_C2500L_3510} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2007-08-19 -->
 					<Fragment slot="caption">サハ3510（2次車）海側</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>新3000系に搭載されたもので、シリンダは <a href="#hs20">HS20 型</a>などの対向4気筒から直列3気筒となり、ちりこしの右側に低圧2、高圧1 が一列に並んだ様相が特徴です。</p>
 
@@ -522,15 +522,15 @@ const slugger = new GithubSlugger();
 	<Section id="c2000m">
 		<Fragment slot="heading">C2000M</Fragment>
 
-		<Flex>
-			<FlexItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_C2000M_toyama17482} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+		<Grid column={2}>
+			<GridItem>
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_C2000M_toyama17482} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 					<!-- 撮影日: 2013-11-03 -->
 					<Fragment slot="caption">富山地方鉄道モハ17482</Fragment>
 				</Embedded>
-			</FlexItem>
-		</Flex>
+			</GridItem>
+		</Grid>
 
 		<p>富山地方鉄道に譲渡された8590系は、モハ17482形（東急デハ8690形）の CP が同鉄道の他車種の多くに使用されている C2000M 型に交換されました。</p>
 

--- a/astro/src/pages/tokyu/machine/pt_7000.astro
+++ b/astro/src/pages/tokyu/machine/pt_7000.astro
@@ -41,19 +41,19 @@ const structuredData: StructuredData = {
 	<Section id="pantograph">
 		<Fragment slot="heading">菱形パンタグラフ</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="pt43" depth={2}>
 					<Fragment slot="heading">PT43</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT43} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT43} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2010-06-30 -->
 						<Fragment slot="caption">デハ7701（1次車）</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT43_side} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT43_side} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2007-03-24 -->
 						<Fragment slot="caption">デハ7701（1次車）</Fragment>
 					</Embedded>
@@ -67,14 +67,14 @@ const structuredData: StructuredData = {
 				<Section id="pt44" depth={2}>
 					<Fragment slot="heading">PT44</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT44} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT44} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2010-06-30 -->
 						<Fragment slot="caption">デハ7801（1次車）</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT44_side} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT44_side} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2007-02-24 -->
 						<Fragment slot="caption">デハ7810（3次車）</Fragment>
 					</Embedded>
@@ -90,13 +90,13 @@ const structuredData: StructuredData = {
 				<Section id="pt44s-c" depth={2}>
 					<Fragment slot="heading">PT44S（C型）</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT44SC} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT44SC} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2010-08-20 -->
 						<Fragment slot="caption">デハ7705（2次車）</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT44SC_side} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT44SC_side} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2007-02-24 -->
 						<Fragment slot="caption">デハ7805（3次車）</Fragment>
 					</Embedded>
@@ -114,13 +114,13 @@ const structuredData: StructuredData = {
 				<Section id="pt44s" depth={2}>
 					<Fragment slot="heading">PT44S（D型、E型）</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT44S} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT44S} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2010-07-01 -->
 						<Fragment slot="caption">デハ7682（1次車）下り方</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT44S_side} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT44S_side} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2007-03-03 -->
 						<Fragment slot="caption">デハ7681（1次車）下り方</Fragment>
 					</Embedded>
@@ -134,13 +134,13 @@ const structuredData: StructuredData = {
 				<Section id="pt4309" depth={2}>
 					<Fragment slot="heading">PT4309（架線検測車・測定用）</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT4309} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT4309} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2005-05-17 -->
 						<Fragment slot="caption">デヤ7290（2次車）下り方</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT4309_side} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT4309_side} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2007-03-08 -->
 						<Fragment slot="caption">デヤ7290（2次車）下り方</Fragment>
 					</Embedded>
@@ -154,23 +154,23 @@ const structuredData: StructuredData = {
 	<Section id="single-arm">
 		<Fragment slot="heading">シングルアーム形パンタグラフ</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="pt7108" depth={2}>
 					<Fragment slot="heading">PT7108</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT7108A} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT7108A} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2010-06-07 -->
 						<Fragment slot="caption">デハ7715（5次車）</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT7108B} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT7108B} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2010-06-07 -->
 						<Fragment slot="caption">デハ7815（4次車）</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_PT7108_side} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_PT7108_side} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2007-04-22 -->
 						<Fragment slot="caption">デハ7815（4次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/rec.astro
+++ b/astro/src/pages/tokyu/machine/rec.astro
@@ -47,13 +47,13 @@ const structuredData: StructuredData = {
 	<Section id="series7200">
 		<Fragment slot="heading">7200系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rs120" depth={2}>
 					<Fragment slot="heading">RS120</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RS120} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RS120} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 						<Fragment slot="caption">デヤ7290（2次車）山側</Fragment>
 					</Embedded>
@@ -67,13 +67,13 @@ const structuredData: StructuredData = {
 	<Section id="series8000">
 		<Fragment slot="heading">8000系グループ</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rs175" depth={2}>
 					<Fragment slot="heading">RS175</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RS175} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RS175} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-06-08 -->
 						<Fragment slot="caption">デハ8692（20次車）海側</Fragment>
 					</Embedded>
@@ -85,8 +85,8 @@ const structuredData: StructuredData = {
 				<Section id="rs180" depth={2}>
 					<Fragment slot="heading">RS180</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RS180} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RS180} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-06-20 -->
 						<Fragment slot="caption">クハ8091（12-1次車）海側</Fragment>
 					</Embedded>
@@ -100,13 +100,13 @@ const structuredData: StructuredData = {
 	<Section id="series9000">
 		<Fragment slot="heading">9000系、1000系、2000系、クハ7915</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rfe001a" depth={2}>
 					<Fragment slot="heading">RFE001-A、RFE001-B</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE001A} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE001A} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-02-11 -->
 						<Fragment slot="caption">クハ9001（1次車）山側</Fragment>
 					</Embedded>
@@ -118,8 +118,8 @@ const structuredData: StructuredData = {
 				<Section id="rfe001d" depth={2}>
 					<Fragment slot="heading">RFE001-C、RFE001-D</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE001C} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE001C} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-03-08 -->
 						<Fragment slot="caption">クハ9006（2次車）山側</Fragment>
 					</Embedded>
@@ -133,8 +133,8 @@ const structuredData: StructuredData = {
 				<Section id="rfe001e" depth={2}>
 					<Fragment slot="heading">RFE001-E、RFE001-F</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE001E} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE001E} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-24 -->
 						<Fragment slot="caption">デハ1213（3次車）海側</Fragment>
 					</Embedded>
@@ -148,8 +148,8 @@ const structuredData: StructuredData = {
 				<Section id="rfe001g" depth={2}>
 					<Fragment slot="heading">RFE001-G</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE001G} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE001G} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-07-14 -->
 						<Fragment slot="caption">デハ1222（4次車）山側</Fragment>
 					</Embedded>
@@ -163,13 +163,13 @@ const structuredData: StructuredData = {
 	<Section id="series7600">
 		<Fragment slot="heading">7600系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rfe005" depth={2}>
 					<Fragment slot="heading">RFE005</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE005} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE005} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-08-18 -->
 						<Fragment slot="caption">クハ7601（1次車）山側</Fragment>
 					</Embedded>
@@ -183,13 +183,13 @@ const structuredData: StructuredData = {
 	<Section id="series8500-18">
 		<Fragment slot="heading">8500系（18次車以降の編成車）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rfe007" depth={2}>
 					<Fragment slot="heading">RFE007</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE007} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE007} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-08-12 -->
 						<Fragment slot="caption">サハ8975（18-1次車）海側</Fragment>
 					</Embedded>
@@ -203,13 +203,13 @@ const structuredData: StructuredData = {
 	<Section id="series7700">
 		<Fragment slot="heading">7700系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rfe013" depth={2}>
 					<Fragment slot="heading">RFE013</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE013} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE013} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-08-19 -->
 						<Fragment slot="caption">クハ7905（2次車）山側</Fragment>
 					</Embedded>
@@ -221,8 +221,8 @@ const structuredData: StructuredData = {
 				<Section id="s4341" depth={2}>
 					<Fragment slot="heading">S4341</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_S4341} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_S4341} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-08-18 -->
 						<Fragment slot="caption">クハ7910（3次車）山側</Fragment>
 					</Embedded>
@@ -236,13 +236,13 @@ const structuredData: StructuredData = {
 	<Section id="series3000">
 		<Fragment slot="heading">新3000系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="cg316" depth={2}>
 					<Fragment slot="heading">CG316</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_CG316} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_CG316} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-08-19 -->
 						<Fragment slot="caption">サハ3510（2次車）海側</Fragment>
 					</Embedded>
@@ -256,13 +256,13 @@ const structuredData: StructuredData = {
 	<Section id="seriesY000">
 		<Fragment slot="heading">Y000系</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rfe059" depth={2}>
 					<Fragment slot="heading">RFE059</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE059} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE059} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-25 -->
 						<Fragment slot="caption">クハY001（1次車）山側</Fragment>
 					</Embedded>
@@ -276,13 +276,13 @@ const structuredData: StructuredData = {
 	<Section id="series8090-100k">
 		<Fragment slot="heading">大井町線8090系二電源化工事車</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rfe068" depth={2}>
 					<Fragment slot="heading">RFE068</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RFE068} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RFE068} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-09-28 -->
 						<Fragment slot="caption">デハ8282（16-2次車）海側</Fragment>
 					</Embedded>
@@ -296,13 +296,13 @@ const structuredData: StructuredData = {
 	<Section id="v24">
 		<Fragment slot="heading">24V整流装置</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="rs157" depth={2}>
 					<Fragment slot="heading">RS157</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_RS157} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_RS157} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-16 -->
 						<Fragment slot="caption">サハ8975（18-1次車）海側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/roof_1000n.astro
+++ b/astro/src/pages/tokyu/machine/roof_1000n.astro
@@ -38,13 +38,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-1000">
 		<Fragment slot="heading">クハ1000形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-1000N" depth={2}>
 					<Fragment slot="heading">1000N系、1000N′系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000N2} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000N2} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-11 -->
 						<Fragment slot="caption">クハ1017（4次車）</Fragment>
 					</Embedded>
@@ -60,13 +60,13 @@ const structuredData: StructuredData = {
 	<Section id="m-1200">
 		<Fragment slot="heading">デハ1200形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m-1200N" depth={2}>
 					<Fragment slot="heading">1000N系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200N} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200N} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-11 -->
 						<Fragment slot="caption">デハ1213（3次車）</Fragment>
 					</Embedded>
@@ -80,8 +80,8 @@ const structuredData: StructuredData = {
 				<Section id="m-1200N2" depth={2}>
 					<Fragment slot="heading">1000N′系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200N2} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200N2} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-11 -->
 						<Fragment slot="caption">デハ1221（4次車）</Fragment>
 					</Embedded>
@@ -95,13 +95,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-1300">
 		<Fragment slot="heading">デハ1300形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-1300N" depth={2}>
 					<Fragment slot="heading">1000N系、1000N′系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1300N2} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1300N2} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-27 -->
 						<Fragment slot="caption">デハ1323（5次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/roof_7200.astro
+++ b/astro/src/pages/tokyu/machine/roof_7200.astro
@@ -38,13 +38,13 @@ const structuredData: StructuredData = {
 	<Section id="cmc-7200">
 		<Fragment slot="heading">デヤ7200形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="cmc-7200-1" depth={2}>
 					<Fragment slot="heading">デヤ7200</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7200} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7200} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2011-11-10 -->
 						<Fragment slot="caption">デヤ7200（2次車）</Fragment>
 					</Embedded>
@@ -60,13 +60,13 @@ const structuredData: StructuredData = {
 	<Section id="cmc-7290">
 		<Fragment slot="heading">デヤ7290形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="cmc-7290-1" depth={2}>
 					<Fragment slot="heading">デヤ7290<small>（集電装置換装前）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7290} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7290} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-07-09 -->
 						<Fragment slot="caption">デヤ7290（2次車）</Fragment>
 					</Embedded>
@@ -82,8 +82,8 @@ const structuredData: StructuredData = {
 				<Section id="cmc-7290-2" depth={2}>
 					<Fragment slot="heading">デヤ7290<small>（集電装置シングルアーム化）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7290_PT7108} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7290_PT7108} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2011-11-10 -->
 						<Fragment slot="caption">デヤ7290（2次車）</Fragment>
 					</Embedded>
@@ -101,13 +101,13 @@ const structuredData: StructuredData = {
 	<Section id="t-7590">
 		<Fragment slot="heading">サヤ7590形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="t-7590-1" depth={2}>
 					<Fragment slot="heading">サヤ7590</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7590} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7590} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2011-11-10 -->
 						<Fragment slot="caption">サヤ7590（5次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/roof_7600.astro
+++ b/astro/src/pages/tokyu/machine/roof_7600.astro
@@ -39,13 +39,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7600">
 		<Fragment slot="heading">クハ7600形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-7601" depth={2}>
 					<Fragment slot="heading">クハ7601〜7603</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7600} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7600} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">クハ7602（1次車）</Fragment>
 					</Embedded>
@@ -61,13 +61,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7650">
 		<Fragment slot="heading">デハ7650形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-7653" depth={2}>
 					<Fragment slot="heading">デハ7653</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7653} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7653} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-27 -->
 						<Fragment slot="caption">デハ7653（1次車）</Fragment>
 					</Embedded>
@@ -83,8 +83,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7661" depth={2}>
 					<Fragment slot="heading">デハ7661〜7662</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7650} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7650} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">デハ7662（2次車）</Fragment>
 					</Embedded>
@@ -100,13 +100,13 @@ const structuredData: StructuredData = {
 	<Section id="m-7670">
 		<Fragment slot="heading">デハ7670形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m-7673" depth={2}>
 					<Fragment slot="heading">デハ7673</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7673} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7673} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-27 -->
 						<Fragment slot="caption">デハ7673（3次車）</Fragment>
 					</Embedded>
@@ -120,8 +120,8 @@ const structuredData: StructuredData = {
 				<Section id="m-7681" depth={2}>
 					<Fragment slot="heading">デハ7681〜7682</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7670} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7670} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">デハ7682（1次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/roof_7700.astro
+++ b/astro/src/pages/tokyu/machine/roof_7700.astro
@@ -42,13 +42,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700">
 		<Fragment slot="heading">デハ7700形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-7701" depth={2}>
 					<Fragment slot="heading">デハ7701〜7702</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7701} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7701} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">デハ7702（1次車）</Fragment>
 					</Embedded>
@@ -64,8 +64,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7703" depth={2}>
 					<Fragment slot="heading">デハ7703〜7708, 7712〜7714</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7700} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7700} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-12 -->
 						<Fragment slot="caption">デハ7707（3次車）</Fragment>
 					</Embedded>
@@ -77,8 +77,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7710" depth={2}>
 					<Fragment slot="heading">デハ7710</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7710} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7710} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">デハ7710（3次車）</Fragment>
 					</Embedded>
@@ -92,13 +92,13 @@ const structuredData: StructuredData = {
 	<Section id="m-7800">
 		<Fragment slot="heading">デハ7800形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-7801" depth={2}>
 					<Fragment slot="heading">デハ7801, 7803</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7801} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7801} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-06-18 -->
 						<Fragment slot="caption">デハ7801（1次車）</Fragment>
 					</Embedded>
@@ -112,8 +112,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7802" depth={2}>
 					<Fragment slot="heading">デハ7802, 7805〜7808, 7812〜7714</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">デハ7802（2次車）</Fragment>
 					</Embedded>
@@ -125,8 +125,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7810" depth={2}>
 					<Fragment slot="heading">デハ7810</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7810} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7810} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">デハ7810（3次車）</Fragment>
 					</Embedded>
@@ -140,13 +140,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900">
 		<Fragment slot="heading">クハ7900形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-7901" depth={2}>
 					<Fragment slot="heading">クハ7901〜7902</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7901} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7901} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-06-18 -->
 						<Fragment slot="caption">クハ7901（1次車）</Fragment>
 					</Embedded>
@@ -160,8 +160,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7903" depth={2}>
 					<Fragment slot="heading">クハ7903〜7914</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">クハ7910（3次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/roof_7700n.astro
+++ b/astro/src/pages/tokyu/machine/roof_7700n.astro
@@ -37,13 +37,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700">
 		<Fragment slot="heading">デハ7700形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-7715" depth={2}>
 					<Fragment slot="heading">デハ7715</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7700N} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7700N} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">デハ7715（5次車）</Fragment>
 					</Embedded>
@@ -61,13 +61,13 @@ const structuredData: StructuredData = {
 	<Section id="m-7800">
 		<Fragment slot="heading">デハ7800形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m-7815" depth={2}>
 					<Fragment slot="heading">デハ7815</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800N} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800N} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">デハ7815（4次車）</Fragment>
 					</Embedded>
@@ -83,13 +83,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900">
 		<Fragment slot="heading">クハ7900形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-7915" depth={2}>
 					<Fragment slot="heading">クハ7915</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900N} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900N} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2009-05-21 -->
 						<Fragment slot="caption">クハ7915（5次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/tra.astro
+++ b/astro/src/pages/tokyu/machine/tra.astro
@@ -33,13 +33,13 @@ const slugger = new GithubSlugger();
 	<Section id="door-non-treat">
 		<Fragment slot="heading">扉非扱い制御用</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">大井町線</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_dnt_oimachi} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_dnt_oimachi} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2008-06-08 -->
 						<Fragment slot="caption">クハ8091（12-1次車）海側</Fragment>
 					</Embedded>
@@ -51,12 +51,12 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">池上、多摩川線</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_dnt_ikegami} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_dnt_ikegami} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2009-01-24 -->
 						<Fragment slot="caption">クハ7912（4次車）山側</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
+					<Embedded width={540} border={true} captionMeta={true}>
 						<MyImage image={image_dnt_ikegami_7600} alt="写真拡大" width={485} height={397} link={true} slot="media" />
 						<!-- 撮影日: 2009-03-21 -->
 						<Fragment slot="caption">クハ7601（1次車）</Fragment>
@@ -71,13 +71,13 @@ const slugger = new GithubSlugger();
 	<Section id="atc">
 		<Fragment slot="heading">列車情報などの伝送用</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">東横線（1000系まで）</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_atc_toyoko} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_atc_toyoko} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2009-01-17 -->
 						<Fragment slot="caption">クハ9013（3次車）山側</Fragment>
 					</Embedded>
@@ -89,8 +89,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">目黒線、こどもの国線（Y000系）</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_atc_meguro} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_atc_meguro} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2008-12-06 -->
 						<Fragment slot="caption">クハ3004（2次車）山側</Fragment>
 					</Embedded>
@@ -104,8 +104,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">大井町線</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_atc_oimachi} alt="写真拡大" width={485} height={324} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_atc_oimachi} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2008-06-21 -->
 						<Fragment slot="caption">デハ8641（18-2次車）海側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_1000n.astro
+++ b/astro/src/pages/tokyu/machine/ub_1000n.astro
@@ -46,13 +46,13 @@ const structuredData: StructuredData = {
 	<Section id="m1-1200">
 		<Fragment slot="heading">デハ1200形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m1-1200-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200Ns} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200Ns} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-09 -->
 						<Fragment slot="caption">デハ1212海側（3次車）</Fragment>
 					</Embedded>
@@ -64,8 +64,8 @@ const structuredData: StructuredData = {
 				<Section id="m1-1200-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200Nm} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200Nm} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-02 -->
 						<Fragment slot="caption">デハ1213山側（3次車）</Fragment>
 					</Embedded>
@@ -79,13 +79,13 @@ const structuredData: StructuredData = {
 	<Section id="m1c-1310">
 		<Fragment slot="heading">デハ1310形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m1c-1310-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1310Ns} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1310Ns} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-09 -->
 						<Fragment slot="caption">デハ1313海側（3次車）</Fragment>
 					</Embedded>
@@ -97,8 +97,8 @@ const structuredData: StructuredData = {
 				<Section id="m1c-1310-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1310Nm} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1310Nm} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-09 -->
 						<Fragment slot="caption">デハ1313山側（3次車）</Fragment>
 					</Embedded>
@@ -112,13 +112,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-1000">
 		<Fragment slot="heading">クハ1000形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-1000-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000Ns} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000Ns} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-01 -->
 						<Fragment slot="caption">クハ1012海側（3次車）</Fragment>
 					</Embedded>
@@ -130,8 +130,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-1000-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000Nm} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000Nm} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-01 -->
 						<Fragment slot="caption">クハ1013山側（3次車）</Fragment>
 					</Embedded>
@@ -145,19 +145,19 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="couple1200" depth={2}>
 					<Fragment slot="heading">デハ1200形 ｰ クハ1000形間</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200N1000N_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200N1000N_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-17 -->
 						<Fragment slot="caption">デハ1213 ｰ クハ1013海側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000N1200N_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000N1200N_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-17 -->
 						<Fragment slot="caption">クハ1013 ｰ デハ1213山側</Fragment>
 					</Embedded>
@@ -167,13 +167,13 @@ const structuredData: StructuredData = {
 				<Section id="couple1310" depth={2}>
 					<Fragment slot="heading">デハ1310形 ｰ デハ1200形間</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1310N1200N_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1310N1200N_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-16 -->
 						<Fragment slot="caption">デハ1313 ｰ デハ1212海側</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200N1310N_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200N1310N_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-16 -->
 						<Fragment slot="caption">デハ1212 ｰ デハ1313山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_1000n2.astro
+++ b/astro/src/pages/tokyu/machine/ub_1000n2.astro
@@ -45,13 +45,13 @@ const structuredData: StructuredData = {
 	<Section id="m-1200">
 		<Fragment slot="heading">デハ1200形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m-1200-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200N2s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200N2s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ1217海側（4次車）</Fragment>
 					</Embedded>
@@ -63,8 +63,8 @@ const structuredData: StructuredData = {
 				<Section id="m-1200-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200N2m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200N2m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ1217山側（4次車）</Fragment>
 					</Embedded>
@@ -78,13 +78,13 @@ const structuredData: StructuredData = {
 	<Section id="m1c-1310">
 		<Fragment slot="heading">デハ1310形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m1c-1310-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1310N2s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1310N2s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ1317海側（4次車）</Fragment>
 					</Embedded>
@@ -96,8 +96,8 @@ const structuredData: StructuredData = {
 				<Section id="m1c-1310-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1310N2m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1310N2m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ1317山側（4次車）</Fragment>
 					</Embedded>
@@ -111,13 +111,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-1000">
 		<Fragment slot="heading">クハ1000形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-1000-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000N2s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000N2s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ1017海側（4次車）</Fragment>
 					</Embedded>
@@ -129,8 +129,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-1000-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000N2m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000N2m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ1017山側（4次車）</Fragment>
 					</Embedded>
@@ -144,19 +144,19 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="couple1200" depth={2}>
 					<Fragment slot="heading">デハ1200形 ｰ クハ1000形間</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200N21000N2_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200N21000N2_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-09 -->
 						<Fragment slot="caption">デハ1223 ｰ クハ1023海側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1000N21200N2_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1000N21200N2_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-17 -->
 						<Fragment slot="caption">クハ1014 ｰ デハ1214山側</Fragment>
 					</Embedded>
@@ -166,14 +166,14 @@ const structuredData: StructuredData = {
 				<Section id="couple1310" depth={2}>
 					<Fragment slot="heading">デハ1310形 ｰ デハ1200形間</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1310N21200N2_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1310N21200N2_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-09 -->
 						<Fragment slot="caption">デハ1322 ｰ デハ1222海側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1200N21310N2_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1200N21310N2_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-02 -->
 						<Fragment slot="caption">デハ1222 ｰ デハ1322山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_1500.astro
+++ b/astro/src/pages/tokyu/machine/ub_1500.astro
@@ -45,13 +45,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-1500">
 		<Fragment slot="heading">デハ1500形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-1500-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1500_sea} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1500_sea} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">デハ1501海側</Fragment>
 					</Embedded>
@@ -63,8 +63,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-1500-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1500_mount} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1500_mount} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">デハ1501山側</Fragment>
 					</Embedded>
@@ -78,13 +78,13 @@ const structuredData: StructuredData = {
 	<Section id="m-1600">
 		<Fragment slot="heading">デハ1600形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m-1600-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1600_sea} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1600_sea} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">デハ1601海側</Fragment>
 					</Embedded>
@@ -96,8 +96,8 @@ const structuredData: StructuredData = {
 				<Section id="m-1600-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1600_mount} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1600_mount} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">デハ1601山側</Fragment>
 					</Embedded>
@@ -111,13 +111,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-1700">
 		<Fragment slot="heading">デハ1700形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-1700-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1724_sea} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1724_sea} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">デハ1724海側</Fragment>
 					</Embedded>
@@ -129,8 +129,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-1700-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1724_mount} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1724_mount} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">デハ1724山側</Fragment>
 					</Embedded>
@@ -144,13 +144,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-1500">
 		<Fragment slot="heading">クハ1500形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-1500-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1524_sea} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1524_sea} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">クハ1524海側</Fragment>
 					</Embedded>
@@ -162,8 +162,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-1500-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1524_mount} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1524_mount} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">クハ1524山側</Fragment>
 					</Embedded>
@@ -177,13 +177,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-1700">
 		<Fragment slot="heading">クハ1700形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-1700-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1700_sea} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1700_sea} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">クハ1701海側</Fragment>
 					</Embedded>
@@ -195,8 +195,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-1700-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_1700_mount} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_1700_mount} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 2019-04-29 -->
 						<Fragment slot="caption">クハ1701山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_7600.astro
+++ b/astro/src/pages/tokyu/machine/ub_7600.astro
@@ -49,13 +49,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7650">
 		<Fragment slot="heading">デハ7650形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-7650-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7650s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7650s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7662海側（2次車）</Fragment>
 					</Embedded>
@@ -67,8 +67,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7650-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7650m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7650m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7662山側（2次車）</Fragment>
 					</Embedded>
@@ -82,13 +82,13 @@ const structuredData: StructuredData = {
 	<Section id="m-7670">
 		<Fragment slot="heading">デハ7670形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m-7670-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7670s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7670s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7682海側（1次車）</Fragment>
 					</Embedded>
@@ -100,8 +100,8 @@ const structuredData: StructuredData = {
 				<Section id="m-7670-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7670m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7670m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7682山側（1次車）</Fragment>
 					</Embedded>
@@ -115,13 +115,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7600">
 		<Fragment slot="heading">クハ7600形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-7600-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7600s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7600s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ7602海側（1次車）</Fragment>
 					</Embedded>
@@ -133,8 +133,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7600-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7600m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7600m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ7602山側（1次車）</Fragment>
 					</Embedded>
@@ -148,19 +148,19 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="couple7601" depth={2}>
 					<Fragment slot="heading">クハ7600形 ｰ デハ7670形間<small>（7601F, 7602F）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_76707600_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_76707600_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-16 -->
 						<Fragment slot="caption">デハ7681 ｰ クハ7601海側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_76007670_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_76007670_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-24 -->
 						<Fragment slot="caption">クハ7601 ｰ デハ7681山側</Fragment>
 					</Embedded>
@@ -170,14 +170,14 @@ const structuredData: StructuredData = {
 				<Section id="couple7603" depth={2}>
 					<Fragment slot="heading">クハ7600形 ｰ デハ7670形間<small>（7603F）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_76737603_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_76737603_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-17 -->
 						<Fragment slot="caption">デハ7673 ｰ クハ7603海側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_76037673_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_76037673_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-16 -->
 						<Fragment slot="caption">クハ7603 ｰ デハ7673山側</Fragment>
 					</Embedded>
@@ -187,13 +187,13 @@ const structuredData: StructuredData = {
 				<Section id="couple7661" depth={2}>
 					<Fragment slot="heading">デハ7650形 ｰ デハ7670形間<small>（7601F, 7602F）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_76507670_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_76507670_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-09 -->
 						<Fragment slot="caption">デハ7662 ｰ デハ7682海側</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_76707650_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_76707650_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-16 -->
 						<Fragment slot="caption">デハ7681 ｰ デハ7661山側</Fragment>
 					</Embedded>
@@ -203,13 +203,13 @@ const structuredData: StructuredData = {
 				<Section id="couple7653" depth={2}>
 					<Fragment slot="heading">デハ7650形 ｰ デハ7670形間<small>（7603F）</small></Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_76537673_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_76537673_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-16 -->
 						<Fragment slot="caption">デハ7653 ｰ デハ7673海側</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_76737653_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_76737653_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-16 -->
 						<Fragment slot="caption">デハ7673 ｰ デハ7653山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_7700.astro
+++ b/astro/src/pages/tokyu/machine/ub_7700.astro
@@ -47,13 +47,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700">
 		<Fragment slot="heading">デハ7700形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-7700-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7700s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7700s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7710海側（3次車）</Fragment>
 					</Embedded>
@@ -67,8 +67,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7700-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7700m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7700m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7706山側（2次車）</Fragment>
 					</Embedded>
@@ -84,13 +84,13 @@ const structuredData: StructuredData = {
 	<Section id="m-7800">
 		<Fragment slot="heading">デハ7800形（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m-7800-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7806海側（3次車）</Fragment>
 					</Embedded>
@@ -104,8 +104,8 @@ const structuredData: StructuredData = {
 				<Section id="m-7800-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7810山側（3次車）</Fragment>
 					</Embedded>
@@ -121,13 +121,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900">
 		<Fragment slot="heading">クハ7900形（台車間、東芝SIV搭載車）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-7900-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ7906海側（2次車）</Fragment>
 					</Embedded>
@@ -143,8 +143,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7900-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900m} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900m} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ7906山側（2次車）</Fragment>
 					</Embedded>
@@ -158,13 +158,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900-tdk">
 		<Fragment slot="heading">クハ7900形（台車間、東洋SIV搭載車）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-7900-tdk-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900TDKs} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900TDKs} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ7910海側（3次車）</Fragment>
 					</Embedded>
@@ -178,8 +178,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7900-tdk-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900TDKm} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900TDKm} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ7910山側（3次車）</Fragment>
 					</Embedded>
@@ -193,19 +193,19 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="couple7700" depth={2}>
 					<Fragment slot="heading">デハ7700形 ｰ デハ7800形間</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_77007800_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_77007800_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-16 -->
 						<Fragment slot="caption">デハ7701 ｰ デハ7801海側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_78007700_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_78007700_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-09 -->
 						<Fragment slot="caption">デハ7807 ｰ デハ7707山側</Fragment>
 					</Embedded>
@@ -215,14 +215,14 @@ const structuredData: StructuredData = {
 				<Section id="couple7800" depth={2}>
 					<Fragment slot="heading">デハ7800形 ｰ クハ7900形間</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_78007900_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_78007900_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-02 -->
 						<Fragment slot="caption">デハ7806 ｰ クハ7906海側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_79007800_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_79007800_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-02 -->
 						<Fragment slot="caption">クハ7906 ｰ デハ7806山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_7700n.astro
+++ b/astro/src/pages/tokyu/machine/ub_7700n.astro
@@ -45,13 +45,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7715">
 		<Fragment slot="heading">デハ7715（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="mc-7715-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7700Ns} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7700Ns} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7715海側（5次車）</Fragment>
 					</Embedded>
@@ -63,8 +63,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7715-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7700Nm} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7700Nm} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7715山側（5次車）</Fragment>
 					</Embedded>
@@ -78,13 +78,13 @@ const structuredData: StructuredData = {
 	<Section id="m-7815">
 		<Fragment slot="heading">デハ7815（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m-7815-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800Ns} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800Ns} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7815海側（4次車）</Fragment>
 					</Embedded>
@@ -96,8 +96,8 @@ const structuredData: StructuredData = {
 				<Section id="m-7815-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800Nm} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800Nm} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">デハ7815山側（4次車）</Fragment>
 					</Embedded>
@@ -111,13 +111,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7915">
 		<Fragment slot="heading">クハ7915（台車間）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="tc-7915-sea" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900Ns} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900Ns} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ7915海側（5次車）</Fragment>
 					</Embedded>
@@ -129,8 +129,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7915-mount" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900Nm} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900Nm} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2008-01-20 -->
 						<Fragment slot="caption">クハ7915山側（5次車）</Fragment>
 					</Embedded>
@@ -144,19 +144,19 @@ const structuredData: StructuredData = {
 	<Section id="couple">
 		<Fragment slot="heading">連結部</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="couple7715" depth={2}>
 					<Fragment slot="heading">デハ7700形 ｰ デハ7800形間</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7700N7800N_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7700N7800N_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-04-12 -->
 						<Fragment slot="caption">デハ7715 ｰ デハ7815海側</Fragment>
 					</Embedded>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800N7700N_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800N7700N_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-24 -->
 						<Fragment slot="caption">デハ7815 ｰ デハ7715山側</Fragment>
 					</Embedded>
@@ -166,13 +166,13 @@ const structuredData: StructuredData = {
 				<Section id="couple7815" depth={2}>
 					<Fragment slot="heading">デハ7700形 ｰ デハ7800形間</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7800N7900N_sea} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7800N7900N_sea} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-04-12 -->
 						<Fragment slot="caption">デハ7815 ｰ クハ7915海側</Fragment>
 					</Embedded>
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7900N7800N_mount} alt="写真拡大" width={485} height={243} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7900N7800N_mount} alt="写真拡大" width={540} height={270} link={true} slot="media" />
 						<!-- 撮影日: 2008-02-17 -->
 						<Fragment slot="caption">クハ7915 ｰ デハ7815山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_7900_m.astro
+++ b/astro/src/pages/tokyu/machine/ub_7900_m.astro
@@ -46,13 +46,13 @@ const structuredData: StructuredData = {
 	<Section id="air">
 		<Fragment slot="heading">元空気指令車（1〜3次車）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="c7901" depth={2}>
 					<Fragment slot="heading">クハ7901</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7901m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7901m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-01 -->
 						<Fragment slot="caption">クハ7901（1次車）</Fragment>
 					</Embedded>
@@ -64,8 +64,8 @@ const structuredData: StructuredData = {
 				<Section id="c7902" depth={2}>
 					<Fragment slot="heading">クハ7902</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7902m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7902m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-01 -->
 						<Fragment slot="caption">クハ7902（1次車）</Fragment>
 					</Embedded>
@@ -77,8 +77,8 @@ const structuredData: StructuredData = {
 				<Section id="c7903" depth={2}>
 					<Fragment slot="heading">クハ7903</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7903m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7903m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-29 -->
 						<Fragment slot="caption">クハ7903（2次車）</Fragment>
 					</Embedded>
@@ -90,8 +90,8 @@ const structuredData: StructuredData = {
 				<Section id="c7905" depth={2}>
 					<Fragment slot="heading">クハ7905</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7905m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7905m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-04-12 -->
 						<Fragment slot="caption">クハ7905（2次車）</Fragment>
 					</Embedded>
@@ -103,8 +103,8 @@ const structuredData: StructuredData = {
 				<Section id="c7906" depth={2}>
 					<Fragment slot="heading">クハ7906</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7906m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7906m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-29 -->
 						<Fragment slot="caption">クハ7906（2次車）</Fragment>
 					</Embedded>
@@ -116,8 +116,8 @@ const structuredData: StructuredData = {
 				<Section id="c7907" depth={2}>
 					<Fragment slot="heading">クハ7907</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7907m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7907m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-01 -->
 						<Fragment slot="caption">クハ7907（3次車）</Fragment>
 					</Embedded>
@@ -129,8 +129,8 @@ const structuredData: StructuredData = {
 				<Section id="c7908" depth={2}>
 					<Fragment slot="heading">クハ7908</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7908m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7908m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-04-05 -->
 						<Fragment slot="caption">クハ7908（2次車）</Fragment>
 					</Embedded>
@@ -142,8 +142,8 @@ const structuredData: StructuredData = {
 				<Section id="c7910" depth={2}>
 					<Fragment slot="heading">クハ7910</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7910m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7910m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-29 -->
 						<Fragment slot="caption">クハ7910（3次車）</Fragment>
 					</Embedded>
@@ -157,13 +157,13 @@ const structuredData: StructuredData = {
 	<Section id="electric">
 		<Fragment slot="heading">改造当初からの電気指令車（4〜5次車）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="c7912" depth={2}>
 					<Fragment slot="heading">クハ7912</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7912m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7912m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-08 -->
 						<Fragment slot="caption">クハ7912（4次車）</Fragment>
 					</Embedded>
@@ -175,8 +175,8 @@ const structuredData: StructuredData = {
 				<Section id="c7913" depth={2}>
 					<Fragment slot="heading">クハ7913</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7913m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7913m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-23 -->
 						<Fragment slot="caption">クハ7913（5次車）</Fragment>
 					</Embedded>
@@ -188,8 +188,8 @@ const structuredData: StructuredData = {
 				<Section id="c7914" depth={2}>
 					<Fragment slot="heading">クハ7914</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7914m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7914m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-08 -->
 						<Fragment slot="caption">クハ7914（5次車）</Fragment>
 					</Embedded>
@@ -203,13 +203,13 @@ const structuredData: StructuredData = {
 	<Section id="t-7950">
 		<Fragment slot="heading">サハ7950形からの改造車（5次車）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="c7915" depth={2}>
 					<Fragment slot="heading">クハ7915</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7915m} alt="写真拡大" width={485} height={122} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7915m} alt="写真拡大" width={540} height={135} link={true} slot="media" />
 						<!-- 撮影日: 2008-03-23 -->
 						<Fragment slot="caption">クハ7915（5次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_8290.astro
+++ b/astro/src/pages/tokyu/machine/ub_8290.astro
@@ -41,13 +41,13 @@ const structuredData: StructuredData = {
 	<Section id="m2-8290-bs33">
 		<Fragment slot="heading">10kVA SIV 搭載車</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m2-8290-bs33-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8290sBS33} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8290sBS33} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2005-05-01 -->
 						<Fragment slot="caption">デハ8294海側（13次車）</Fragment>
 					</Embedded>
@@ -59,8 +59,8 @@ const structuredData: StructuredData = {
 				<Section id="m2-8290-bs33-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8290mBS33} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8290mBS33} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-24 -->
 						<Fragment slot="caption">デハ8284山側（16-2次車）</Fragment>
 					</Embedded>
@@ -72,8 +72,8 @@ const structuredData: StructuredData = {
 				<Section id="m2-8290-bs33-j" depth={2}>
 					<Fragment slot="heading">山側連結部</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_IC3C} alt="写真拡大" width={485} height={364} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_IC3C} alt="写真拡大" width={540} height={405} link={true} slot="media" />
 						<!-- 撮影日: 2007-08-18 -->
 						<Fragment slot="caption">デハ8495 ｰ デハ8280山側</Fragment>
 					</Embedded>
@@ -87,13 +87,13 @@ const structuredData: StructuredData = {
 	<Section id="m2-8290-inv104">
 		<Fragment slot="heading">100kVA SIV（INV-104 型）搭載車</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m2-8290-inv104-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8290sINV104} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8290sINV104} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2005-05-01 -->
 						<Fragment slot="caption">デハ8282海側（16-2次車）</Fragment>
 					</Embedded>
@@ -105,8 +105,8 @@ const structuredData: StructuredData = {
 				<Section id="m2-8290-inv104-m" depth={2}>
 					<Fragment slot="heading">山側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8290mINV104} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8290mINV104} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-13 -->
 						<Fragment slot="caption">デハ8296山側（13次車）</Fragment>
 					</Embedded>
@@ -118,8 +118,8 @@ const structuredData: StructuredData = {
 				<Section id="m2-8290-inv104-j" depth={2}>
 					<Fragment slot="heading">山側連結部</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_IC3Cfo} alt="写真拡大" width={485} height={364} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_IC3Cfo} alt="写真拡大" width={540} height={405} link={true} slot="media" />
 						<!-- 撮影日: 2007-04-15 -->
 						<Fragment slot="caption">デハ8496 ｰ デハ8282山側</Fragment>
 					</Embedded>
@@ -133,13 +133,13 @@ const structuredData: StructuredData = {
 	<Section id="m2-8290-inv153">
 		<Fragment slot="heading">100kVA SIV（INV-153 型）搭載車</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m2-8290-inv153-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8290sINV153} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8290sINV153} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2005-05-01 -->
 						<Fragment slot="caption">デハ8298海側（16-2次車）</Fragment>
 					</Embedded>
@@ -153,8 +153,8 @@ const structuredData: StructuredData = {
 				<Section id="m2-8290-inv153-j" depth={2}>
 					<Fragment slot="heading">山側連結部</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_IC3Crem} alt="写真拡大" width={485} height={364} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_IC3Crem} alt="写真拡大" width={540} height={405} link={true} slot="media" />
 						<!-- 撮影日: 2007-05-19 -->
 						<Fragment slot="caption">デハ8494 ｰ デハ8298山側</Fragment>
 					</Embedded>
@@ -166,13 +166,13 @@ const structuredData: StructuredData = {
 	<Section id="m2-8200">
 		<Fragment slot="heading">（参考）10kVA SIV 搭載車・デハ8200形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m2-820-s" depth={2}>
 					<Fragment slot="heading">海側</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8200s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8200s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2005-05-01 -->
 						<Fragment slot="caption">デハ8203海側（1次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/ub_8800.astro
+++ b/astro/src/pages/tokyu/machine/ub_8800.astro
@@ -40,13 +40,13 @@ const structuredData: StructuredData = {
 	<Section id="m2-8800">
 		<Fragment slot="heading">通常のデハ8800形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m2-8800-7" depth={2}>
 					<Fragment slot="heading">7〜11次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8800s7} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8800s7} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2010-01-11 -->
 						<Fragment slot="caption">デハ8816海側（7-2次車）</Fragment>
 					</Embedded>
@@ -60,8 +60,8 @@ const structuredData: StructuredData = {
 				<Section id="m2-8800-14" depth={2}>
 					<Fragment slot="heading">14〜17次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8800s14} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8800s14} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2010-01-11 -->
 						<Fragment slot="caption">デハ8862海側（14-2次車）</Fragment>
 					</Embedded>
@@ -77,13 +77,13 @@ const structuredData: StructuredData = {
 	<Section id="cpremove">
 		<Fragment slot="heading">CP撤去車（6号車に連結されたデハ8800形）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="cpremove-10" depth={2}>
 					<Fragment slot="heading">10〜11次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8800scpremove10} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8800scpremove10} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2009-10-23 -->
 						<Fragment slot="caption">デハ8835海側（10-1次車）</Fragment>
 					</Embedded>
@@ -97,8 +97,8 @@ const structuredData: StructuredData = {
 				<Section id="cpremove-13" depth={2}>
 					<Fragment slot="heading">14〜17次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8800scpremove13} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8800scpremove13} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2010-01-20 -->
 						<Fragment slot="caption">デハ8850海側（14-2次車）</Fragment>
 					</Embedded>
@@ -110,8 +110,8 @@ const structuredData: StructuredData = {
 				<Section id="bttransfer" depth={2}>
 					<Fragment slot="heading">蓄電池移設車（18-1次車）</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8800sBTtransfer} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8800sBTtransfer} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2009-11-24 -->
 						<Fragment slot="caption">デハ8897海側（18-1次車）</Fragment>
 					</Embedded>
@@ -125,8 +125,8 @@ const structuredData: StructuredData = {
 				<Section id="frame" depth={2}>
 					<Fragment slot="heading">HB-2000型の吊り枠搭載車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8800sframe} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8800sframe} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2009-11-27 -->
 						<Fragment slot="caption">デハ8849海側（14-2次車）</Fragment>
 					</Embedded>
@@ -140,13 +140,13 @@ const structuredData: StructuredData = {
 	<Section id="hs20">
 		<Fragment slot="heading">HS-20型コンプレッサ搭載車</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="hs20-18" depth={2}>
 					<Fragment slot="heading">18〜21次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8800s20G} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8800s20G} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2009-12-10 -->
 						<Fragment slot="caption">デハ0808海側（19-1次車）</Fragment>
 					</Embedded>
@@ -162,13 +162,13 @@ const structuredData: StructuredData = {
 	<Section id="m2-8290">
 		<Fragment slot="heading">（参考）デハ8290形</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="m2-8290-16" depth={2}>
 					<Fragment slot="heading">16〜17次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8290s} alt="写真拡大" width={485} height={152} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8290s} alt="写真拡大" width={540} height={169} link={true} slot="media" />
 						<!-- 撮影日: 2009-11-29 -->
 						<Fragment slot="caption">デハ8283海側（16-2次車）</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/machine/usl.astro
+++ b/astro/src/pages/tokyu/machine/usl.astro
@@ -34,13 +34,13 @@ const slugger = new GithubSlugger();
 	<Section id="olr">
 		<Fragment slot="heading">7200系、7600系の過負荷灯</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">オリジナルタイプ</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7200_OLR1} alt="写真拡大" width={485} height={364} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7200_OLR1} alt="写真拡大" width={540} height={405} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-16 -->
 						<Fragment slot="caption">デハ7662（2次車）山側</Fragment>
 					</Embedded>
@@ -52,8 +52,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">新型タイプ</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_7200_OLR2} alt="写真拡大" width={485} height={364} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_7200_OLR2} alt="写真拡大" width={540} height={405} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-07 -->
 						<Fragment slot="caption">デヤ7200（2次車）海側</Fragment>
 					</Embedded>
@@ -67,13 +67,13 @@ const slugger = new GithubSlugger();
 	<Section id="series8000">
 		<Fragment slot="heading">8000系グループ、7600系、7700系等の床下灯</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">3灯タイプ</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_8500_sidelamp} alt="写真拡大" width={485} height={364} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_8500_sidelamp} alt="写真拡大" width={540} height={405} link={true} slot="media" />
 						<!-- 撮影日: 2006-08-13 -->
 						<Fragment slot="caption">デハ8591（20次車）山側</Fragment>
 					</Embedded>
@@ -89,13 +89,13 @@ const slugger = new GithubSlugger();
 	<Section id="series9000">
 		<Fragment slot="heading">9000系、2000系等の床下灯</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">4灯タイプ</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_9000_sidelamp4} alt="写真拡大" width={485} height={364} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_9000_sidelamp4} alt="写真拡大" width={540} height={405} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-21 -->
 						<Fragment slot="caption">デハ1218（4次車）山側</Fragment>
 					</Embedded>
@@ -107,8 +107,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">3灯タイプ</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_9000_sidelamp3} alt="写真拡大" width={485} height={364} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_9000_sidelamp3} alt="写真拡大" width={540} height={405} link={true} slot="media" />
 						<!-- 撮影日: 2006-08-19 -->
 						<Fragment slot="caption">サハ9706（2次車）山側</Fragment>
 					</Embedded>

--- a/astro/src/pages/tokyu/truck/etc.astro
+++ b/astro/src/pages/tokyu/truck/etc.astro
@@ -172,7 +172,7 @@ const structuredData: StructuredData = {
 	<Section id="nsk-a1">
 		<Fragment slot="heading">A-1 型 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-		<Embedded border={true} captionMeta={true}>
+		<Embedded width={1024} border={true} captionMeta={true}>
 			<MyImage image={image_nskA1_hossyoji203} alt="写真拡大" width={1022} height={409} link={true} slot="media" />
 			<!-- 撮影日: 2010-03-08 -->
 			<Fragment slot="caption">日ノ丸自動車デハ203 米子市方</Fragment>
@@ -190,8 +190,8 @@ const structuredData: StructuredData = {
 	<Section id="3100">
 		<Fragment slot="heading">東京横浜電鉄／目黒蒲田電鉄　デハ100形用台車 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-		<Embedded border={true} captionMeta={true}>
-			<MyImage image={image_3100_kaya3104} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+		<Embedded width={1024} border={true} captionMeta={true}>
+			<MyImage image={image_3100_kaya3104} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 			<!-- 撮影日: 2010-07-21 -->
 			<Fragment slot="caption">加悦鉄道サハ3104</Fragment>
 		</Embedded>
@@ -216,8 +216,8 @@ const structuredData: StructuredData = {
 	<Section id="ks33">
 		<Fragment slot="heading">KS-33L 型 → KS-33E 型 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-		<Embedded border={true} captionMeta={true}>
-			<MyImage image={image_KS33E_oigawa821} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+		<Embedded width={1024} border={true} captionMeta={true}>
+			<MyImage image={image_KS33E_oigawa821} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 			<!-- 撮影日: 2010-05-25 -->
 			<Fragment slot="caption">大井川鐵道スイテ82 1 金谷方</Fragment>
 		</Embedded>
@@ -238,8 +238,8 @@ const structuredData: StructuredData = {
 	<Section id="dt21">
 		<Fragment slot="heading">DT-21T 型、TR-64 型、DT-21B 型 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-		<Embedded border={true} captionMeta={true}>
-			<MyImage image={image_DT21B_hokuriku7112} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+		<Embedded width={1024} border={true} captionMeta={true}>
+			<MyImage image={image_DT21B_hokuriku7112} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 			<!-- 撮影日: 2007-03-31 -->
 			<Fragment slot="caption">北陸鉄道クハ7112 野町方</Fragment>
 		</Embedded>
@@ -252,8 +252,8 @@ const structuredData: StructuredData = {
 	<Section id="fs342">
 		<Fragment slot="heading">FS-342 型 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-		<Embedded border={true} captionMeta={true}>
-			<MyImage image={image_FS342_hokuriku7102} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+		<Embedded width={1024} border={true} captionMeta={true}>
+			<MyImage image={image_FS342_hokuriku7102} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 			<!-- 撮影日: 2007-03-31 -->
 			<Fragment slot="caption">北陸鉄道モハ7102 鶴来方</Fragment>
 		</Embedded>
@@ -264,8 +264,8 @@ const structuredData: StructuredData = {
 	<Section id="fs097">
 		<Fragment slot="heading">FS-097 型 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-		<Embedded border={true} captionMeta={true}>
-			<MyImage image={image_FS097_iyotetsu502} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+		<Embedded width={1024} border={true} captionMeta={true}>
+			<MyImage image={image_FS097_iyotetsu502} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 			<!-- 撮影日: 2008-10-19 -->
 			<Fragment slot="caption">伊予鉄道サハ502 横河原方</Fragment>
 		</Embedded>
@@ -278,8 +278,8 @@ const structuredData: StructuredData = {
 	<Section id="tr230">
 		<Fragment slot="heading">TR-230C 型 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-		<Embedded border={true} captionMeta={true}>
-			<MyImage image={image_TR230_mani502186} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+		<Embedded width={1024} border={true} captionMeta={true}>
+			<MyImage image={image_TR230_mani502186} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 			<!-- 撮影日: 2019-07-03 -->
 			<Fragment slot="caption">マニ50 2186</Fragment>
 		</Embedded>

--- a/astro/src/pages/tokyu/truck/ts1000.astro
+++ b/astro/src/pages/tokyu/truck/ts1000.astro
@@ -184,8 +184,8 @@ const structuredData: StructuredData = {
 		<Section id="ts1004-m" depth={2}>
 			<Fragment slot="heading">TS-1004 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1004_9208} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1004_9208} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2016-10-23 -->
 				<Fragment slot="caption">デハ9208（3次車）上り方山側</Fragment>
 			</Embedded>
@@ -206,14 +206,14 @@ const structuredData: StructuredData = {
 		<Section id="ts1005-t" depth={2}>
 			<Fragment slot="heading">TS-1005 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1005_9007} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1005_9007} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-02-14 -->
 				<Fragment slot="caption">クハ9007（2次車）上り方山側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1005_9109} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1005_9109} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2011-10-09 -->
 				<Fragment slot="caption">クハ9109（3次車）上り方山側</Fragment>
 			</Embedded>
@@ -234,8 +234,8 @@ const structuredData: StructuredData = {
 		<Section id="ts1006-m" depth={2}>
 			<Fragment slot="heading">TS-1006 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1006_1223} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1006_1223} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-06-17 -->
 				<Fragment slot="caption">デハ1223（4次車）上り方山側</Fragment>
 			</Embedded>
@@ -246,8 +246,8 @@ const structuredData: StructuredData = {
 		<Section id="ts1006a" depth={2}>
 			<Fragment slot="heading">TS-1006A <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1006A_1362} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1006A_1362} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2006-04-09 -->
 				<Fragment slot="caption">デハ1362（3次車）上り方山側</Fragment>
 			</Embedded>
@@ -262,14 +262,14 @@ const structuredData: StructuredData = {
 		<Section id="ts1007-t" depth={2}>
 			<Fragment slot="heading">TS-1007 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1007_1101} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1007_1101} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-03-01 -->
 				<Fragment slot="caption">クハ1101（1次車）上り方山側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1007_1015} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1007_1015} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2006-03-03 -->
 				<Fragment slot="caption">クハ1015（4次車）上り方海側</Fragment>
 			</Embedded>
@@ -288,8 +288,8 @@ const structuredData: StructuredData = {
 		<Section id="ts1010-m" depth={2}>
 			<Fragment slot="heading">TS-1010 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1010_2453} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1010_2453} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-06-18 -->
 				<Fragment slot="caption">デハ2453（2次車）上り方山側</Fragment>
 			</Embedded>
@@ -308,14 +308,14 @@ const structuredData: StructuredData = {
 		<Section id="ts1011-t" depth={2}>
 			<Fragment slot="heading">TS-1011 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1011_2101} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1011_2101} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-03-01 -->
 				<Fragment slot="caption">クハ2101（1次車）下り方海側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1011_9022} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1011_9022} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2019-05-19 -->
 				<Fragment slot="caption">クハ9022（1次車）下り方山側</Fragment>
 			</Embedded>
@@ -334,8 +334,8 @@ const structuredData: StructuredData = {
 		<Section id="ts1019-m" depth={2}>
 			<Fragment slot="heading">TS-1019 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1019_3404} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1019_3404} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-01-31 -->
 				<Fragment slot="caption">デハ3404（2次車）下り方海側</Fragment>
 			</Embedded>
@@ -352,8 +352,8 @@ const structuredData: StructuredData = {
 		<Section id="ts1020-t" depth={2}>
 			<Fragment slot="heading">TS-1020 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS1020_3104} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS1020_3104} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-01-31 -->
 				<Fragment slot="caption">クハ3104（2次車）下り方海側</Fragment>
 			</Embedded>

--- a/astro/src/pages/tokyu/truck/ts300.astro
+++ b/astro/src/pages/tokyu/truck/ts300.astro
@@ -184,20 +184,20 @@ const structuredData: StructuredData = {
 		<Section id="ts301-m" depth={2}>
 			<Fragment slot="heading">TS-301 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS301_kumamoto5102A} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS301_kumamoto5102A} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2007-01-02 -->
 				<Fragment slot="caption">熊本電気鉄道モハ5102A 上熊本方（東急デハ5032 上り方）</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS301_kumamoto5101A} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS301_kumamoto5101A} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2007-01-02 -->
 				<Fragment slot="caption">熊本電気鉄道モハ5101A 上熊本方（東急デハ5031 上り方）</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS301_gakunan5002} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS301_gakunan5002} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2005-11-15 -->
 				<Fragment slot="caption">岳南鉄道モハ5002 岳南江尾方（東急デハ5028 下り方）</Fragment>
 			</Embedded>
@@ -216,8 +216,8 @@ const structuredData: StructuredData = {
 		<Section id="ts301-t" depth={2}>
 			<Fragment slot="heading">TS-301 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS301_ueda5251} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS301_ueda5251} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2007-05-05 -->
 				<Fragment slot="caption">上田交通クハ5251 別所温泉方（東急デハ5202 下り方）</Fragment>
 			</Embedded>
@@ -280,8 +280,8 @@ const structuredData: StructuredData = {
 		<Section id="ts302-m" depth={2}>
 			<Fragment slot="heading">TS-302 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS302_204} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS302_204} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-02-01 -->
 				<Fragment slot="caption">デハ204 海側</Fragment>
 			</Embedded>
@@ -302,14 +302,14 @@ const structuredData: StructuredData = {
 		<Section id="ts315-m" depth={2}>
 			<Fragment slot="heading">TS-315 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS315_konan6007_motor} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS315_konan6007_motor} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2007-05-26 -->
 				<Fragment slot="caption">弘南鉄道デハ6007 大鰐温泉方（東急デハ6007 上り方）モーター側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS315_konan6007_gear} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS315_konan6007_gear} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2007-05-26 -->
 				<Fragment slot="caption">弘南鉄道デハ6007 中央弘前方（東急デハ6007 下り方）・第1段歯車装置側</Fragment>
 			</Embedded>
@@ -326,8 +326,8 @@ const structuredData: StructuredData = {
 		<Section id="ts332-m" depth={2}>
 			<Fragment slot="heading">TS-332 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS332_307B} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS332_307B} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-02-28 -->
 				<Fragment slot="caption">デハ307B（2次車）上り方山側</Fragment>
 			</Embedded>
@@ -342,8 +342,8 @@ const structuredData: StructuredData = {
 		<Section id="ts332t" depth={2}>
 			<Fragment slot="heading">TS-332T <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS332T_305} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS332T_305} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-02-28 -->
 				<Fragment slot="caption">デハ305B―デハ305A（2次車）連接部山側</Fragment>
 			</Embedded>
@@ -364,8 +364,8 @@ const structuredData: StructuredData = {
 		<Section id="ts333-t" depth={2}>
 			<Fragment slot="heading">TS-333 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS333_7590} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS333_7590} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-01-20 -->
 				<Fragment slot="caption">サヤ7590 上り方山側</Fragment>
 			</Embedded>
@@ -382,8 +382,8 @@ const structuredData: StructuredData = {
 		<Section id="ts334-t" depth={2}>
 			<Fragment slot="heading">TS-334 <TruckIcon><small>中間台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS334_7590} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS334_7590} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-01-20 -->
 				<Fragment slot="caption">サヤ7590 車央部山側</Fragment>
 			</Embedded>

--- a/astro/src/pages/tokyu/truck/ts700.astro
+++ b/astro/src/pages/tokyu/truck/ts700.astro
@@ -106,8 +106,8 @@ const structuredData: StructuredData = {
 		<Section id="ts701-m" depth={2}>
 			<Fragment slot="heading">TS-701 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS701_mizuma7003} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS701_mizuma7003} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2006-09-02 -->
 				<Fragment slot="caption">水間鉄道デハ7003 貝塚方（東急デハ7012 下り方）</Fragment>
 			</Embedded>
@@ -122,8 +122,8 @@ const structuredData: StructuredData = {
 		<Section id="ts701-t" depth={2}>
 			<Fragment slot="heading">TS-701 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS701_fukushima7315} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS701_fukushima7315} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2017-08-26 -->
 				<Fragment slot="caption">福島交通サハ7315 飯坂温泉方（東急デハ7134 上り方）</Fragment>
 			</Embedded>
@@ -138,8 +138,8 @@ const structuredData: StructuredData = {
 		<Section id="ts708-t" depth={2}>
 			<Fragment slot="heading">TS-708 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS708_ueda7551} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS708_ueda7551} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2005-04-16 -->
 				<Fragment slot="caption">上田交通クハ7551 別所温泉方（東急クハ7551 下り方）</Fragment>
 			</Embedded>

--- a/astro/src/pages/tokyu/truck/ts800.astro
+++ b/astro/src/pages/tokyu/truck/ts800.astro
@@ -243,14 +243,14 @@ const structuredData: StructuredData = {
 		<Section id="ts802-m" depth={2}>
 			<Fragment slot="heading">TS-802 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS802_7200} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS802_7200} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-01-20 -->
 				<Fragment slot="caption">デヤ7200（2次車）上り方山側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS802_toyohashi1856} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS802_toyohashi1856} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-01-10 -->
 				<Fragment slot="caption">豊橋鉄道モ1856 新豊橋方（東急デハ7401 下り方）</Fragment>
 			</Embedded>
@@ -267,8 +267,8 @@ const structuredData: StructuredData = {
 		<Section id="ts802a" depth={2}>
 			<Fragment slot="heading">TS-802A <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS802A_7290} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS802A_7290} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-01-20 -->
 				<Fragment slot="caption">デヤ7290（2次車）上り方山側</Fragment>
 			</Embedded>
@@ -493,8 +493,8 @@ const structuredData: StructuredData = {
 		<Section id="ts807-m" depth={2}>
 			<Fragment slot="heading">TS-807, TS-807M <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS807M_8728} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS807M_8728} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-10-23 -->
 				<Fragment slot="caption">デハ8728（8次車）上り方山側</Fragment>
 			</Embedded>
@@ -507,8 +507,8 @@ const structuredData: StructuredData = {
 		<Section id="ts807a" depth={2}>
 			<Fragment slot="heading">TS-807A, TS-807C <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS807A_8791} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS807A_8791} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-10-23 -->
 				<Fragment slot="caption">デハ8791（18-1次車）上り方山側</Fragment>
 			</Embedded>
@@ -523,8 +523,8 @@ const structuredData: StructuredData = {
 		<Section id="ts807b" depth={2}>
 			<Fragment slot="heading">TS-807B <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS807B_8492} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS807B_8492} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2008-09-06 -->
 				<Fragment slot="caption">デハ8492（13次車）下り方海側</Fragment>
 			</Embedded>
@@ -543,14 +543,14 @@ const structuredData: StructuredData = {
 		<Section id="ts815m" depth={2}>
 			<Fragment slot="heading"><small>（TS-815M →）</small>TS-815C <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS815CM_8918} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS815CM_8918} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-11-16 -->
 				<Fragment slot="caption">サハ8918（9-2次車）下り方山側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS815CM_8904} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS815CM_8904} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2006-02-27 -->
 				<Fragment slot="caption">サハ8904（6次車）上り方山側</Fragment>
 			</Embedded>
@@ -565,8 +565,8 @@ const structuredData: StructuredData = {
 		<Section id="ts815a" depth={2}>
 			<Fragment slot="heading"><small>（TS-815A →）</small>TS-815C <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS815CA_8935} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS815CA_8935} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2006-02-27 -->
 				<Fragment slot="caption">サハ8935（11-1次車）下り方山側</Fragment>
 			</Embedded>
@@ -579,8 +579,8 @@ const structuredData: StructuredData = {
 		<Section id="ts815b" depth={2}>
 			<Fragment slot="heading"><small>（TS-815B →）</small>TS-815E <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS815E_8093} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS815E_8093} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-03-08 -->
 				<Fragment slot="caption">クハ8093（13次車）下り方山側</Fragment>
 			</Embedded>
@@ -591,8 +591,8 @@ const structuredData: StructuredData = {
 		<Section id="ts815c" depth={2}>
 			<Fragment slot="heading">TS-815C<small>（オリジナル）</small> <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS815C_8978} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS815C_8978} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2008-12-23 -->
 				<Fragment slot="caption">サハ8978（18-2次車）下り方海側</Fragment>
 			</Embedded>
@@ -605,8 +605,8 @@ const structuredData: StructuredData = {
 		<Section id="ts815d" depth={2}>
 			<Fragment slot="heading">TS-815D <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS815D_8097} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS815D_8097} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-03-01 -->
 				<Fragment slot="caption">クハ8097（16-2次車）下り方山側</Fragment>
 			</Embedded>
@@ -621,8 +621,8 @@ const structuredData: StructuredData = {
 		<Section id="ts815f" depth={2}>
 			<Fragment slot="heading">TS-815F, <small>（TS-815F →）</small>TS-815T, <small>（TS-835 → TS-839 →）</small>TS-815T <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS815F_8020} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS815F_8020} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2007-09-11 -->
 				<Fragment slot="caption">クハ8020（2次車）下り方山側</Fragment>
 			</Embedded>
@@ -643,14 +643,14 @@ const structuredData: StructuredData = {
 		<Section id="ts831-m" depth={2}>
 			<Fragment slot="heading">TS-831 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS831_7681} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS831_7681} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2010-05-07 -->
 				<Fragment slot="caption">デハ7681（1次車）上り方山側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS831_7673} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS831_7673} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-04-21 -->
 				<Fragment slot="caption">デハ7673（3次車）下り方海側</Fragment>
 			</Embedded>
@@ -667,14 +667,14 @@ const structuredData: StructuredData = {
 		<Section id="ts832-m" depth={2}>
 			<Fragment slot="heading">TS-832 <TruckIcon type="m"><small>動力台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS832_7810} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS832_7810} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2006-03-03 -->
 				<Fragment slot="caption">デハ7810（3次車）下り方海側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS832_towada7703} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS832_towada7703} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-04-23 -->
 				<Fragment slot="caption">十和田観光電鉄モハ7703 三沢方（東急デハ7711 下り方）</Fragment>
 			</Embedded>
@@ -693,14 +693,14 @@ const structuredData: StructuredData = {
 		<Section id="ts835-t" depth={2}>
 			<Fragment slot="heading">TS-835 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS835_7907} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS835_7907} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-07-09 -->
 				<Fragment slot="caption">クハ7907（3次車）下り方山側</Fragment>
 			</Embedded>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS835_7915} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS835_7915} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2008-02-26 -->
 				<Fragment slot="caption">クハ7915（5次車）上り方海側</Fragment>
 			</Embedded>
@@ -723,8 +723,8 @@ const structuredData: StructuredData = {
 		<Section id="ts839-t" depth={2}>
 			<Fragment slot="heading">TS-839 <TruckIcon type="t"><small>付随台車</small></TruckIcon></Fragment>
 
-			<Embedded border={true} captionMeta={true}>
-				<MyImage image={image_TS839_7601} alt="写真拡大" width={1022} height={341} link={true} slot="media" />
+			<Embedded width={1024} border={true} captionMeta={true}>
+				<MyImage image={image_TS839_7601} alt="写真拡大" width={1024} height={341} link={true} slot="media" />
 				<!-- 撮影日: 2009-08-19 -->
 				<Fragment slot="caption">クハ7601（1次車）下り方山側</Fragment>
 			</Embedded>

--- a/astro/src/pages/tokyu/yomoyama/7700_front.astro
+++ b/astro/src/pages/tokyu/yomoyama/7700_front.astro
@@ -524,13 +524,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700">
 		<Fragment slot="heading">デハ7700形</Fragment>
 
-		<Grid column="medium">
+		<Grid column={4}>
 			<GridItem>
 				<Section id="mc-7701" depth={2}>
 					<Fragment slot="heading">デハ7701<small>（1次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7701} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7701} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -541,8 +541,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7702" depth={2}>
 					<Fragment slot="heading">デハ7702<small>（1次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7702} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7702} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-07 -->
 					</Embedded>
 
@@ -553,8 +553,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7703" depth={2}>
 					<Fragment slot="heading">デハ7703<small>（2次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7703} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7703} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-21 -->
 					</Embedded>
 
@@ -565,8 +565,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7705" depth={2}>
 					<Fragment slot="heading">デハ7705<small>（2次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7705} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7705} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-16 -->
 					</Embedded>
 
@@ -577,8 +577,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7706" depth={2}>
 					<Fragment slot="heading">デハ7706<small>（2次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7706} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7706} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-02 -->
 					</Embedded>
 
@@ -589,8 +589,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7707" depth={2}>
 					<Fragment slot="heading">デハ7707<small>（3次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7707} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7707} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-08 -->
 					</Embedded>
 
@@ -601,8 +601,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7708" depth={2}>
 					<Fragment slot="heading">デハ7708<small>（2次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7708} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7708} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-08 -->
 					</Embedded>
 
@@ -613,8 +613,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7710" depth={2}>
 					<Fragment slot="heading">デハ7710<small>（3次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7710} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7710} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-22 -->
 					</Embedded>
 
@@ -625,8 +625,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7712" depth={2}>
 					<Fragment slot="heading">デハ7712<small>（4次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7712} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7712} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-09-09 -->
 					</Embedded>
 
@@ -637,8 +637,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7713" depth={2}>
 					<Fragment slot="heading">デハ7713<small>（5次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7713} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7713} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -649,8 +649,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7714" depth={2}>
 					<Fragment slot="heading">デハ7714<small>（5次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7714} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7714} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -661,8 +661,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-7715" depth={2}>
 					<Fragment slot="heading">デハ7715<small>（5次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7715} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7715} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-21 -->
 					</Embedded>
 
@@ -679,13 +679,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900">
 		<Fragment slot="heading">クハ7900形</Fragment>
 
-		<Grid column="medium">
+		<Grid column={4}>
 			<GridItem>
 				<Section id="tc-7901" depth={2}>
 					<Fragment slot="heading">クハ7901<small>（1次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7901} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7901} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-11-23 -->
 					</Embedded>
 
@@ -696,8 +696,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7902" depth={2}>
 					<Fragment slot="heading">クハ7902<small>（1次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7902} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7902} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-16 -->
 					</Embedded>
 
@@ -708,8 +708,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7903" depth={2}>
 					<Fragment slot="heading">クハ7903<small>（2次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7903} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7903} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-07 -->
 					</Embedded>
 
@@ -720,8 +720,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7905" depth={2}>
 					<Fragment slot="heading">クハ7905<small>（2次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7905} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7905} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-07-16 -->
 					</Embedded>
 
@@ -732,8 +732,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7906" depth={2}>
 					<Fragment slot="heading">クハ7906<small>（2次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7906} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7906} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-28 -->
 					</Embedded>
 
@@ -744,8 +744,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7907" depth={2}>
 					<Fragment slot="heading">クハ7907<small>（3次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7907} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7907} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-11-23 -->
 					</Embedded>
 
@@ -756,8 +756,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7908" depth={2}>
 					<Fragment slot="heading">クハ7908<small>（2次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7908} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7908} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-28 -->
 					</Embedded>
 
@@ -770,8 +770,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7910" depth={2}>
 					<Fragment slot="heading">クハ7910<small>（3次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7910} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7910} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-28 -->
 					</Embedded>
 
@@ -782,8 +782,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7912" depth={2}>
 					<Fragment slot="heading">クハ7912<small>（4次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7912} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7912} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-10-28 -->
 					</Embedded>
 
@@ -796,8 +796,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7913" depth={2}>
 					<Fragment slot="heading">クハ7913<small>（5次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7913} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7913} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -808,8 +808,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7914" depth={2}>
 					<Fragment slot="heading">クハ7914<small>（5次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7914} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7914} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-10-01 -->
 					</Embedded>
 
@@ -820,8 +820,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-7915" depth={2}>
 					<Fragment slot="heading">クハ7915<small>（5次車）</small></Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_7915} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_7915} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-23 -->
 					</Embedded>
 
@@ -838,13 +838,13 @@ const structuredData: StructuredData = {
 	<Section id="mc-7700-towada">
 		<Fragment slot="heading">十和田観光電鉄 モハ7700形</Fragment>
 
-		<Grid column="medium">
+		<Grid column={4}>
 			<GridItem>
 				<Section id="mc-towada7701" depth={2}>
 					<Fragment slot="heading">モハ7701</Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_towada_7701} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_towada_7701} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2008-05-04 -->
 					</Embedded>
 
@@ -855,8 +855,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-towada7702" depth={2}>
 					<Fragment slot="heading">モハ7702</Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_towada_7702} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_towada_7702} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2008-07-21 -->
 					</Embedded>
 
@@ -869,8 +869,8 @@ const structuredData: StructuredData = {
 				<Section id="mc-towada7703" depth={2}>
 					<Fragment slot="heading">モハ7703</Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_towada_7703} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_towada_7703} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2008-05-04 -->
 					</Embedded>
 
@@ -889,13 +889,13 @@ const structuredData: StructuredData = {
 	<Section id="tc-7900-towada">
 		<Fragment slot="heading">十和田観光電鉄 クハ7900形</Fragment>
 
-		<Grid column="medium">
+		<Grid column={4}>
 			<GridItem>
 				<Section id="tc-towada7901" depth={2}>
 					<Fragment slot="heading">クハ7901</Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_towada_7901} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_towada_7901} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2008-09-13 -->
 					</Embedded>
 
@@ -906,8 +906,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-towada7902" depth={2}>
 					<Fragment slot="heading">クハ7902</Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_towada_7902} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_towada_7902} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2006-09-03 -->
 					</Embedded>
 
@@ -920,8 +920,8 @@ const structuredData: StructuredData = {
 				<Section id="tc-towada7903" depth={2}>
 					<Fragment slot="heading">クハ7903</Fragment>
 
-					<Embedded border={true}>
-						<MyImage image={image_towada_7903} alt="写真拡大" width={306} height={383} link={true} slot="media" />
+					<Embedded width={280} border={true}>
+						<MyImage image={image_towada_7903} alt="写真拡大" width={280} height={350} link={true} slot="media" />
 						<!-- 撮影日: 2007-04-30 -->
 					</Embedded>
 

--- a/astro/src/pages/tokyu/yomoyama/8000_amp.astro
+++ b/astro/src/pages/tokyu/yomoyama/8000_amp.astro
@@ -39,13 +39,13 @@ const slugger = new GithubSlugger();
 	<Section id="trumpet-1">
 		<Fragment slot="heading">トランペット型（1〜5次車）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1次車（一部を除く）</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_trumpet_8004} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_trumpet_8004} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-07 -->
 						<Fragment slot="caption">クハ8004（1次車）</Fragment>
@@ -60,8 +60,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">1次車（一部）</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_trumpet_8006} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_trumpet_8006} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-07 -->
 						<Fragment slot="caption">クハ8006（1次車）</Fragment>
@@ -74,8 +74,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">5次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_trumpet_8051} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_trumpet_8051} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2002-05-23 -->
 						<Fragment slot="caption">クハ8051（5次車）</Fragment>
@@ -90,13 +90,13 @@ const slugger = new GithubSlugger();
 	<Section id="trumpet-6">
 		<Fragment slot="heading">トランペット型（6〜15次車）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">6〜8次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_trumpet_8515} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_trumpet_8515} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-25 -->
 						<Fragment slot="caption">デハ8515（7次車）</Fragment>
@@ -109,8 +109,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">9次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_trumpet_8629} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_trumpet_8629} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-10 -->
 						<Fragment slot="caption">デハ8629（9-2次車）</Fragment>
@@ -123,8 +123,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">10次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_trumpet_8931} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_trumpet_8931} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-10 -->
 						<Fragment slot="caption">サハ8931（10-1次車）</Fragment>
@@ -137,8 +137,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">11〜14次車など</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_trumpet_8409} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_trumpet_8409} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-07 -->
 						<Fragment slot="caption">デハ8409（13次車）</Fragment>
@@ -153,13 +153,13 @@ const slugger = new GithubSlugger();
 	<Section id="cone">
 		<Fragment slot="heading">コーン型</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">15〜20次車と8090系全車両</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_cone_0807} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_cone_0807} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-07 -->
 						<Fragment slot="caption">デハ0807（18-2次車）</Fragment>
@@ -172,8 +172,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">21次車と8945, 8946</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_cone_0718} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_cone_0718} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-11 -->
 						<Fragment slot="caption">デハ0718（21次車）</Fragment>
@@ -188,13 +188,13 @@ const slugger = new GithubSlugger();
 	<Section id="renewal">
 		<Fragment slot="heading">更新工事</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">田園都市線6〜11次車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_emergency_8629} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_emergency_8629} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-10 -->
 						<Fragment slot="caption">デハ8629（9-2次車）</Fragment>
@@ -207,8 +207,8 @@ const slugger = new GithubSlugger();
 				<Section id={slugger} depth={2}>
 					<Fragment slot="heading">田園都市線12〜14次車など</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_renewal_8248} alt="" width={485} height={324} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_renewal_8248} alt="" width={540} height={360} slot="media" />
 
 						<!-- 撮影日: 2005-07-14 -->
 						<Fragment slot="caption">デハ8248（12-3次車）</Fragment>

--- a/astro/src/pages/tokyu/yomoyama/8637.astro
+++ b/astro/src/pages/tokyu/yomoyama/8637.astro
@@ -43,7 +43,7 @@ const slugger = new GithubSlugger();
 
 		<p>デビュー直後はほかの8500系と同じく、装飾は正面の赤帯のみとなっていましたが、この姿が見られたのは半年ほどの期間だったようです。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_1987_red} width={400} height={280} slot="media" />
 			<Fragment slot="caption">撮影: 高橋うさおさん</Fragment>
 		</Embedded>
@@ -54,7 +54,7 @@ const slugger = new GithubSlugger();
 
 		<p>デビュー翌年には東急ケーブルテレビジョンの統一広告車となり、正面帯を青色に変更、側面にも青帯が巻かれたほか、「TOKYU CABLE TV」ステッカーが貼られました。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_1988_catv} width={400} height={280} slot="media" />
 			<Fragment slot="caption">撮影: 高橋うさおさん</Fragment>
 		</Embedded>
@@ -63,7 +63,7 @@ const slugger = new GithubSlugger();
 
 		<p>東横線は9013Fだったようですが、田玉線はこの8637Fが抜擢され、「TOKYU CABLE TV」マーク下部に「がんばれ！ニッポン！オリンピック報道電車」のステッカーが貼られました。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_1988_olympic} width={400} height={280} slot="media" />
 			<Fragment slot="caption">撮影: kazumaさん</Fragment>
 		</Embedded>
@@ -83,7 +83,7 @@ const slugger = new GithubSlugger();
 
 		<p>写真は側面の青帯が貼られたまま8642Fに組込まれて試運転を行うサハ8974で、組み替えにより通常の側帯のない車と混在しています。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_1989_saha8974} width={400} height={280} slot="media" />
 			<Fragment slot="caption">撮影: 高橋うさおさん</Fragment>
 		</Embedded>
@@ -94,7 +94,7 @@ const slugger = new GithubSlugger();
 
 		<p>1991年3月には、両先頭車のみ正面と側面にしゃぼん玉の装飾が貼付されました。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_1998_balloon} width={400} height={280} slot="media" />
 		</Embedded>
 	</Section>
@@ -104,7 +104,7 @@ const slugger = new GithubSlugger();
 
 		<p>1998年10月には帯の貼り替えが行われました。貼り替え前と比較すると、貫通扉枠部分の帯の有無や、しゃぼん玉の配置に変化がみられます。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_2001_balloon} width={400} height={280} slot="media" />
 		</Embedded>
 
@@ -116,7 +116,7 @@ const slugger = new GithubSlugger();
 
 		<p>以下の写真は大小数十個のしゃぼん玉装飾が成された先頭車側面の様子です（帯貼替え後・デハ8537海側）。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_2002_8537} width={400} height={280} slot="media" />
 			<Fragment slot="caption">撮影: 高橋うさおさん</Fragment>
 		</Embedded>
@@ -129,14 +129,14 @@ const slugger = new GithubSlugger();
 
 		<p>写真は2002年3月に急行停車駅に加えられたばかりのあざみ野駅に停車中の様子で、翌4月から急行灯の点灯が中止されたため、わずかな期間だけ見られた貴重なシーンとなりました。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_2002_itscom} width={400} height={280} slot="media" />
 			<Fragment slot="caption">撮影: 高橋うさおさん</Fragment>
 		</Embedded>
 
 		<p>iTSCOMの装飾が行われていた時代には、一部の側窓に広告が入れられたこともありました。写真はデハ8537のものです。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_2002_itscom_sideWin} width={400} height={280} slot="media" />
 			<Fragment slot="caption">撮影: 高橋うさおさん</Fragment>
 		</Embedded>
@@ -149,7 +149,7 @@ const slugger = new GithubSlugger();
 
 		<p>写真は、2003年春に多摩田園都市開発50周年を記念して正面、側面に「東急多摩田園都市50周年」のステッカーが貼られていた時の姿です。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_2003_tamadenentoshi50th} width={400} height={280} slot="media" />
 		</Embedded>
 
@@ -165,7 +165,7 @@ const slugger = new GithubSlugger();
 
 		<p>つづけて2010年には正面のしゃぼん玉装飾も撤去され、青帯のみの姿となって現在に至ります。</p>
 
-		<Embedded border={true}>
+		<Embedded width={400} border={true} captionMeta={true}>
 			<MyImage image={image_2010_blue} width={400} height={267} slot="media" />
 		</Embedded>
 	</Section>

--- a/astro/src/pages/tokyu/yomoyama/ca105.astro
+++ b/astro/src/pages/tokyu/yomoyama/ca105.astro
@@ -29,17 +29,17 @@ const structuredData: StructuredData = {
 
 		<p>熊本電気鉄道と水間鉄道の車両に残るクラリオン製のCA-105型放送装置。水間鉄道のテープ式搭載車7000系は、現在では基本的に営業運転に就くことはなく、実質これが稼働している譲渡車両は熊本電気鉄道モハ5100形のみとなっています。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_CA105_kumamoto} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_CA105_kumamoto} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2009-05-30 -->
 					<Fragment slot="caption">熊本電気鉄道モハ5101A</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_CA105_mizuma} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_CA105_mizuma} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2007-06-24 -->
 					<Fragment slot="caption">水間鉄道デハ7003</Fragment>
 				</Embedded>
@@ -54,10 +54,10 @@ const structuredData: StructuredData = {
 
 		<p>デハ7003は2007年にデハ7052（現在のデハ1007）との客ドア交換が成され、東急時代に室内更新工事を受けた車両でありながら、Hゴム支持窓の側引戸を持つアンバランスな形態となっています。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true} captionMeta={true}>
-					<MyImage image={image_mizuma_7003} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true} captionMeta={true}>
+					<MyImage image={image_mizuma_7003} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2007-10-20 -->
 					<Fragment slot="caption">水間鉄道デハ7003</Fragment>
 				</Embedded>

--- a/astro/src/pages/tokyu/yomoyama/echizen_mc1101.astro
+++ b/astro/src/pages/tokyu/yomoyama/echizen_mc1101.astro
@@ -4,8 +4,6 @@ import Anchor from '@components/+phrasing/Anchor.astro';
 import DocBook from '@components/+phrasing/DocBook.astro';
 import DocMagazine from '@components/+phrasing/DocMagazine.astro';
 import Embedded from '@components/Embedded.astro';
-import Grid from '@components/Grid.astro';
-import GridItem from '@components/GridItem.astro';
 import MyImage from '@components/+phrasing/MyImage.astro';
 import List from '@components/List.astro';
 import ListNote from '@components/ListNote.astro';
@@ -43,15 +41,11 @@ const structuredData: StructuredData = {
 
 		<p>車両によって走り装置の更新や冷房搭載など各種の改造が行われていますが、今回注目するのはMC1101形という車両で、1981年に阪神電鉄で廃車になった車両の車体を譲り受け、各種機器は在来車のものを流用して2両が竣功したものとのことです。</p>
 
-		<Grid column="wide">
-			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_MC1102} alt="写真拡大" width={500} height={333} link={true} slot="media" />
-					<!-- 撮影日: 2009-07-20 -->
-					<Fragment slot="caption">えちぜん鉄道MC1102</Fragment>
-				</Embedded>
-			</GridItem>
-		</Grid>
+		<Embedded width={540} border={true} captionMeta={true}>
+			<MyImage image={image_MC1102} alt="写真拡大" width={540} height={360} link={true} slot="media" />
+			<!-- 撮影日: 2009-07-20 -->
+			<Fragment slot="caption">えちぜん鉄道MC1102</Fragment>
+		</Embedded>
 
 		<p>この車種は竣功当初は吊り掛け式だったようですが、京福時代の1998年にカルダン駆動化が行われており、同時に主制御器は MMC-H-10K に換装されました。</p>
 
@@ -105,14 +99,10 @@ const structuredData: StructuredData = {
 
 		<p>これらに書かれているように、第1編成は名鉄3880系で使用されていた主制御器を流用したようです。これはそのまま東急デハ3700形由来のものと思われますが、同じ MMC-H-10 でもえち鉄MC1101形とはタイプが異なります。</p>
 
-		<Grid column="wide">
-			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_toyohashi_1956} width={500} height={356} slot="media" />
-					<Fragment slot="caption">豊橋鉄道モ1956</Fragment>
-				</Embedded>
-			</GridItem>
-		</Grid>
+		<Embedded width={540} border={true} captionMeta={true}>
+			<MyImage image={image_toyohashi_1956} width={540} height={385} slot="media" />
+			<Fragment slot="caption">豊橋鉄道モ1956</Fragment>
+		</Embedded>
 
 		<ListNote>
 			<li>豊橋鉄道モ1956の写真は <Anchor href="http://js3vxw.cocolog-nifty.com/photos/toyohashi__600v/">JS3VXWの鉄道管理局</Anchor>より許可を得て転載。</li>
@@ -124,22 +114,17 @@ const structuredData: StructuredData = {
 
 		<p>MMC-H-10は、東急ではD型、G型、K型の3種類が使われていました。D型とG型は外観がよく似た3室構造ですが、後期に登場したK型は2室で、蓋形状も曲線がなく角張っているなどの違いがあります。</p>
 
-		<Grid column="wide">
-			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_ttm_MMCH10G} alt="写真拡大" width={500} height={333} link={true} slot="media" />
-					<!-- 撮影日: 2006-04-23 -->
-					<Fragment slot="caption">MMC-H-10G（電車とバスの博物館展示品）</Fragment>
-				</Embedded>
-			</GridItem>
-			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_MC1102_MMCH10K} alt="写真拡大" width={500} height={333} link={true} slot="media" />
-					<!-- 撮影日: 2009-07-20 -->
-					<Fragment slot="caption">MMC-H-10K（えちぜん鉄道MC1102）</Fragment>
-				</Embedded>
-			</GridItem>
-		</Grid>
+		<Embedded width={540} border={true} captionMeta={true}>
+			<MyImage image={image_ttm_MMCH10G} alt="写真拡大" width={540} height={360} link={true} slot="media" />
+			<!-- 撮影日: 2006-04-23 -->
+			<Fragment slot="caption">MMC-H-10G（電車とバスの博物館展示品）</Fragment>
+		</Embedded>
+
+		<Embedded width={540} border={true} captionMeta={true}>
+			<MyImage image={image_MC1102_MMCH10K} alt="写真拡大" width={540} height={360} link={true} slot="media" />
+			<!-- 撮影日: 2009-07-20 -->
+			<Fragment slot="caption">MMC-H-10K（えちぜん鉄道MC1102）</Fragment>
+		</Embedded>
 
 		<p>デハ3700形は東急末期にはG型となっていたようで、鉄道ピクトリアルの東急特集号にこんな記述があります。</p>
 
@@ -290,15 +275,11 @@ const structuredData: StructuredData = {
 
 		<p>さらに前面蓋の向かって右側、MCOS部分にはうっすら<q>3509</q>という車番らしき数字が残っていました。豊橋鉄道渥美線とえちぜん鉄道（京福電鉄）には、3500番台の車両は存在しません。名古屋鉄道にはモ3500形という車両が居たようですが、主制御器はMMC系ではなく、そもそもモ3509は東急譲渡車が入線するずっと前に制御車化されており、可能性はないでしょう。そう考えると東急デハ3509のものでしょうか。</p>
 
-		<Grid column="wide">
-			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_MC1102_MMCH10K_magnify} alt="写真拡大" width={500} height={375} link={true} slot="media" />
-					<!-- 撮影日: 2009-07-20 -->
-					<Fragment slot="caption">MC1102の主制御器、MCOS蓋拡大</Fragment>
-				</Embedded>
-			</GridItem>
-		</Grid>
+		<Embedded width={540} border={true} captionMeta={true}>
+			<MyImage image={image_MC1102_MMCH10K_magnify} alt="写真拡大" width={540} height={405} link={true} slot="media" />
+			<!-- 撮影日: 2009-07-20 -->
+			<Fragment slot="caption">MC1102の主制御器、MCOS蓋拡大</Fragment>
+		</Embedded>
 
 		<p>1939年に東京横浜電鉄モハ1000形として登場した東急デハ3500形の主制御器は、当初はMC-200、MMC-H-200でしたが、1969年よりMMC-H-10Kに更新されたようです。</p>
 

--- a/astro/src/pages/tokyu/yomoyama/hsc.astro
+++ b/astro/src/pages/tokyu/yomoyama/hsc.astro
@@ -35,17 +35,17 @@ const structuredData: StructuredData = {
 
 		<p>ブレーキ制御装置はHD23型で、左下には7000系までのA動作弁に代わって取り付けられた<dfn>M非常弁</dfn>があります。これは保守軽減のため、自動ブレーキの作用を非常ブレーキ（EB）のみとしたものです。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_HD23} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_HD23} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2009-05-12 -->
 					<Fragment slot="caption">HD23型ブレーキ制御装置（デヤ7200）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_GR3} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_GR3} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2009-06-09 -->
 					<Fragment slot="caption">参考比較: 旧7000系のブレーキ制御装置（福島交通デハ7111）</Fragment>
 				</Embedded>
@@ -62,17 +62,17 @@ const structuredData: StructuredData = {
 
 		<p>前述のとおり、空気指令車はデヤ7200とデヤ7290の2両のみとなってしまったため、すべての空気管が連結された様子は、両車が2連を組んだ時にしか見ることができません。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_cocks} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_cocks} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2009-05-14 -->
 					<Fragment slot="caption">3本の空気管（デヤ7200）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_connect} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_connect} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2008-01-04 -->
 					<Fragment slot="caption">空気管がすべて連結された様子（デヤ7200+デヤ7290）</Fragment>
 				</Embedded>
@@ -87,10 +87,10 @@ const structuredData: StructuredData = {
 
 		<p>現存する7200系空気指令車2両は、アルミ試作車として1967年に製造された2次車です。1991年には両運転台化などの改造が成され、動力車（デハ7200）および電気検測車（デヤ7290）として派手な塗装を施されました。なお、デハ7200は1996年にデヤ7200に改称されています。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_sakusei} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_sakusei} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2003-02-23 -->
 					<Fragment slot="caption">デヤ7290+デハ7706-デハ7806-クハ7906+デヤ7200</Fragment>
 				</Embedded>
@@ -105,17 +105,17 @@ const structuredData: StructuredData = {
 
 		<p>元7000系が活躍する青森県の弘南鉄道弘南線では、休校日を除く平日朝の1往復（黒石駅7時20分発）のみ4両編成での運転となっており、黒石駅で車両の増解結が行われます。日常的にみられる空気指令車同士の連結・解放作業としては唯一のものです。</p>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_konan_connect_m} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_konan_connect_m} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2009-09-07 -->
 					<Fragment slot="caption">空気管側連結部（弘南鉄道デハ7152+デハ7011）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_konan_connect_s} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_konan_connect_s} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<!-- 撮影日: 2009-04-24 -->
 					<Fragment slot="caption">電気栓側連結部（弘南鉄道デハ7011+デハ7153）</Fragment>
 				</Embedded>

--- a/astro/src/pages/tokyu/yomoyama/ibaraki_6000.astro
+++ b/astro/src/pages/tokyu/yomoyama/ibaraki_6000.astro
@@ -39,16 +39,16 @@ const structuredData: StructuredData = {
 			<li>2018年に撤去されました。</li>
 		</ListNote>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_6201} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_6201} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<Fragment slot="caption">デハ6201（撮影: 2009年5月<!-- 2009-05-03 -->）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_6201_surroundings} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_6201_surroundings} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<Fragment slot="caption">デハ6201が置かれている周辺（撮影: 2017年4月<!-- 2017-04-22 -->）</Fragment>
 				</Embedded>
 			</GridItem>
@@ -71,16 +71,16 @@ const structuredData: StructuredData = {
 			<li>2017年4月に訪問したところ、事務所と思われる建物もろとも撤去されていました。</li>
 		</ListNote>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_6202} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_6202} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<Fragment slot="caption">デハ6202（撮影: 2009年5月<!-- 2009-05-03 -->）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_6202_trace} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_6202_trace} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<Fragment slot="caption">デハ6202が置かれていた跡地（撮影: 2017年4月<!-- 2017-04-22 -->）</Fragment>
 				</Embedded>
 			</GridItem>
@@ -112,16 +112,16 @@ const structuredData: StructuredData = {
 			<li>2014年〜2015年頃に撤去されたようです。ブログ「<cite>饂飩と蕎麦</cite>」の記事<Anchor href="https://karaageya.exblog.jp/25291913/">東急6000系の保存車たち</Anchor>に2015年2月時点で更地になっていたとの情報があります。</li>
 		</ListNote>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_6302_1} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_6302_1} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<Fragment slot="caption">デハ6302 （1位側）（撮影: 2009年5月<!-- 2009-05-03 -->）</Fragment>
 				</Embedded>
 			</GridItem>
 			<GridItem>
-				<Embedded border={true}>
-					<MyImage image={image_6302_2} alt="写真拡大" width={500} height={333} link={true} slot="media" />
+				<Embedded width={540} border={true}>
+					<MyImage image={image_6302_2} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 					<Fragment slot="caption">デハ6302 （2位側）（撮影: 2009年5月<!-- 2009-05-03 -->）</Fragment>
 				</Embedded>
 			</GridItem>

--- a/astro/src/pages/tokyu/yomoyama/nosmoking.astro
+++ b/astro/src/pages/tokyu/yomoyama/nosmoking.astro
@@ -34,13 +34,13 @@ const structuredData: StructuredData = {
 	<Section id="string">
 		<Fragment slot="heading">文字のみのタイプ</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="bold-purple" depth={2}>
 					<Fragment slot="heading">太フォント、英文紺字</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_bold_purple} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_bold_purple} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-07-30 -->
 						<Fragment slot="caption">デハ8218（4次車）</Fragment>
 					</Embedded>
@@ -52,8 +52,8 @@ const structuredData: StructuredData = {
 				<Section id="bold-black" depth={2}>
 					<Fragment slot="heading">太フォント、英文黒字</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_bold_black} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_bold_black} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-07-30 -->
 						<Fragment slot="caption">クハ8040（4次車）</Fragment>
 					</Embedded>
@@ -65,8 +65,8 @@ const structuredData: StructuredData = {
 				<Section id="bold-blue" depth={2}>
 					<Fragment slot="heading">太フォント、英文青字</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_bold_blue} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_bold_blue} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-06-25 -->
 						<Fragment slot="caption">デハ1312（3次車）</Fragment>
 					</Embedded>
@@ -78,8 +78,8 @@ const structuredData: StructuredData = {
 				<Section id="thin-black" depth={2}>
 					<Fragment slot="heading">細フォント、英文黒字</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_thin_black} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_thin_black} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-06-25 -->
 						<Fragment slot="caption">クハ7908（2次車）</Fragment>
 					</Embedded>
@@ -93,13 +93,13 @@ const structuredData: StructuredData = {
 	<Section id="pictogram1">
 		<Fragment slot="heading">ピクトグラム（旧）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="pic-str" depth={2}>
 					<Fragment slot="heading">ピクトグラム + 文字</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_pic_str} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_pic_str} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-06-18 -->
 						<Fragment slot="caption">デハ7653（1次車）</Fragment>
 					</Embedded>
@@ -111,8 +111,8 @@ const structuredData: StructuredData = {
 				<Section id="pic-only" depth={2}>
 					<Fragment slot="heading">ピクトグラムのみ</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_pic_only} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_pic_only} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-06-18 -->
 						<Fragment slot="caption">クハ8001（1次車）</Fragment>
 					</Embedded>
@@ -126,13 +126,13 @@ const structuredData: StructuredData = {
 	<Section id="pictogram2">
 		<Fragment slot="heading">ピクトグラム（新）</Fragment>
 
-		<Grid column="wide">
+		<Grid column={2}>
 			<GridItem>
 				<Section id="3000" depth={2}>
 					<Fragment slot="heading">新3000系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_3000} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_3000} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-06-25 -->
 						<Fragment slot="caption">クハ3013（3次車）</Fragment>
 					</Embedded>
@@ -144,8 +144,8 @@ const structuredData: StructuredData = {
 				<Section id="y000" depth={2}>
 					<Fragment slot="heading">Y000系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_Y000} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_Y000} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-06-24 -->
 						<Fragment slot="caption">デハY011（1次車）</Fragment>
 					</Embedded>
@@ -157,8 +157,8 @@ const structuredData: StructuredData = {
 				<Section id="300" depth={2}>
 					<Fragment slot="heading">300系</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_300} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_300} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-06-24 -->
 						<Fragment slot="caption">デハ301A（1次車）</Fragment>
 					</Embedded>
@@ -170,8 +170,8 @@ const structuredData: StructuredData = {
 				<Section id="9000-renewal" depth={2}>
 					<Fragment slot="heading">9000系化粧板修繕車</Fragment>
 
-					<Embedded border={true} captionMeta={true}>
-						<MyImage image={image_9000_renewal} alt="写真拡大" width={485} height={323} link={true} slot="media" />
+					<Embedded width={540} border={true} captionMeta={true}>
+						<MyImage image={image_9000_renewal} alt="写真拡大" width={540} height={360} link={true} slot="media" />
 						<!-- 撮影日: 2006-07-01 -->
 						<Fragment slot="caption">クハ9011（3次車）</Fragment>
 					</Embedded>

--- a/frontend/style/foundation/_var.css
+++ b/frontend/style/foundation/_var.css
@@ -9,18 +9,11 @@
 	initial-value: 1280px;
 }
 
-/* サイドバーの幅 */
-@property --page-sidebar-width {
+/* コンテンツエリアの最大幅 */
+@property --page-content-width {
 	syntax: "<length>";
 	inherits: false;
-	initial-value: 230px;
-}
-
-/* コンテンツエリアとサイドバーの横間隔 */
-@property --page-content-sidebar-gap {
-	syntax: "<length>";
-	inherits: false;
-	initial-value: 26px;
+	initial-value: 1024px;
 }
 
 /* ページの左右の余白 */
@@ -520,6 +513,9 @@
 }
 
 :root {
+	/* ページの左右の余白 */
+	--page-margin-inline: calc((100% - var(--page-max-width)) / 2 - var(--page-padding-inline));
+
 	/**
 	 * フォーム
 	 */

--- a/frontend/style/layout/_common.css
+++ b/frontend/style/layout/_common.css
@@ -3,9 +3,6 @@
  * ============================== */
 
 .l-page {
-	/* ページの左右の余白 */
-	--_page-margin-inline: calc((100% - var(--page-max-width)) / 2 - var(--page-padding-inline));
-
 	display: block grid;
 }
 
@@ -15,9 +12,9 @@
 	container: header / inline-size;
 	grid-template-columns:
 		[full-start]
-		var(--_page-margin-inline) var(--page-padding-inline)
+		var(--page-margin-inline) var(--page-padding-inline)
 		[content-start] 1fr [content-end]
-		var(--page-padding-inline) var(--_page-margin-inline)
+		var(--page-padding-inline) var(--page-margin-inline)
 		[full-end];
 	grid-column: header;
 	padding: 10px 0 40px;
@@ -150,9 +147,9 @@
 	container: footer / inline-size;
 	grid-template-columns:
 		[full-start]
-		var(--_page-margin-inline) var(--page-padding-inline)
+		var(--page-margin-inline) var(--page-padding-inline)
 		[content-start] 1fr [content-end]
-		var(--page-padding-inline) var(--_page-margin-inline)
+		var(--page-padding-inline) var(--page-margin-inline)
 		[full-end];
 	grid-column: footer;
 	margin-block-start: 80px;

--- a/frontend/style/layout/_error.css
+++ b/frontend/style/layout/_error.css
@@ -4,13 +4,13 @@
 
 .l-page {
 	/* ページの左右の余白 */
-	--_page-margin-inline: calc((100% - var(--page-max-width)) / 2 - var(--page-padding-inline));
+	--page-margin-inline: calc((100% - var(--page-max-width)) / 2 - var(--page-padding-inline));
 
 	display: block grid;
 	grid-template-areas:
 		"margin-left padding-left header  padding-right margin-right"
 		"margin-left padding-left content padding-right margin-right";
-	grid-template-columns: var(--_page-margin-inline) var(--page-padding-inline) 1fr var(--page-padding-inline) var(--_page-margin-inline);
+	grid-template-columns: var(--page-margin-inline) var(--page-padding-inline) 1fr var(--page-padding-inline) var(--page-margin-inline);
 }
 
 /* ===== ページヘッダー ===== */

--- a/frontend/style/layout/_page-full.css
+++ b/frontend/style/layout/_page-full.css
@@ -8,8 +8,11 @@
 		"margin-left padding-left cm      cm                  cm      padding-right margin-right"
 		"footer      footer       footer  footer              footer  footer        footer      ";
 	grid-template-columns:
-		var(--_page-margin-inline) var(--page-padding-inline) 1fr var(--page-content-sidebar-gap) var(--page-sidebar-width) var(--page-padding-inline)
-		var(--_page-margin-inline);
+		var(--page-margin-inline) var(--page-padding-inline) 1fr calc((var(--page-max-width) - var(--page-content-width)) / 8) calc(
+			(var(--page-max-width) - var(--page-content-width)) / 8 * 7
+		)
+		var(--page-padding-inline)
+		var(--page-margin-inline);
 }
 
 @media (width <= 60em) {


### PR DESCRIPTION
- ページレイアウトのサイドバー幅を変更
- Flex / Grid コンポーネントの gap を含めた幅をコンテンツ幅基準で計算するように変更
- 画像横並びは Flex → Grid コンポーネントに変更
- `<Embedded>` コンポーネント内にキャプションを含む場合は幅を明記する
