### PR TITLE
`security.checkOrigin` 無効化

### DIFF
--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -20,6 +20,9 @@ export default defineConfig({
 			minify: false,
 		},
 	},
+	security: {
+		checkOrigin: false, // https://github.com/withastro/astro/issues/12851
+	},
 	build: {
 		format: 'preserve',
 		assets: 'assets/astro',


### PR DESCRIPTION
#1232 で `security.checkOrigin` の設定を削除したが、本番環境でフォームの POST 送信ができなくなっていたのでふたたび無効化設定に戻す。