### PR TITLE
`:hover` スタイルが効かなくなっていたバグを修正

### DIFF
--- a/astro/src/components/TopNavCardItem.astro
+++ b/astro/src/components/TopNavCardItem.astro
@@ -40,11 +40,11 @@ const { linkHref, title, description } = Astro.props;
 				overflow: hidden;
 				text-decoration-line: none;
 				color: var(--color-darkgray);
+			}
 
-				&:hover {
-					background-color: oklch(from var(--bgcolor-light) calc(l - var(--bgcolor-hover-l)) c h);
-					color: var(--color-black);
-				}
+			& > :global(a:hover) {
+				background-color: oklch(from var(--bgcolor-light) calc(l - var(--bgcolor-hover-l)) c h);
+				color: var(--color-black);
 			}
 		}
 


### PR DESCRIPTION
[astro@7.0.4](https://github.com/withastro/astro/releases/tag/astro%407.0.4) へのアップデートにより、出力された CSS に `:global` が残る状況となっていた。