### PR TITLE
サイト内検索のフォーカスリング表示バグを修正

### DIFF
--- a/astro/src/components/SearchCtrl.astro
+++ b/astro/src/components/SearchCtrl.astro
@@ -34,6 +34,10 @@ const buttonTitleId = getHTMLId();
 			& :is(input, select, button) {
 				line-height: inherit;
 			}
+
+			& :focus {
+				z-index: 0;
+			}
 		}
 
 		/* 検索エンジン選択欄 */


### PR DESCRIPTION
サイト内検索のフォームコントロールにフォーカスした状態で直後のフォームコントロールにマウスオーバーした時にフォーカスリングの右端が途切れる現象を修正