### PR TITLE
サイドバーの日記記事の見出し下に若干の空きを設ける

### DIFF
--- a/astro/src/components/sidebar/BlogEntries.astro
+++ b/astro/src/components/sidebar/BlogEntries.astro
@@ -55,12 +55,13 @@
 		}
 
 		.heading {
+			& + * {
+				padding-block-start: 0.125em;
+			}
 		}
 
 		.link {
 			--_padding-inline: 0.5em;
-
-			padding-block-start: 0.125em;
 
 			& :global(a) {
 				box-sizing: revert;

--- a/astro/src/components/sidebar/BlogEntries.astro
+++ b/astro/src/components/sidebar/BlogEntries.astro
@@ -58,8 +58,9 @@
 		}
 
 		.link {
-			--_padding-block: 0.5em;
 			--_padding-inline: 0.5em;
+
+			padding-block-start: 0.125em;
 
 			& :global(a) {
 				box-sizing: revert;
@@ -67,19 +68,18 @@
 				contain: content;
 				outline-offset: -1px;
 				outline-width: var(--outline-width-bold);
-				background-color: var(--_bg-color);
-				padding: var(--_padding-block) var(--_padding-inline);
+				padding: 0.5em var(--_padding-inline);
 				min-block-size: 2em;
 				font-size: calc(100% / pow(var(--font-ratio), 1));
 			}
 
 			& :global(:any-link) {
-				--_bg-color: var(--color-white);
 				--_icon-color: var(--color-lightgray); /* アイコンの色 */
 				--_icon-inline-size: 0.67em; /* アイコンの幅 */
 				--_icon-block-size: 1em; /* アイコンの高さ */
 				--_icon-gap: 0.75em; /* テキストとアイコンの間隔 */
 
+				background-color: var(--color-white);
 				padding-inline-end: calc(var(--_icon-gap) + var(--_icon-inline-size) + var(--_padding-inline));
 				text-decoration-line: none;
 			}
@@ -100,12 +100,13 @@
 
 			/* 奇数行 */
 			& > :global(li:nth-child(2n + 1) :any-link) {
-				--_bg-color: var(--bgcolor-light);
+				background-color: var(--bgcolor-light);
 			}
 
 			& > :global(li :any-link:hover) {
-				--_bg-color: oklch(from var(--color-yellow) l c h / 25%);
 				--_icon-color: var(--color-gray);
+
+				background-color: oklch(from var(--color-yellow) l c h / 25%);
 			}
 		}
 	}


### PR DESCRIPTION
フォーカスリングが見出しと近接しているため

<img width="540" height="360" alt="「最近の日記記事」の部分スクショ" src="https://github.com/user-attachments/assets/72db11ce-42df-46c0-8fbc-ad80b375b00b" />
