### PR TITLE
ヤングマガジン 2015年6号のAmaonリンクを外す

### DIFF
--- a/astro/src/pages/kumeta/manga/list.astro
+++ b/astro/src/pages/kumeta/manga/list.astro
@@ -639,9 +639,7 @@ const structuredData: StructuredData = {
 				<tr>
 					<td><cite>オフサイドトラップ</cite></td>
 					<td>2015年1月5日</td>
-					<td>
-						<Anchor href="https://www.amazon.co.jp/dp/B00R3BMQKQ/">ヤングマガジン 2015年6号</Anchor>
-					</td>
+					<td>ヤングマガジン 2015年6号</td>
 					<td class="u-cell -center">✘</td>
 					<td></td>
 				</tr>


### PR DESCRIPTION
別商品に差し替わっていたため