### PR TITLE
Amazon コンポーネントの商品画像 hover 時の色指定を oklch へ変更

### DIFF
--- a/astro/src/components/Amazon.astro
+++ b/astro/src/components/Amazon.astro
@@ -113,7 +113,7 @@ const dateDayjs = date !== undefined ? dayjs(date) : undefined;
 			}
 
 			:any-link:hover & {
-				box-shadow: 0 0 5px 1px hsl(30deg 100% 60%);
+				box-shadow: oklch(from var(--_bg-color) calc(l - 0.2) calc(c + 0.1) h) 0 0 5px 1px;
 			}
 		}
 


### PR DESCRIPTION
#1239 の作業ミスで1か所だけ hsl のままになっていた