### PR TITLE
Bing 検索の URL パラメーターに `rdr=1` を追加

### DIFF
--- a/hono/src/controller/search.test.ts
+++ b/hono/src/controller/search.test.ts
@@ -88,7 +88,7 @@ await test('engine', async (t) => {
 		const res = await app.request('/search?engine=bing&q=text');
 
 		assert.equal(res.status, 301);
-		assert.equal(res.headers.get('location'), 'https://www.bing.com/search?q=text+site%3Aw0s.jp');
+		assert.equal(res.headers.get('location'), 'https://www.bing.com/search?q=text+site%3Aw0s.jp&rdr=1');
 	});
 
 	await t.test('ddg', async () => {

--- a/hono/src/controller/search.ts
+++ b/hono/src/controller/search.ts
@@ -34,6 +34,7 @@ const getURL = (params: Readonly<{ site: Site; engine: Engine; q: string }>): st
 		}
 		case 'bing': {
 			urlSearchParams.append('q', `${q} site:${getSite(site)}`); // https://support.microsoft.com/en-us/bing/advanced-search-keywords
+			urlSearchParams.append('rdr', '1');
 
 			return `https://www.bing.com/search?${urlSearchParams.toString()}`;
 		}
@@ -61,10 +62,10 @@ export const searchApp = new Hono<{ Variables: Variables }>().get(validatorParam
 
 	return context.html(
 		`<!DOCTYPE html>
-	<html lang=ja>
-	<meta name=viewport content="width=device-width,initial-scale=1">
-	<title>ページ移動</title>
-	<p>検索結果は次の URL で取得できます。 <a href="${escape(redirectUrl)}"><code>${escape(redirectUrl)}</code></a>`,
+<html lang=ja>
+<meta name=viewport content="width=device-width,initial-scale=1">
+<title>ページ移動</title>
+<p>検索結果は次の URL で取得できます。 <a href="${escape(redirectUrl)}"><code>${escape(redirectUrl)}</code></a>`,
 		301,
 		{ Location: redirectUrl },
 	);


### PR DESCRIPTION
これがないと `site:` 絞り込みが機能しない模様